### PR TITLE
feat: server-side support for iOS universal links

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "details": [
+      "appIDs": ["3YE4W86L3G.Tavultesoft.Keyman"],
+      "components": [
+        "/": "keyboards/install",
+        "comment": "Registers the keyboard-package universal link pattern specified at https://docs.google.com/document/d/1rhgMeJlCdXCi6ohPb_CuyZd0PZMoSzMqGpv1A8cMFHY/edit#"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Please note the documentation here: https://developer.apple.com/documentation/safariservices/supporting_associated_domains

Apple's file location _and_ name requirements are pretty stringent.  
- Yes, the file uses the JSON format.  
- No, it _must not_ use the .json extension.
- According to older documentation, we _may_ be able to drop the `.well-known` folder component of the URL.
- Any form of redirect leading to the file is not allowed.  The file itself must exist at the specified location, no redirects.