### PR TITLE
feat: keyman protocol support in install page for Windows

### DIFF
--- a/cdn/dev/keyboard-search/install.js
+++ b/cdn/dev/keyboard-search/install.js
@@ -34,12 +34,14 @@ function buildStandardKeymanProtocolDownloadLink(id, bcp47) {
 
 /**
  * Redirects to keyman:// to trigger Keyman Configuration, and if that fails,
- * to the standard download url for the package to install.
+ * to the standard download url for the package to install. This currently only
+ * applies to Windows users (it may apply in future for Linux as well).
  * @param {object} data from the object with properties for host, tier, version, id, bcp47
  */
 function startAfterPageLoad_Windows(data) {
   window.setTimeout(function() {
-    if(document.documentElement.getAttribute('data-platform') == 'windows') {
+    const platform = document.documentElement.getAttribute('data-platform'), browser = document.documentElement.getAttribute('data-browser');
+    if(platform == 'windows') {
       // This only runs for Windows
       const downloadUrl = buildStandardWindowsDownloadUrl(
         data.host, data.tier, data.version, data.id, data.bcp47
@@ -49,7 +51,11 @@ function startAfterPageLoad_Windows(data) {
         data.id, data.bcp47
       );
 
-      location.href = keymanUrl;
+      if(browser != "Internet Explorer" && browser != "Microsoft Edge Legacy") {
+        // On IE and Edge Legacy, we will never try the keyman: protocol because
+        // it gives a poor user experience.
+        location.href = keymanUrl;
+      }
 
       const fallbackHandle = window.setTimeout(function() {
           location.href = downloadUrl;

--- a/cdn/dev/keyboard-search/install.js
+++ b/cdn/dev/keyboard-search/install.js
@@ -1,0 +1,63 @@
+// TODO: show arrow in window where download is likely to be accessible from;
+//       this is browser+browser version dependent :(  don't forget to look
+//       for a library that implements this which may save pain
+
+/**
+ * Returns a URL for a downloads.keyman.com bootstrap installer
+ * for Windows. Assumes all parameters are legitimate and correctly
+ * associated (e.g. tier + version are paired)
+ * @param {string} host      https://downloads.keyman.com (or staging equivalent)
+ * @param {string} tier      alpha, beta or stable
+ * @param {string} version   version number to download (e.g 14.0.80)
+ * @param {string} id        id of keyboard to download
+ * @param {string} bcp47     bcp47 tag to associate with keyboard at install
+ */
+function buildStandardWindowsDownloadUrl(host, tier, version, id, bcp47) {
+  const url =
+    host + "/windows/" + encodeURIComponent(tier) + "/" + encodeURIComponent(version) +
+    "/keyman-setup." + encodeURIComponent(id) +
+    (bcp47 == '' ? '' : '.' + encodeURIComponent(bcp47)) + ".exe";
+  return url;
+}
+
+/**
+ * Build a keyman://download/keyboard/<id>?bcp47=<bcp47> link
+ * @param {string} id     id of keyboard to download
+ * @param {string} bcp47  bcp47 tag to associate with keyboard on install
+ */
+function buildStandardKeymanProtocolDownloadLink(id, bcp47) {
+  const url =
+    'keyman://download/keyboard/' + encodeURIComponent(id) +
+    (bcp47 == '' ? '' : '?bcp47=' + encodeURIComponent(bcp47));
+  return url;
+}
+
+/**
+ * Redirects to keyman:// to trigger Keyman Configuration, and if that fails,
+ * to the standard download url for the package to install.
+ * @param {object} data from the object with properties for host, tier, version, id, bcp47
+ */
+function startAfterPageLoad_Windows(data) {
+  window.setTimeout(function() {
+    if(document.documentElement.getAttribute('data-platform') == 'windows') {
+      // This only runs for Windows
+      const downloadUrl = buildStandardWindowsDownloadUrl(
+        data.host, data.tier, data.version, data.id, data.bcp47
+      );
+
+      const keymanUrl = buildStandardKeymanProtocolDownloadLink(
+        data.id, data.bcp47
+      );
+
+      location.href = keymanUrl;
+
+      const fallbackHandle = window.setTimeout(function() {
+          location.href = downloadUrl;
+      }, 1000);
+
+      window.addEventListener('blur', function() {
+        window.clearTimeout(fallbackHandle);
+       });
+    }
+  }, 10);
+}

--- a/cdn/dev/keyboard-search/keyboard-details.js
+++ b/cdn/dev/keyboard-search/keyboard-details.js
@@ -5,8 +5,15 @@
 (function() {
   const bowserParser = bowser.getParser(window.navigator.userAgent);
   const platform = bowserParser.getOSName({toLowerCase: true});
+  const browser = bowserParser.getBrowser();
+  const engine = bowserParser.getEngine();
+
   document.documentElement.setAttribute("data-platform",
     platform === 'chrome os' ? 'android' : // This is not ideal but works on most Chromebooks for now
     platform.match(/^(android|ios|linux|macos|windows)$/) ? platform :
     'unknown');
+
+  document.documentElement.setAttribute("data-browser",
+    engine.name == 'EdgeHTML' ? 'Microsoft Edge Legacy' : // We need to treat Edge Legacy differently to Edge Chromium
+    browser.name);
 })();


### PR DESCRIPTION
Adds support for the `keyman:` protocol refresh pattern for Windows install/ processes.

TODO:

- [x] Disable this for IE and Legacy Edge because they kinda mess up