### PR TITLE
chore: disable install pages for deprecated keyboards

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -93,7 +93,9 @@
     }
 
     protected static function download_box($platform) {
-      if(isset(self::$keyboard->platformSupport->$platform) && self::$keyboard->platformSupport->$platform != 'none') {
+      if(!empty(self::$deprecatedBy)) {
+        return "";
+      } else if(isset(self::$keyboard->platformSupport->$platform) && self::$keyboard->platformSupport->$platform != 'none') {
         $filename = self::$id . ".kmp";
         $installLink = '/keyboard/install/' . rawurlencode(self::$id);
         if(!empty(self::$bcp47)) $installLink .= "?bcp47=" . rawurlencode(self::$bcp47);
@@ -118,8 +120,8 @@ END;
     protected static function WriteWebBoxes() {
       global $embed_target;
       global $KeymanHosts;
-      if (isset(self::$keyboard->platformSupport->desktopWeb) && self::$keyboard->platformSupport->desktopWeb != 'none') {
-        if(empty(self::$bcp47)) {
+      if (isset(self::$keyboard->platformSupport->desktopWeb) && self::$keyboard->platformSupport->desktopWeb != 'none' && empty(self::$deprecatedBy)) {
+          if(empty(self::$bcp47)) {
           if (isset(self::$keyboard->languages)) {
             if (is_array(self::$keyboard->languages)) {
               if (count(self::$keyboard->languages) > 0) {


### PR DESCRIPTION
The keyboard details page will no longer show an Install button or
a Use Online button for deprecated keyboards. While this is forced
on us by technical requirements around package identifier character
use, it also helps to push users to the non-deprecated keyboards,
which is a good outcome.