### PR TITLE
Disable styling for "Rawang" in download links

### DIFF
--- a/cdn/dev/css/index.css
+++ b/cdn/dev/css/index.css
@@ -336,9 +336,11 @@
 	font-family: OriyaWeb;
 }
 /* Rawang */
+/*
 :lang(raw).lang-example {
 	font-family: MyanmarWeb;
 }
+*/
 /* Sindhi */
 :lang(snd).lang-example {
 	font-family: SindhiWeb;

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -160,10 +160,12 @@ html{
 :lang(ori).lang-example {
 	font-family: OriyaWeb;
 }
-/* Rawang */
+/* Rawang
 :lang(raw).lang-example {
 	font-family: MyanmarWeb;
 }
+*/
+
 /* Sindhi */
 :lang(snd).lang-example {
 	font-family: SindhiWeb;


### PR DESCRIPTION
Fixes #9

Applying the font family `MyanmarWeb` was causing "Krangku" to get squashed

With the fix:
![image](https://user-images.githubusercontent.com/7358010/70878666-ffa97b80-1ff4-11ea-8260-2a54a43b37a1.png)
