### PR TITLE
feat: Add a permalink for keyboard downloads

### DIFF
--- a/go/web.config
+++ b/go/web.config
@@ -9,6 +9,23 @@
                   <match url="^why\/?$" />
                   <action type="Redirect" url="https://marc.durdin.net/2018/03/the-case-for-keyman/" />
                 </rule>
+
+                <!-- Download redirects for keyboard permalinks -->
+
+                <rule name="download-kmp" stopProcessing="true">
+                    <match url="^keyboard/([^/?]+)/download/kmp$" />
+                    <action type="Redirect" url="/keyboards/download?id={R:1}&amp;platform=windows&amp;mode=standalone" />
+                </rule>
+
+                <rule name="download-exe" stopProcessing="true">
+                    <match url="^keyboard/([^/?]+)/download/exe$" />
+                    <action type="Redirect" url="/keyboards/download?id={R:1}&amp;platform=windows&amp;mode=bundle" />
+                </rule>
+
+                <rule name="download-js" stopProcessing="true">
+                    <match url="^keyboard/([^/?]+)/download/js$" />
+                    <action type="Redirect" url="/keyboards/download?id={R:1}&amp;platform=web&amp;mode=standalone" />
+                </rule>
             </rules>
         </rewrite>
     </system.webServer>


### PR DESCRIPTION
Fixes #56.

Documented at https://github.com/keymanapp/keyman/wiki/Permalinks-for-keyboard-downloads