### PR TITLE
fix: hide deprecated keyboards by default

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -273,8 +273,8 @@ END;
 
     protected static function WriteiPadBoxes() {
       global $appstore;
-      if (isset(self::$downloads->js)) {
-        if (isset(self::$keyboard->platformSupport->ios) && self::$keyboard->platformSupport->ios != 'none' && isset(self::$downloads->kmp)) {
+      if (isset(self::$downloads->kmp)) {
+        if (isset(self::$keyboard->platformSupport->ios) && self::$keyboard->platformSupport->ios != 'none') {
           return self::download_box(
             self::embed_path(self::$downloads->kmp),
             htmlentities(self::$keyboard->name) . ' for iPad',

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -274,7 +274,7 @@ END;
     protected static function WriteiPadBoxes() {
       global $appstore;
       if (isset(self::$downloads->js)) {
-        if (isset(self::$keyboard->platformSupport->ios) && self::$keyboard->platformSupport->ios != 'none') {
+        if (isset(self::$keyboard->platformSupport->ios) && self::$keyboard->platformSupport->ios != 'none' && isset(self::$downloads->kmp)) {
           return self::download_box(
             self::embed_path(self::$downloads->kmp),
             htmlentities(self::$keyboard->name) . ' for iPad',

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -132,6 +132,14 @@ h2 a {
   color: red;
 }
 
+#search-results .deprecated .keyboard {
+  display: none;
+}
+
+#search-results .deprecated.show .keyboard {
+  display: block;
+}
+
 #search-results .keyboard .title a {
   background-image: url(/cdn/dev/keyboard-search/icon-keyman-20.png);
   background-repeat: no-repeat;

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -132,12 +132,28 @@ h2 a {
   color: red;
 }
 
-#search-results .deprecated .keyboard {
+#search-results .keyboards-deprecated h4 {
+  margin-top: 24px;
+  margin-left: 36px;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 14pt;
+}
+
+#search-results .keyboards-deprecated h4:hover {
+  text-decoration: underline;
+}
+
+#search-results .keyboards-deprecated .keyboard {
   display: none;
 }
 
-#search-results .deprecated.show .keyboard {
+#search-results .keyboards-deprecated.show .keyboard {
   display: block;
+}
+
+#search-results .keyboards-deprecated .keyboard .title::after {
+  content: " (obsolete)";
 }
 
 #search-results .keyboard .title a {

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -297,6 +297,8 @@ function process_response(q, res) {
   resultsElement.empty();
 
   if(res.keyboards) {
+    var deprecatedElement = null;
+
     $('<h3>').addClass('red underline').text(res.rangetext ? res.rangetext : "Keyboards matching '"+q+"'").appendTo(resultsElement);
 
     document.title = q + ' - Keyboard search';
@@ -315,6 +317,12 @@ function process_response(q, res) {
 
       if(embed=='linux' && (!kbd.platformSupport || !kbd.platformSupport['linux'] || kbd.platformSupport['linux'] == 'none')) {
         return;
+      }
+
+      if(kbd.deprecated && !deprecatedElement) {
+        deprecatedElement = $('<div class="keyboards-deprecated"><h2>Obsolete keyboards</h2></div>');
+        deprecatedElement.click(function() {deprecatedElement.toggleClass('show');});
+        resultsElement.append(deprecatedElement);
       }
 
       var k = $(
@@ -352,7 +360,7 @@ function process_response(q, res) {
         }
       }
       $('.platforms', k).text();
-      resultsElement.append(k);
+      (deprecatedElement ? deprecatedElement : resultsElement).append(k);
     });
   }
   if(res.languages) {

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -320,8 +320,8 @@ function process_response(q, res) {
       }
 
       if(kbd.deprecated && !deprecatedElement) {
-        deprecatedElement = $('<div class="keyboards-deprecated"><h2>Obsolete keyboards</h2></div>');
-        deprecatedElement.click(function() {deprecatedElement.toggleClass('show');});
+        deprecatedElement = $('<div class="keyboards-deprecated"><h4 class="red">Show obsolete keyboards</h4></div>');
+        deprecatedElement.find('h4').click(function() {deprecatedElement.toggleClass('show');});
         resultsElement.append(deprecatedElement);
       }
 


### PR DESCRIPTION
This depends on an API update in keymanapp/api.keyman.com#28.