### PR TITLE
feat: Add android and ios platforms for keyboard search

### DIFF
--- a/go/android/web.config
+++ b/go/android/web.config
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <clear />
+
+                <!-- Links for Android 14.0 onward -->
+
+                <rule name="/go/android/X.Y/download-keyboards/languages" stopProcessing="true">
+                    <match url="^([1-9][0-9]\.[0-9])/download-keyboards/languages/(.*)" />
+                    <action type="Redirect" url="/keyboards/languages/{R:2}?embed=android&amp;embed_version={R:1}" />
+                </rule>
+
+                <rule name="/go/android/X.Y/download-keyboards" stopProcessing="true">
+                    <match url="^([1-9][0-9]\.[0-9])/download-keyboards" />
+                    <action type="Redirect" url="/keyboards?embed=android&amp;embed_version={R:1}" />
+                </rule>
+
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>

--- a/go/ios/web.config
+++ b/go/ios/web.config
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <clear />
+
+                <!-- Links for iOS 14.0 onward -->
+
+                <rule name="/go/ios/X.Y/download-keyboards/languages" stopProcessing="true">
+                    <match url="^([1-9][0-9]\.[0-9])/download-keyboards/languages/(.*)" />
+                    <action type="Redirect" url="/keyboards/languages/{R:2}?embed=ios&amp;embed_version={R:1}" />
+                </rule>
+
+                <rule name="/go/ios/X.Y/download-keyboards" stopProcessing="true">
+                    <match url="^([1-9][0-9]\.[0-9])/download-keyboards" />
+                    <action type="Redirect" url="/keyboards?embed=ios&amp;embed_version={R:1}" />
+                </rule>
+
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>

--- a/keyboards/session.php
+++ b/keyboards/session.php
@@ -3,7 +3,7 @@
 
   if(isset($_REQUEST['embed'])) {
     $embed = $_REQUEST['embed'];
-    if(!in_array($embed, ['none','windows','macos','linux'])) {
+    if(!in_array($embed, ['none','windows','macos','linux','android','ios'])) {
       $embed = 'none';
     }
     if(isset($_REQUEST['version'])) {
@@ -24,6 +24,8 @@
   $embed_win = $embed == 'windows';
   $embed_mac = $embed == 'macos';
   $embed_linux = $embed == 'linux';
+  $embed_android = $embed == 'android';
+  $embed_ios = $embed == 'ios';
   
   if($embed != 'none') {
     // Poor man's session control because IE embedded in downlevel Windows destroys cookie support by


### PR DESCRIPTION
For Keyman 14.0, we'll be revamping the keyboard search experience on the mobile apps (embedded views to the https://keyman.com/keyboards search page).

This PR adds some preliminary go/android and go/ios links.