### PR TITLE
change: remove training registration link

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,9 +22,6 @@
           <div class='wrapper'>
             <p style='font-size:2em'><a href='/13/'>New: Keyman 13.0 is now in Beta!</a></p>
           </div>
-          <div class='wrapper'>
-            <p style='font-size:2em'><a href='/training/'>🎓 New! Online Keyman Developer Training Workshop, Feb 2020</a></p>
-          </div>
         </div>
         <!-- -->
     

--- a/training/index.php
+++ b/training/index.php
@@ -12,8 +12,6 @@
 
 <h3 class="red underline">Online Keyman Developer Training Workshop - 24-28 February, 2020</h3>
 
-<p><a class='generic-cta-button' href='https://intre.org?487' target='_blank'>Register Now!</a></p>
-
 <p>We are hosting an Online Keyman Developer Training Workshop the week of February 24-28. We will teach you how to create powerful
 multi-platform keyboard layouts for desktop and mobile devices. By the end of the week, you will have a working keyboard layout
 for your language(s) ready to share with the world.</p>
@@ -23,11 +21,10 @@ For those in the US, this will be early morning, after which they can spend the 
 it will fall in the evening, and they can spend the following day doing their assignment before the next group session.  We will have support
 staff in various time zones standing by to help participants if needed.</p>
 
-<p>The cost is $30 which must be paid by credit card at our <a href='https://intre.org?487' target='_blank'>registration site</a>.
-The payment confirmation email will contain a link to register for the Zoom webinar, which will send you reminders as the day approaches.</p>
+<p>Registrants have a confirmation email that contains a link to the webinar. The Zoom Client software will need to be
+  <a href="https://zoom.us/download#client_4meeting">installed</a> to join.</p>
 
-<p><a href='https://intre.org/?487&amp;a=home' target='_blank'>Learn more...</a>
-
+<p><strong class="red">Update:</strong> Registration is now closed for this workshop</p>
 <br>
 <br>
 


### PR DESCRIPTION
Registration is closed for the upcoming online Developer workshop, so updating the training page.