### PR TITLE
fix: obsolete keyboards in search

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -309,7 +309,7 @@ END;
         $s = json_decode($s);
         if(is_object($s)) {
           self::$keyboard = $s;
-          self::$title = self::$keyboard->name;
+          self::$title = htmlentities(self::$keyboard->name);
           if (!preg_match('/keyboard$/i', self::$title)) self::$title .= ' keyboard';
           self::$description = isset(self::$keyboard->description) ? self::$keyboard->description : '';
           self::$authorName = isset(self::$keyboard->authorName) ? self::$keyboard->authorName : '';
@@ -457,12 +457,12 @@ END;
 <?php
       if(!empty(self::$deprecatedBy)) {
         $dep = self::$deprecatedBy;
-        $name = self::$title;
+        $id = self::$id;
         echo "
           <div class='download deprecated-new'>
             <a class='download-link' href='/keyboards/$dep$session_query_q'><span>Download</span></a>
-            <div class='download-title'>Download the latest version of $name</div>
-            <div class='download-description'>Click the Download button to get the latest version of this keyboard.</div>
+            <div class='download-title'>Keyboard '$id' is obsolete.</div>
+            <div class='download-description'>Click the Download button to get the replacement <span style='font-weight:bold'>$dep</span> keyboard instead.</div>
             <div class='download-filename'>$dep</div>
           </div>
           <div>

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -134,26 +134,16 @@ h2 a {
 
 #search-results .keyboards-deprecated h4 {
   margin-top: 24px;
-  margin-left: 36px;
+  margin-left: 8px;
+  xborder-top: solid 1px #B92034;
   cursor: pointer;
   font-weight: bold;
   font-size: 14pt;
 }
 
-#search-results .keyboards-deprecated h4:hover {
-  text-decoration: underline;
-}
-
-#search-results .keyboards-deprecated .keyboard {
-  display: none;
-}
-
-#search-results .keyboards-deprecated.show .keyboard {
-  display: block;
-}
-
 #search-results .keyboards-deprecated .keyboard .title::after {
   content: " (obsolete)";
+  color: red;
 }
 
 #search-results .keyboard .title a {

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -135,9 +135,7 @@ h2 a {
 #search-results .keyboards-deprecated h4 {
   margin-top: 24px;
   margin-left: 8px;
-  xborder-top: solid 1px #B92034;
-  cursor: pointer;
-  font-weight: bold;
+  font-weight: 600;
   font-size: 14pt;
 }
 

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -133,8 +133,8 @@ function process_response(q, res) {
 
       if(kbd.deprecated && !deprecatedElement) {
         // TODO: make title change depending on whether deprecated keyboards are shown or hidden
-        deprecatedElement = $('<div class="keyboards-deprecated"><h4 class="red">Show obsolete keyboards</h4></div>');
-        deprecatedElement.find('h4').click(function() {deprecatedElement.toggleClass('show');});
+        deprecatedElement = $(
+          '<div class="keyboards-deprecated"><h4 class="red underline">Obsolete keyboards</h4></div>');
         resultsElement.append(deprecatedElement);
       }
 


### PR DESCRIPTION
For compatibility with pagination, obsolete keyboards are always shown but with red flag by them. The wording on the landing page has also been adjusted accordingly.