### PR TITLE
cherrypick: Add Android app association

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **/.idea
 cdn/deploy/
+
+/vendor/
+/node_modules/

--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,9 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "com.tavultesoft.kmapro",
+    "sha256_cert_fingerprints":
+      ["8F:00:F8:3F:41:BB:BF:C3:D4:AD:B2:3F:BD:63:F8:75:82:0C:A5:51:A9:EA:5A:A0:D0:FC:62:B9:49:A8:4B:85"]
+  }
+}]


### PR DESCRIPTION
Cherrypick #143 to master

Following the documentation from https://developer.android.com/training/app-links/verify-site-associations

This adds the assetlinks.json file to keyman.com

* Also updated .gitignore to include dependencies used in the staging branch.