### PR TITLE
feat: add bcp47 tag for embedded downloads

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -66,6 +66,7 @@ define('GITHUB_ROOT', 'https://github.com/keymanapp/keyboards/tree/master/');
      * @param $id - keyboard ID
      * @param string $tier - ['stable', 'alpha', or 'beta']
      * @param bool $landingPage - when true, details won't display keyboard search box or title
+     * @param string $tag - BCP 47 tag to pass as a hint to download links for apps to make connection
      */
     public static function render_keyboard_details($id, $tier = 'stable', $landingPage = false, $tag = null) {
       self::$id = $id;

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -21,6 +21,9 @@ define('GITHUB_ROOT', 'https://github.com/keymanapp/keyboards/tree/master/');
     static private $id;
     static private $tier;
 
+    // Properties to provide to apps in embedded download mode
+    static private $tag;
+
     // Properties for querying keyboard downloads
     static private $keyboard;
     static private $downloads;
@@ -64,8 +67,9 @@ define('GITHUB_ROOT', 'https://github.com/keymanapp/keyboards/tree/master/');
      * @param string $tier - ['stable', 'alpha', or 'beta']
      * @param bool $landingPage - when true, details won't display keyboard search box or title
      */
-    public static function render_keyboard_details($id, $tier = 'stable', $landingPage = false) {
+    public static function render_keyboard_details($id, $tier = 'stable', $landingPage = false, $tag = null) {
       self::$id = $id;
+      self::$tag = $tag;
       self::$tier = self::get_tier_from_request($tier);
       self::$landingPage = $landingPage;
 
@@ -111,6 +115,7 @@ define('GITHUB_ROOT', 'https://github.com/keymanapp/keyboards/tree/master/');
       if($embed != 'none') {
         // note: if embed != none, mode should was be standalone
         $url = "keyman:download?filename=$e_filename&url=".urlencode("https://keyman.com/keyboard/download?id=$e_id&platform=$platform&mode=$mode");
+        if(!empty(self::$tag)) $url .= "&tag=".urlencode(self::$tag);
       } else {
         $url = "/keyboard/download?id=$e_id&platform=$platform&mode=$mode";
       }
@@ -476,11 +481,11 @@ END;
         }
       }
 
-      if ($webtext) {
-        echo "<h2 class='red underline'>Online tools</h2>" . $webtext;
-      }
-
       if ($embed == 'none') {
+        if ($webtext) {
+          echo "<h2 class='red underline'>Online tools</h2>" . $webtext;
+        }
+
         echo "<h2 class='red underline'>Downloads for other devices</h2><div class='download-other'>";
         if(empty(self::$deprecatedBy)) {
           self::WriteQRCode('other');

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -145,7 +145,7 @@ function process_response(q, res) {
           "</div>"+
         "</div>");
 
-      $('.title a', k).text(kbd.name).attr('href', '/keyboards/'+kbd.id+embed_query_q);
+      $('.title a', k).text(kbd.name).attr('href', '/keyboards/'+kbd.id+(kbd.match.tag ? '?tag='+kbd.match.tag+embed_query_x : embed_query_q));
 
       if(kbd.match.downloads == 0)
         $('.downloads', k).text('No recent downloads');

--- a/keyboards/keyboard.php
+++ b/keyboards/keyboard.php
@@ -18,6 +18,8 @@
 
   $id = clean_id($_REQUEST['id']);
 
+  $tag = isset($_REQUEST['tag']) ? $_REQUEST['tag'] : null;
+
   function clean_id($id) {
     return preg_replace('/[^A-Za-z0-9_ .-]/', '', $id);
   }
@@ -35,6 +37,6 @@
     return $search->keyboards[0]->id;
   }
 
-  \UI\KeyboardDetails::render_keyboard_details($id);
+  \UI\KeyboardDetails::render_keyboard_details($id, 'stable', false, $tag);
 
 ?>


### PR DESCRIPTION
This will allow Keyman to automatically associate the appropriate language from the package at install time.

Part of solution for keymanapp/keyman#1456.