### PR TITLE
Collect analytics on keyboard downloads and trigger build of keyboard bundle when keyboard download is started

### DIFF
--- a/_includes/async/keyboard-download.php
+++ b/_includes/async/keyboard-download.php
@@ -1,5 +1,5 @@
 <?php
-  define('DEBUG', 1); // 0 = off, 1 = lots of logging but don't force a build, 2 = force a build
+  define('DEBUG', 0); // 0 = off, 1 = lots of logging but don't force a build, 2 = force a build
 
   if(!is_cli()) {
     echo 'keyboard-download.php must be run from the command line, not web server environment.';
@@ -32,6 +32,8 @@
   recordGoogleAnalyticsEvent($cid, $id, $platform, $mode);
 
   if(hasNewerBundleVersion($id, $downloads)) {
+    // TeamCity by default will not queue multiple instances of builds with similar properties
+    // so it doesn't hurt to re-trigger it.
     triggerBuildOfBundle($id);
   }
 
@@ -166,7 +168,6 @@
     }
 
     $bearer_token = $_ENV['teamcity_bearer_token'];
-
     $url = 'https://build.palaso.org/app/rest/buildQueue';
     $options = array(
       'http' => array(
@@ -178,7 +179,7 @@
       )
     );
     $context = stream_context_create($options);
