### PR TITLE
Don't show PHP error on the site

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -347,7 +347,11 @@ END;
           <h1 class='red underline'><?= self::$id ?></h1>
           <p>Keyboard <?= self::$id ?> not found.</p>
         <?php
-        if(ini_get('display_errors') !== '0') echo "<p>" . self::$error . "</p>";
+        // DEBUG: Only display errors on local sites
+        $site_suffix = GetHostSuffix();
+        if (($site_suffix == '.local')  && (ini_get('display_errors') !== '0')) {
+          echo "<p>" . self::$error . "</p>";
+        }
         exit;
       }
 


### PR DESCRIPTION
Fixes #31 

Even if a site's PHP is configured to `display_errors`, we'll only show them for debugging purposes on `.local` sites.