### PR TITLE
fix(linux): Add Linux to featured keyboards pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ root = true
 [*]
 indent_style = space
 
-[*.{java, sh, php, css, html, xml}]
+[*.{java,sh,php,css,html,xml}]
 indent_size = 2
 

--- a/amharic/index.php
+++ b/amharic/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Amharic | <span lang="am" class="lang-example large">አማርኛ ይጻፉ</span></h2>
 <p>
-    Type in Amharic on iPhone, Windows and Android. Our Amharic keyboard works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+  Type in Amharic on iPhone, Windows and Android. Our Amharic keyboard works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <img id="ezana-stone" style="height:488px" src="<?php echo cdn('img/ezana.jpg'); ?>" title="The Ezana Stone — Image Courtesy of A. Davey" />
 <div id="download-cta" data-language='am' data-keyboard='gff_amharic'>

--- a/amharic/index.php
+++ b/amharic/index.php
@@ -29,6 +29,18 @@
       <a class="download-cta-more" href="/desktop/">Learn more about Keyman Desktop</a>
     </div>
   </div>
+  <div class="download-cta-big Linux" id="cta-big-Linux">
+    <h3>Amharic for Keyman for Linux</h3>
+    <p>
+      Type in Amharic in all your favourite software applications for Linux. Install Keyman for Linux first.
+    </p>
+    <div class="download-stable-email">
+      <div class="download-cta-button">
+        <h4>Download Now</h4>
+      </div>
+      <a class="download-cta-more" href="/linux/">Learn more about Keyman for Linux</a>
+    </div>
+  </div>
   <div class="download-cta-big mac" id="cta-big-mac">
     <h3>Amharic Keyman for macOS</h3>
     <p>

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -1099,6 +1099,10 @@ body[data-device |= Windows] #cta-big-Windows{
 	display: block;
 }
 
+body[data-device |= Linux] #cta-big-Linux{
+	display: block;
+}
+
 body[data-device |= mac] #cta-big-mac{
 	display: block;
 }

--- a/tamil/anjal-paangu/index.php
+++ b/tamil/anjal-paangu/index.php
@@ -35,6 +35,18 @@
       <a class="download-cta-more" href="/desktop/">Learn more about Keyman Desktop</a>
     </div>
   </div>
+  <div class="download-cta-big Linux" id="cta-big-Linux">
+    <h3>Tamil Anjal Paangu for Keyman for Linux</h3>
+    <p>
+      Type in Tamil in all your favourite software applications for Linux. Install Keyman for Linux first.
+    </p>
+    <div class="download-stable-email">
+      <div class="download-cta-button">
+        <h4>Download Now</h4>
+      </div>
+      <a class="download-cta-more" href="/linux/">Learn more about Keyman for Linux</a>
+    </div>
+  </div>
   <div class="download-cta-big mac" id="cta-big-mac">
     <h3>Tamil Anjal Paangu Keyman for macOS</h3>
     <p>

--- a/tamil/anjal-paangu/index.php
+++ b/tamil/anjal-paangu/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Tamil Anjal Paangu</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     Popularly used in eKalappai, this keyboard follows the Anjal phonetic standard. It’s the easiest to use when learning Tamil.

--- a/tamil/index.php
+++ b/tamil/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Tamil99</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     Popularly used in eKalappai, this keyboard follows the Tamil99 standard recommended by the Tamil Nadu government.

--- a/tamil/isis/index.php
+++ b/tamil/isis/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Tamil (ISIS)</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     This keyboard is phonetic (Romanised). It comes in the ISIS keyboards package, great for working in multiple Indian scripts.

--- a/tamil/new-typewriter/index.php
+++ b/tamil/new-typewriter/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Tamil New Typewriter</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+  Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     Popularly used in eKalappai, this keyboard follows the standard Tamil typewriter layout.

--- a/tamil/new-typewriter/index.php
+++ b/tamil/new-typewriter/index.php
@@ -35,6 +35,18 @@
       <a class="download-cta-more" href="/desktop/">Learn more about Keyman Desktop</a>
     </div>
   </div>
