### PR TITLE
Add if() to mac/ features

### DIFF
--- a/linux/index.php
+++ b/linux/index.php
@@ -77,7 +77,7 @@
     <tr>
       <td><a href='http://help.keyman.com/developer/language/reference/if'><code>if()</code> statement</a></td>
       <td><?=$tick;?></td>
-      <td><?=$tick;?></td>
+      <td><?=$tick;?><br>(except options forms)</td>
     </tr>
     <tr>
       <td><a href='http://help.keyman.com/developer/language/reference/mnemoniclayout'>mnemonic layouts</a> (always US base layout)</td>

--- a/mac/index.php
+++ b/mac/index.php
@@ -68,7 +68,7 @@
     </tr>
     <tr>
       <td><a href='http://help.keyman.com/developer/language/reference/if'><code>if()</code> statement</a></td>
-      <td></td>
+      <td><?=$tick;?> (except options forms)</td>
     </tr>
     <tr>
       <td><a href='http://help.keyman.com/developer/language/reference/language'><code>&amp;language</code> store</a></td>


### PR DESCRIPTION
Fixes #68

Update mac features table to include `if()` (except for options forms).

Update: Also clarify `if()` support on Linux