### PR TITLE
chore: Use new staging site for search

### DIFF
--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -42,11 +42,7 @@ function wrapSearch(localCounter, updateHistory) {
 
   $('#search-box').addClass('searching');
 
-  // TODO: setup a base hosts.js file?
-  var base =
-    location.host === 'staging-keyman-com.azurewebsites.net' ?
-    location.protocol+'//staging-api-keyman-com.azurewebsites.net' :
-    location.protocol+'//api.'+location.host; // this works on test sites as well as live, assuming we use the host pattern "keyman.com[.local]"
+  var base = location.protocol+'//api.'+location.host; // this works on test sites as well as live, assuming we use the host pattern "keyman.com[.local]"
 
   var url = base+'/search/2.0?p='+page+'&q='+encodeURIComponent(q);
 


### PR DESCRIPTION
search.js still had a reference to azurewebsites.net. With the new
staging site scheme we don't need to treat staging sites any
special - they follow the regular pattern.