+  <div class="download-cta-big Linux" id="cta-big-Linux">
+    <h3>Tamil New Typewriter for Keyman for Linux</h3>
+    <p>
+      Type in Tamil in all your favourite software applications for Linux. Install Keyman for Linux first.
+    </p>
+    <div class="download-stable-email">
+      <div class="download-cta-button">
+        <h4>Download Now</h4>
+      </div>
+      <a class="download-cta-more" href="/linux/">Learn more about Keyman for Linux</a>
+    </div>
+  </div>
   <div class="download-cta-big mac" id="cta-big-mac">
     <h3>Tamil New Typewriter Keyman for macOS</h3>
     <p>

--- a/tamil/suratha-bamuni/index.php
+++ b/tamil/suratha-bamuni/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Tamil Suratha Bamuni</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+  Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     Popularly used in eKalappai, this keyboard follows the Bamini standard common in Sri Lanka, based on old Tamil typewriters.

--- a/tamil/suratha-bamuni/index.php
+++ b/tamil/suratha-bamuni/index.php
@@ -35,6 +35,18 @@
       <a class="download-cta-more" href="/desktop/">Learn more about Keyman Desktop</a>
     </div>
   </div>
+  <div class="download-cta-big Linux" id="cta-big-Linux">
+    <h3>Tamil Suratha Bamuni for Keyman for Linux</h3>
+    <p>
+      Type in Tamil in all your favourite software applications for Linux. Install Keyman for Linux first.
+    </p>
+    <div class="download-stable-email">
+      <div class="download-cta-button">
+        <h4>Download Now</h4>
+      </div>
+      <a class="download-cta-more" href="/linux/">Learn more about Keyman for Linux</a>
+    </div>
+  </div>
   <div class="download-cta-big mac" id="cta-big-mac">
     <h3>Tamil Suratha Bamuni Keyman for macOS</h3>
     <p>

--- a/tamil/visual-media-modular/index.php
+++ b/tamil/visual-media-modular/index.php
@@ -35,6 +35,18 @@
       <a class="download-cta-more" href="/desktop/">Learn more about Keyman Desktop</a>
     </div>
   </div>
+  <div class="download-cta-big Linux" id="cta-big-Linux">
+    <h3>Visual Media (Modular) for Keyman for Linux</h3>
+    <p>
+      Type in Tamil in all your favourite software applications for Linux. Install Keyman for Linux first.
+    </p>
+    <div class="download-stable-email">
+      <div class="download-cta-button">
+        <h4>Download Now</h4>
+      </div>
+      <a class="download-cta-more" href="/linux/">Learn more about Keyman for Linux</a>
+    </div>
+  </div>
   <div class="download-cta-big mac" id="cta-big-mac">
     <h3>Tamil Visual Media (Modular) Keyman for macOS</h3>
     <p>

--- a/tamil/visual-media-modular/index.php
+++ b/tamil/visual-media-modular/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Visual Media (Modular)</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+  Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     This keyboard follows the popular Modular layout standard.

--- a/tamil/visual-media-typewriter/index.php
+++ b/tamil/visual-media-typewriter/index.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="red underline large">Keyman for Visual Media (Typewriter)</h2>
 <p>
-    Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications. Free trial available!
+  Type in Tamil on iPhone, Windows and Android. Our Tamil keyboards works with Microsoft Word, Photoshop, Facebook, Twitter, email and thousands of other applications.
 </p>
 <p class="desktop">
     This keyboard follows the standard Tamil typewriter layout.

--- a/tamil/visual-media-typewriter/index.php
+++ b/tamil/visual-media-typewriter/index.php
@@ -35,6 +35,18 @@
       <a class="download-cta-more" href="/desktop/">Learn more about Keyman Desktop</a>
     </div>
   </div>
+  <div class="download-cta-big Linux" id="cta-big-Linux">
+    <h3>Visual Media (Typewriter) for Keyman for Linux</h3>
+    <p>
+      Type in Tamil in all your favourite software applications for Linux. Install Keyman for Linux first.
+    </p>
+    <div class="download-stable-email">
+      <div class="download-cta-button">
+        <h4>Download Now</h4>
+      </div>
+      <a class="download-cta-more" href="/linux/">Learn more about Keyman for Linux</a>
+    </div>
+  </div>
   <div class="download-cta-big mac" id="cta-big-mac">
     <h3>Tamil Visual Media (Typewriter) Keyman for macOS</h3>
     <p>


### PR DESCRIPTION
This change allows to download the keyboards that support Linux on the featured keyboards pages. Previously on Linux only the web option was available.

This change also removes the "Free trial available!" from all the pages that still had it, and fixes a
problem in `.editorconfig`.