-    $result = file_get_contents($url, false, $context);
+    $result = @file_get_contents($url, false, $context);
     if ($result !== FALSE) {
       if(DEBUG) {
         error_log("TeamCity response for $url(".print_r($options, true)."): ".$result);

--- a/_includes/async/keyboard-download.php
+++ b/_includes/async/keyboard-download.php
@@ -113,8 +113,9 @@
     }
 
     if($supportsWindows) {
-      if(!isset($downloads->windows) && $target == 'windows') {
-        // TODO: trigger Windows bundled build because it is not present and allow retry
+      if(!isset($downloads->windows)) {
+        // Trigger Windows bundled build because it is not present
+        // Building initial version will be triggered through a maintenance plan
         $shouldBuild = true;
       } else {
         //

--- a/_includes/async/keyboard-download.php
+++ b/_includes/async/keyboard-download.php
@@ -1,0 +1,199 @@
+<?php
+  define('DEBUG', 1); // 0 = off, 1 = lots of logging but don't force a build, 2 = force a build
+
+  if(!is_cli()) {
+    echo 'keyboard-download.php must be run from the command line, not web server environment.';
+    exit(1);
+  }
+
+  require_once(dirname(__FILE__)."\\..\\includes\\servervars.php");
+
+  if($argv < 4) {
+    error_log('Parameters: cid id platform mode');
+    exit(1);
+  }
+
+  $cid = $argv[1];
+  $id = $argv[2];
+  $platform = $argv[3];
+  $mode = $argv[4];
+
+  if(DEBUG) {
+    error_log("Input parameters: cid=$cid id=$id platform=$platform mode=$mode");
+  }
+
+  function fail($s) {
+    error_log('FAIL: '.$s);
+    exit(1);
+  }
+
+  $downloads = getKeyboardDownloadData($id);
+
+  recordGoogleAnalyticsEvent($cid, $id, $platform, $mode);
+
+  if(hasNewerBundleVersion($id, $downloads)) {
+    triggerBuildOfBundle($id);
+  }
+
+  // TODO: have shared download code
+
+  /**
+   * Get metadata on the downloadable files from the download server for the keyboard in question
+   */
+  function getKeyboardDownloadData($id) {
+    global $downloadhost;
+    $url = $downloadhost . '/api/keyboard/1.0/' . rawurlencode($id);
+    $s = @file_get_contents($url);
+    if($s === FALSE) {
+      fail("Unable to find keyboard $id");
+    }
+
+    $downloads = json_decode($s);
+
+    if(DEBUG) {
+      error_log("Downloads data for $url: ".print_r($downloads, true));
+    }
+
+    return $downloads;
+  }
+
+
+  /**
+   * Record download request on Google Analytics
+   */
+  function recordGoogleAnalyticsEvent($cid, $id, $platform, $mode) {
+    if(empty($cid)) {
+      $uid = com_create_guid();
+      $gauser = 'uid='.$uid;
+    } else {
+      $gauser = 'cid='.rawurlencode($cid);
+    }
+
+    if(DEBUG) {
+      $gabaseurl = "https://www.google-analytics.com/debug/collect";
+    } else {
+      $gabaseurl = "https://www.google-analytics.com/collect";
+    }
+    $gaurl = "$gabaseurl?v=1&t=event&tid=UA-249828-1&$gauser&ds=server&ec=keyboard&ea=download-$platform-$mode&el=".rawurlencode($id);
+    $result = @file_get_contents($gaurl);
+    if(DEBUG) {
+      error_log("Google Analytics response for $gaurl: ".print_r($http_response_header, true));
+    }
+
+    return !($result === FALSE);
+  }
+
+  /**
+   * Check if a newer version of the keyboard package and/or Keyman Desktop executable are available
+   */
+  function hasNewerBundleVersion($id, $downloads) {
+    global $apihost, $downloadhost;
+
+    $shouldBuild = false;
+
+    // Get the keyboard version from api.keyman.com:
+    $url = $apihost . '/keyboard/' . rawurlencode($id);
+    $s = @file_get_contents($url);
+    if ($s !== FALSE) {
+      // Test if we have a Windows version available
+      $keyboard_info = json_decode($s);
+
+      if(DEBUG) {
+        error_log("api response for $url: ".print_r($keyboard_info, true));
+      }
+
+      $keyboardVersion = $keyboard_info->version;
+      $supportsWindows = is_object($keyboard_info) && isset($keyboard_info->platformSupport->windows) && $keyboard_info->platformSupport->windows != 'none';
+    } else {
+      // We avoid
+      error_log("Failed to download $url: $php_errormsg");
+      $supportsWindows = false;
+    }
+
+    if($supportsWindows) {
+      if(!isset($downloads->windows) && $target == 'windows') {
+        // TODO: trigger Windows bundled build because it is not present and allow retry
+        $shouldBuild = true;
+      } else {
+        //
+        // Parse the executable filename. This is not ideal but better than adding a bunch of additional infrastructure
+        // to store the version metadata separately
+        //
+
+        $url = $downloadhost . '/api/version/windows';
+        $s = @file_get_contents($url);
+        if ($s !== FALSE) {
+          $windowsVersion = json_decode($s);
+
+          if(DEBUG) {
+            error_log("api response for $url: ".print_r($windowsVersion, true));
+          }
+
+          $windowsStableVersion = $windowsVersion->windows->stable;
+          $shouldBuild =
+            preg_match('/keymandesktop-(\d+\.\d+\.\d+\.\d+)-(.+)-([0-9.]+)\.exe$/', $downloads->windows, $matches) &&
+              (version_compare($keyboardVersion, $matches[3], '>') || version_compare($windowsStableVersion, $matches[1], '>'));
+
+          if(DEBUG == 2) {
+            // Force a test build
+            $shouldBuild = true;
+          }
+        } else {
+          error_log("Failed to download $url: $php_errormsg");
+        }
+      }
+    }
+
+    return $shouldBuild;
+  }
+
+  /**
+   * Ask TeamCity to queue build and upload of a keyboard bundle for Windows
+   */
+  function triggerBuildOfBundle($id) {
+    $data =
+    '<build>
+      <buildType id="Keyboards_BuildAndDeployBundledInstaller"/>
+      <comment><text>Build triggered by keyboard download</text></comment>
+      <properties>
+        <property name="target_keyboard" value="'.htmlspecialchars($id, ENT_COMPAT, 'UTF-8').'"/>
+      </properties>
+    </build>';
+
+    if(!isset($_ENV['teamcity_bearer_token'])) {
+      error_log("ERROR: teamcity_bearer_token is not configured.");
+      return false;
+    }
+
+    $bearer_token = $_ENV['teamcity_bearer_token'];
+
+    $url = 'https://build.palaso.org/app/rest/buildQueue';
+    $options = array(
+      'http' => array(
+          'header'  => "Content-Type: application/xml\r\n".
+                        "Origin: https://build.palaso.org\r\n".
+                        "Authorization: Bearer $bearer_token\r\n",
+          'method'  => 'POST',
+          'content' => $data
+      )
+    );
+    $context = stream_context_create($options);
+    $result = file_get_contents($url, false, $context);
+    if ($result !== FALSE) {
+      if(DEBUG) {
+        error_log("TeamCity response for $url(".print_r($options, true)."): ".$result);
+      }
+    } else {
+      /* Handle error */
+      if(DEBUG) {
+        error_log("Error loading $url: " . print_r($http_response_header));
+      }
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  function is_cli() {
+    return empty($_SERVER['REMOTE_ADDR']);
+  }
+?>

--- a/_includes/includes/servervars.php
+++ b/_includes/includes/servervars.php
@@ -1,21 +1,21 @@
 <?php /*
   Name:             servervars
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      17 Oct 2009
 
   Modified Date:    17 Oct 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          17 Oct 2009 - mcdurdin - Alter help base dir
 */
-  if(file_exists($_SERVER['DOCUMENT_ROOT'].'/cdn/deploy/cdn.php')) {
+  if(!empty($_SERVER['DOCUMENT_ROOT']) && file_exists($_SERVER['DOCUMENT_ROOT'].'/cdn/deploy/cdn.php')) {
     require_once($_SERVER['DOCUMENT_ROOT'].'/cdn/deploy/cdn.php');
   }
 
@@ -35,22 +35,26 @@
   }
 
   // We allow the site to strip off everything post its basic siteurl
-  
+
   function GetHostSuffix() {
     global $site_url;
+
+    if(!isset($_SERVER['SERVER_NAME']))
+      return '';
+
     $name = $_SERVER['SERVER_NAME'];
     if(stripos($name, $site_url.'.') == 0) {
       return substr($name, strlen($site_url), 1024);
     }
     return '';
   }
-  
+
   $site_suffix = GetHostSuffix();
   $site_protocol = (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) ? 'https://' : 'http://';
-    
+
   if($site_suffix == '') {
     $TestServer = false;
-   
+
     $site_tavultesoft = 'www.tavultesoft.com';
     $site_securetavultesoft = 'secure.tavultesoft.com';
     $buy9Link = "https://secure.tavultesoft.com/buy/90/";
@@ -78,7 +82,7 @@
   $localhost = "{$site_protocol}keyman.com{$site_suffix}";
   $keymanwebhost = "{$site_protocol}keymanweb.com{$site_suffix}";
   $resourcehost = "https://r.keymanweb.com"; /// local dev domain is usually not available
-  
+
   function cdn($file) {
     global $cdn, $staticDomain, $TestServer;
     $use_cdn = !$TestServer || (isset($_REQUEST['cdn']) && $_REQUEST['cdn'] == 'force');

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -34,6 +34,26 @@
 
     static private $deprecatedBy;
 
+    private function WriteLinkAnnotator() {
+      echo '<script>
+        var binaryFileClientId = null;
+        function downloadBinaryFile(a) {
+          if(!a.href.match(/cid=/) && binaryFileClientId) {
+            a.href = a.href + "&cid="+binaryFileClientId;
+          }
+          //alert(a.href);
+          return true;
+        }
+
+        try {
+          if(ga) ga(function(tracker) {
+            binaryFileClientId = tracker.get("clientId");
+          });
+        } catch {
+        }
+      </script>';
+    }
+
     /**
      * render_keyboard_details - display keyboard download boxes and details
      * @param $id - keyboard ID
@@ -50,6 +70,7 @@
       self::WriteDownloadBoxes();
       self::WriteKeyboardDetails();
       if(!empty(self::$deprecatedBy)) echo "</div></div>";
+      self::WriteLinkAnnotator();
     }
 
     /**
@@ -74,14 +95,11 @@
       return array_key_exists($s, $license_map) ? $license_map[$s] : $s;
     }
 
-    protected function download_box($url, $title, $description, $class, $linktitle, $platform = '') {
+    protected function download_box($url, $title, $description, $class, $linktitle, $platform, $mode='standalone') {
       $urlbits = explode('/', $url);
       $filename = array_pop($urlbits);
-      if ($platform != '') {
-        $downloadlink = "<a class='download-link' href='#' onclick='alert(\"Click this link on your $platform device\");return false;'><span>$linktitle</span></a>";
-      } else {
-        $downloadlink = "<a class='download-link' href='$url'><span>$linktitle</span></a>";
-      }
+      $id = self::$id;
+      $downloadlink = "<a class='download-link binary-download' href='download?id=$id&platform=$platform&mode=$mode' onclick='return downloadBinaryFile(this);'><span>$linktitle</span></a>";
       return <<<END
       <div class='download $class'>
         $downloadlink
@@ -121,7 +139,8 @@ END;
           htmlentities(self::$keyboard->name) . ' + Keyman Desktop',
           'Keyman Desktop and ' . htmlentities(self::$keyboard->name) . ' in a single installer.',
           'download-windows',
-          'Install on Windows');
+          'Install on Windows',
+          'windows', 'bundle');
       }
 
       if (isset(self::$downloads->kmp)) {
@@ -133,7 +152,8 @@ END;
               'Install ' . htmlentities(self::$keyboard->name) :
               'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/desktop">Keyman Desktop</a> for Windows must be installed first.',
             'download-kmp-windows',
-            $embed_win ? 'Install keyboard' : 'Windows download');
+            $embed_win ? 'Install keyboard' : 'Windows download',
+            'windows');
         }
       }
 
@@ -151,7 +171,8 @@ END;
               'Install ' . htmlentities(self::$keyboard->name) :
               'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/macosx">Keyman for Mac</a> must be installed first.',
             'download-kmp-macos',
-            $embed_mac ? 'Install keyboard' : 'macOS download');
+            $embed_mac ? 'Install keyboard' : 'macOS download',
+            'macos');
         }
       }
       return FALSE;
@@ -168,7 +189,8 @@ END;
               'Install ' . htmlentities(self::$keyboard->name) :
               'Installs only ' . htmlentities(self::$keyboard->name) . '. Keyman for Linux must be installed first.',
             'download-kmp-linux',
-            $embed_linux ? 'Install keyboard' : 'Linux download');
+            $embed_linux ? 'Install keyboard' : 'Linux download',
+            'linux');
         }
       }
       return FALSE;
@@ -210,7 +232,8 @@ END;
             htmlentities(self::$keyboard->name) . ' for Android',
             'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/android">Keyman for Android</a> must be installed first.',
             'download-android',
-            'Install on Android');
+            'Install on Android',
+            'android');
         }
       }
       return FALSE;
@@ -224,7 +247,8 @@ END;
             htmlentities(self::$keyboard->name) . ' for iPhone',
             'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/iphone">Keyman for iPhone</a> must be installed first.',
             'download-ios',
-            'Install on iPhone');
+            'Install on iPhone',
+            'ios');
         }
       }
 
@@ -239,7 +263,8 @@ END;
             htmlentities(self::$keyboard->name) . ' for iPad',
             'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/ipad">Keyman for iPad</a> must be installed first.',
             'download-ios',
-            'Install on iPad');
+            'Install on iPad',
+            'ios');
         }
       }
 

--- a/keyboards/download.php
+++ b/keyboards/download.php
@@ -1,0 +1,223 @@
+<?php
+  define('DEBUG', false);
+
+  // Redirects download to the appropriate file on downloads.keyman.com
+  // On the way, captures some statistics on the download for GA with a 'keyboard' event
+  // If necessary, triggers a rebuild for a bundled installer upgrade
+  //
+  // Parameters:
+  //   id        string identifier of keyboard to download
+  //   platform  one of windows,macos,linux,ios,android,web
+  //   mode:     optional, either bundle or standalone (for now, supported only for Windows)
+  //   cid:      optional, adds client id for Google Analytics tracking
+
+  require_once('includes/template.php');
+
+  if(DEBUG)
+    header('Content-Type: text/plain');
+
+  function fail($s) {
+    header('HTTP/1.0 400');
+    header('Content-Type: text/plain');
+    echo $s;
+    exit;
+  }
+
+  if(!validateParameters($id, $platform, $mode, $cid, $target)) {
+    fail('Invalid parameters');
+  }
+
+  $downloads = getKeyboardDownloadData($id);
+
+  recordGoogleAnalyticsEvent($cid, $id, $platform, $mode);
+
+  if(hasNewerBundleVersion($id, $downloads)) {
+    triggerBuildOfBundle($id);
+  }
+
+  redirectToDownload($downloads, $target);
+
+  /**
+   * Validate that input parameters are correct
+   */
+  function validateParameters(&$id, &$platform, &$mode, &$cid, &$target) {
+    if(!isset($_REQUEST['id']) || !isset($_REQUEST['platform'])) {
+      fail("Usage: download.php?id=<keyboard_id>&platform=<platform>[&mode=<bundle|standalone>][&cid=xxxx]");
+    }
+
+    $id = $_REQUEST['id'];
+    $platform = $_REQUEST['platform'];
+    if(isset($_REQUEST['mode'])) $mode = $_REQUEST['mode']; else $mode = 'standalone';
+    if(isset($_REQUEST['cid'])) $cid = $_REQUEST['cid'];
+
+    if(!in_array($platform, ['windows','macos','linux','ios','android','web'])) {
+      fail("Invalid platform parameter");
+    }
+
+    if(!in_array($mode, ['bundle', 'standalone'])) {
+      fail("Invalid mode parameter");
+    }
+
+    // For now, the only bundle type supported is Windows
+    if($mode == 'standalone' && $platform != 'windows') {
+      fail("Bundles are only supported for Windows platform");
+    }
+
+    switch($mode) {
+      case 'bundle':
+        if($platform != 'windows') {
+          fail("Bundles are only supported for Windows platform");
+        }
+        $target = 'windows';
+        break;
+      case 'standalone':
+        if($platform == 'web') {
+          $target = 'js';
+        } else {
+          $target = 'kmp';
+        }
+        break;
+    }
+    return true;
+  }
+
+  /**
+   * Get metadata on the downloadable files from the download server for the keyboard in question
+   */
+  function getKeyboardDownloadData($id) {
+    global $downloadhost;
+
+    $s = @file_get_contents($downloadhost . '/api/keyboard/1.0/' . rawurlencode($id));
+    if($s === FALSE) {
+      echo "Unable to find keyboard $id";
+      exit;
+    }
+
+    $downloads = json_decode($s);
+
+    return $downloads;
+  }
+
+  /**
+   * Record download request on Google Analytics
+   */
+  function recordGoogleAnalyticsEvent($cid, $id, $platform, $mode) {
+    if(empty($cid)) {
+      $uid = com_create_guid();
+      $gauser = 'uid='.$uid;
+    } else {
+      $gauser = 'cid='.rawurlencode($cid);
+    }
+
+    if(DEBUG) {
+      $gabaseurl = "https://www.google-analytics.com/debug/collect";
+    } else {
+      $gabaseurl = "https://www.google-analytics.com/collect";
+    }
+    $gaurl = "$gabaseurl?v=1&t=event&tid=UA-249828-1&$gauser&ds=server&ec=keyboard&ea=download-$platform-$mode&el=".rawurlencode($id);
+    $result = @file_get_contents($gaurl);
+    if(DEBUG)
+      var_dump($http_response_header);
+
+    return !($result === FALSE);
+  }
+
+  /**
+   * Check if a newer version of the keyboard package and/or Keyman Desktop executable are available
+   */
+  function hasNewerBundleVersion($id, $downloads) {
+    // Get the keyboard version from api.keyman.com:
+    $s = @file_get_contents($apihost . '/keyboard/' . rawurlencode($id));
+    if ($s !== FALSE) {
+      // Test if we have a Windows version available
+      $keyboard_info = json_decode($s);
+      $keyboardVersion = $keyboard_info->version;
+      $supportsWindows = is_object($keyboard_info) && isset($keyboard_info->platformSupport->windows) && $keyboard_info->platformSupport->windows != 'none';
+    } else {
+      // We avoid
+      $supportsWindows = false;
+    }
+
+    if($supportsWindows) {
+      if(!isset($downloads->windows) && $target == 'windows') {
+        // TODO: trigger Windows bundled build because it is not present and allow retry
+        $shouldBuild = true;
+      } else {
+        //
+        // Parse the executable filename. This is not ideal but better than adding a bunch of additional infrastructure
+        // to store the version metadata separately
+        //
+
+        $s = @file_get_contents($downloadhost . '/api/version/windows');
+        if ($s !== FALSE) {
+          $windowsVersion = json_decode($s);
+          $windowsStableVersion = $windowsVersion->windows->stable;
+        }
+
+        $shouldBuild =
+          preg_match('/keymandesktop-(\d+\.\d+\.\d+\.\d+)-(.+)-([0-9.]+)\.exe$/', $downloads->windows, $matches) &&
+          (version_compare($keyboardVersion, $matches[3], '>') || version_compare($windowsStableVersion, $matches[1], '>'));
+      }
+    } else {
+      $shouldBuild = false;
+    }
+
+    return $shouldBuild;
+  }
+
+  /**
+   * Ask TeamCity to queue build and upload of a keyboard bundle for Windows
+   */
+  function triggerBuildOfBundle($id) {
+    $data =
+    '<build>
+      <buildType id="Keyboards_BuildAndDeployBundledInstaller"/>
+      <comment><text>Build triggered by keyboard download</text></comment>
+      <properties>
+        <property name="target_keyboard" value="'.htmlspecialchars($id, ENT_COMPAT, 'UTF-8').'"/>
+      </properties>
+    </build>';
+
+    $bearer_token = $_ENV['teamcity_bearer_token'];
+    $url = 'https://build.palaso.org/app/rest/buildQueue';
+    $options = array(
+      'http' => array(
+          'header'  => "Content-Type: application/xml\r\n".
+                        "Origin: https://build.palaso.org\r\n".
+                        "Authorization: Bearer $bearer_token\r\n",
+          'method'  => 'POST',
+          'content' => $data
+      )
+    );
+    $context = stream_context_create($options);
+    $result = file_get_contents($url, false, $context);
+    if ($result === FALSE) {
+      /* Handle error */
+      // TODO: log the error; but where; this will come later with active error monitoring
+      if(DEBUG) {
+        var_dump($http_response_header);
+        var_dump($result);
+      }
+    }
+    return !($result === FALSE);
+  }
+
+  /**
+   * Redirect to the download, if it is available; otherwise, return to the keyboard
+   * information page and show a toast.
+   */
+  function redirectToDownload($downloads, $target) {
+    if(!isset($downloads->$target)) {
+      // TODO: redirect to keyboard page and toast
+      fail("Download target is not found");
+      exit;
+    }
+
+    if(DEBUG) {
+      echo $downloads->$target;
+    } else {
+      header($_SERVER["SERVER_PROTOCOL"].' 302 Found');
+      header('Location: '.$downloads->$target);
+    }
+  }
+?>

--- a/web.config
+++ b/web.config
@@ -68,6 +68,11 @@
                   <action type="Rewrite" url="keyboards/index.php?q=l:id:{R:1}" />
                 </rule>
 
+                <rule name="/keyboards/download to /keyboards/download.php" stopProcessing="true">
+                  <match url="^keyboards/download(.php)?" />
+                  <action type="Rewrite" url="keyboards/download.php" appendQueryString="true" />
+                </rule>
+
                 <rule name="/keyboards/legacy to /keyboards/keyboard.php" stopProcessing="true">
                   <match url="^keyboards/legacy/(.*)" />
                   <action type="Rewrite" url="keyboards/keyboard.php?legacy={R:1}" />


### PR DESCRIPTION
Part of https://github.com/keymanapp/keyman/issues/2248

Initial work on this feature. This redirects all keyboard downloads through a proxy page to allow for triggering of a rebuild of the bundled installer on demand. As a side benefit, implemented the keyboard analytics.

Still to do:
- [x] ~~Add support for triggering an initial version of a bundled installer when it is missing (it will happen if a user selects the .kmp but it's a little less obvious)~~
- [x] Consider moving the trigger and GA callbacks into an asynchronous response (the user doesn't need to wait for those to complete)
- [x] Control for multiple users downloading the same file avoiding multiple build triggers