### PR TITLE
fix(bookmarklet): url not escaped correctly

### DIFF
--- a/bookmarklet/install-bookmarklet.js
+++ b/bookmarklet/install-bookmarklet.js
@@ -3,7 +3,7 @@ function getBookmarkletCode(lang, kbd) {
     "javascript:void((function(){try{var%20e=document.createElement('script');e.type='text/javascript';"+
     "e.src='"+resourceBase+"/code/bml20.php"+
     "?langid="+encodeURIComponent(lang.id)+
-    "&keyboard="+encodeURIComponent(kbd.id)+
+    "&amp;keyboard="+encodeURIComponent(kbd.id)+
     "';document.body.appendChild(e);}catch(v){}})())";
   return code;
 }  


### PR DESCRIPTION
Fixes keymanapp/keyman#2507.