### PR TITLE
chore: ci test change link for khmer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         cat tier.txt
         echo "--- PHP Errors ---"
         [ -f php_errors.log ] && cat php_errors.log
-        echo "--- Contents of /khmer/ ---"
-        curl http://localhost:8888/khmer/
+        echo "--- Contents of /keyboards/khmer_angkor ---"
+        curl http://localhost:8888/keyboards/khmer_angkor
         echo "--- PHPInfo ---"
         php -r 'phpinfo();'


### PR DESCRIPTION
Given the failed test https://github.com/keymanapp/keyman.com/pull/143/checks?check_run_id=929928229 I wanted to see what the Khmer link returned, but it was a redirect so that wasn't very helpful for diagnostics!