### PR TITLE
Avoids script errors when users click Buy link in Keyman 8.0/9.0

### DIFF
--- a/downloads/archive/index.php
+++ b/downloads/archive/index.php
@@ -1,6 +1,6 @@
  <?php
   require_once('includes/template.php');
-  
+
   // Required
   head([
     'title' =>'Download Archives',
@@ -8,10 +8,11 @@
     'showMenu' => true
   ]);
 
+  require_once('./static-keys.php');
+
   // These variables should be progressively added if we update older versions.
   $ver_windows_10 = "10.0.1208.0";
 ?>
-
 <h2 class="red underline">Keyman Desktop Download Archive</h2>
 <ul>
     <!-- TODO: use downloads API to get the latest 10.0 version -->
@@ -43,17 +44,6 @@ Those that are listed with "Online static activation" require connection to an o
 
 <p>Please note: manual activation support requests will not be accepted. <a href='https://secure.tavultesoft.com/support/activate.php'>Self-service manual activation</a>.</p>
 
-<table class='feature-grid'>
-  <thead>
-    <tr><th>Version</th><th>Key</th></tr>
-  </thead>
-  <tbody>
-    <tr><td>Keyman Desktop 9.0 (Pro)</td><td>BUES-NJBK-3UZW-S3AB-9VNF</td></tr>
-    <tr><td>Keyman Developer 9.0</td><td>AVFT-PB54-CFRJ-NF67-DR67</td></tr>
-    <tr><td>Keyman Desktop 8.0 (Pro)</td><td>HWCY-LYT2-PKJ5-8ZQR-T74B</td></tr>
-    <tr><td>Keyman Developer 8.0</td><td>GXDZ-MZ9P-XS8J-PE76-CQD6</td></tr>
-    <tr><td>Keyman Desktop 7.1 Light</td><td>FYAW-JWRJ-RDHP-JB23-HMJB</td></tr>
-    <tr><td>Keyman Desktop 7.1 Pro</td><td>EZBX-KFP4-YAJS-X677-DRLV</td></tr>
-    <tr><td>Keyman 6.2</td><td>Name: Keyman<br/>Company: Keyman<br/>Licence No: K0300-1406-7831<br/>Reg Key: TS-Keyman-8341-B62F</td></tr>
-  </tbody>
-</table>
+<?php
+  render_static_keys(false);
+?>

--- a/downloads/archive/legacy-embed.php
+++ b/downloads/archive/legacy-embed.php
@@ -1,0 +1,36 @@
+ <?php
+  require_once('includes/template.php');
+
+  // Required
+  head([
+    'title' =>'Activate Older Versions',
+    'css' => ['template.css', 'feature-grid.css'],
+    'showMenu' => false,
+    'showHeader' => false,
+    'foot' => false,
+    'addSection2' => false // also avoids adding <div class='wrapper'> which is what we want
+  ]);
+
+  require_once('./static-keys.php');
+?>
+<div id='section2'>
+<h2 class="red underline">About Keyman</h2>
+
+<p>Keyman is now a free program. We recommend you download the latest version of Keyman from <a href='keyman:link?url=https://keyman.com/downloads/'>keyman.com</a>.</p>
+
+<p>If you wish to continue using this version, please use the table below to find a free license key for activation:</p>
+
+<?php
+  render_static_keys(true);
+?>
+
+<script>
+function activationResult(code, result, message, canElevate, wasElevated) {
+  if(result) {
+    alert('Your license has now been activated.');
+    location.href = 'keyman:finishpurchase';
+  } else {
+    alert(message);
+  }
+}
+</script>

--- a/downloads/archive/static-keys.php
+++ b/downloads/archive/static-keys.php
@@ -1,0 +1,32 @@
+<?php
+  function render_static_keys($links) {
+    $keys = [
+      "Keyman Desktop 9.0 (Pro)" => ["BUES-NJBK-3UZW-S3AB-9VNF", "keyman:activate?code=BUES-NJBK-3UZW-S3AB-9VNF"],
+      "Keyman Developer 9.0" => ["AVFT-PB54-CFRJ-NF67-DR67", ""],
+      "Keyman Desktop 8.0 (Pro)" => ["HWCY-LYT2-PKJ5-8ZQR-T74B", "keyman:activate?code=HWCY-LYT2-PKJ5-8ZQR-T74B"],
+      "Keyman Developer 8.0" => ["GXDZ-MZ9P-XS8J-PE76-CQD6", ""],
+      "Keyman Desktop 7.1 Light" => ["FYAW-JWRJ-RDHP-JB23-HMJB", ""],
+      "Keyman Desktop 7.1 Pro" => ["EZBX-KFP4-YAJS-X677-DRLV", ""],
+      "Keyman 6.2" => ["Name: Keyman<br/>Company: Keyman<br/>Licence No: K0300-1406-7831<br/>Reg Key: TS-Keyman-8341-B62F", ""]
+    ];
+?>
+
+<table class='feature-grid'>
+  <thead>
+    <tr><th>Version</th><th>Key</th></tr>
+  </thead>
+  <tbody>
+
+<?php
+    foreach($keys as $product => $key) {
+      if($links && $key[1])
+        echo "<tr><td>$product</td><td><a style='text-decoration:underline' href='{$key[1]}'>{$key[0]}</a></td></tr>";
+      else
+        echo "<tr><td>$product</td><td>{$key[0]}</td></tr>";
+    }
+?>
+  </tbody>
+</table>
+<?php
+  }
+?>


### PR DESCRIPTION
When clicking the Buy link in version 8 or 9 of Keyman, users would be taken to a confusing page which talked about support. However many of the pages linked there (e.g. community forum) also had script errors which would come up as errors in Keyman to be reported (e.g. [I2992](https://github.com/sillsdev/keyman-issues/issues/2985#issuecomment-536203051)).

This fix means that the users will be given a little more direction about upgrading to latest Keyman version, or at least can activate with a click on one of the listed activation keys. The fix is targeted to resolve that confusion and hopefully get more people on recent versions of Keyman -- nothing else.

Goes with a corresponding tavultesoft.com PR.