### PR TITLE
feat: improve keyboard homepage ux on mobile

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -2,6 +2,8 @@
   namespace UI;
 
   require_once('includes/template.php');
+  require_once('includes/playstore.php');
+  require_once('includes/appstore.php');
 
   use \DateTime;
 
@@ -237,12 +239,13 @@ END;
     }
 
     protected static function WriteAndroidBoxes() {
+      global $playstore;
       if (isset(self::$downloads->kmp)) {
         if (isset(self::$keyboard->platformSupport->android) && self::$keyboard->platformSupport->android != 'none') {
           return self::download_box(
             self::embed_path(self::$downloads->kmp),
             htmlentities(self::$keyboard->name) . ' for Android',
-            'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/android">Keyman for Android</a> must be installed first.',
+            'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="'.$playstore.'">Keyman for Android</a> must be installed first.',
             'download-android',
             'Install on Android',
             'android');
@@ -252,12 +255,13 @@ END;
     }
 
     protected static function WriteiPhoneBoxes() {
+      global $appstore;
       if (isset(self::$downloads->kmp)) {
         if (isset(self::$keyboard->platformSupport->ios) && self::$keyboard->platformSupport->ios != 'none') {
           return self::download_box(
             self::embed_path(self::$downloads->kmp),
             htmlentities(self::$keyboard->name) . ' for iPhone',
-            'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/iphone">Keyman for iPhone</a> must be installed first.',
+            'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="'.$appstore.'">Keyman for iPhone</a> must be installed first.',
             'download-ios',
             'Install on iPhone',
             'ios');
@@ -268,12 +272,13 @@ END;
     }
 
     protected static function WriteiPadBoxes() {
+      global $appstore;
       if (isset(self::$downloads->js)) {
         if (isset(self::$keyboard->platformSupport->ios) && self::$keyboard->platformSupport->ios != 'none') {
           return self::download_box(
             self::embed_path(self::$downloads->kmp),
             htmlentities(self::$keyboard->name) . ' for iPad',
-            'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/ipad">Keyman for iPad</a> must be installed first.',
+            'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="'.$appstore.'">Keyman for iPad</a> must be installed first.',
             'download-ios',
             'Install on iPad',
             'ios');
@@ -518,7 +523,7 @@ END;
               if (isset(self::$keyboard->helpLink)) {
 ?>
                 <a <?= $embed_target ?>
-                  href='<?= self::$keyboard->helpLink ?>'><?= self::$keyboard->helpLink ?></a>
+                  href='<?= self::$keyboard->helpLink ?>'>Keyboard help</a>
 <?php
               } else {
                 echo "Help not available.";

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -2544,3 +2544,42 @@ ul.beta-link a {
 		display: none;
 	}
 }
+
+@media all and (min-width: 10px) and (max-width: 600px) {
+	html #search-box #search-q {
+		width: 80px;
+	}
+
+	html #section2 h1 {
+		font-size: 16pt;
+	}
+
+	html #section2 h2 {
+		font-size: 14pt;
+		padding-left: 0;
+	}
+
+	html .download {
+		background-image: none !important;
+	}
+
+	html .download a.download-link {
+		margin: 4px auto 8px auto;
+		display: block;
+		float: none;
+	}
+
+	html .download .download-filename {
+		margin-top: 8px;
+	}
+
+	html .download.download-android, 
+	html .download.download-windows,
+	html .download.download-ios, 
+	html .download.download-kmp-windows, 
+	html .download.download-kmp-macos, 
+	html .download.download-kmp-linux, 
+	html .download.download-web {
+		padding-left: 8px;
+	}
+}


### PR DESCRIPTION
This reduces font sizes, removes unnecessary elements, and cleans up
the display of the download boxes on mobile devices. It points directly
to the App Store and Play Store to reduce the number of steps to install
a keyboard into Keyman.

# Before
![image](https://user-images.githubusercontent.com/4498365/70256012-04b23380-1788-11ea-88c1-7adc92c5345c.png)

# After
![image](https://user-images.githubusercontent.com/4498365/70255969-f5cb8100-1787-11ea-80fa-a747781ea9fd.png)
