### PR TITLE
chore: improve build reporting

### DIFF
--- a/_includes/async/keyboard-download.php
+++ b/_includes/async/keyboard-download.php
@@ -182,7 +182,7 @@
     $data =
     '<build>
       <buildType id="Keyboards_BuildAndDeployBundledInstaller"/>
-      <comment><text>Build triggered by keyboard download</text></comment>
+      <comment><text>'.htmlspecialchars($id, ENT_COMPAT, 'UTF-8').': build triggered by keyboard download</text></comment>
       <properties>
         <property name="target_keyboard" value="'.htmlspecialchars($src, ENT_COMPAT, 'UTF-8').'"/>
       </properties>


### PR DESCRIPTION
Include the keyboard id in the message for the build so it shows in
failed builds and in the comment popup for the build in TeamCity.