### PR TITLE
fix: skip deprecated keyboards

### DIFF
--- a/downloads/archive/index.php
+++ b/downloads/archive/index.php
@@ -41,6 +41,16 @@
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/8.0.360.0/keymandeveloper-8.0.360.0.exe">Keyman Developer 8.0.360.0 Download</a> (Online static activation required)</li>
 </ul>
 
+<h2 class="red underline">Obsolete Keyboards</h2>
+
+<p>Keyboards that are non-Unicode or older versions may be downloaded from the following link. Generally, unless you know you have a specific
+need for an older keyboard, you should download the latest version from the <a href='/keyboards/'>Keyboard Search</a>. Note that the search
+for obsolete keyboards will return both current and obsolete keyboards.</p>
+
+<ul>
+  <li><a href='/keyboards/?obsolete=1'>Obsolete keyboard search</a></li>
+</ul>
+
 <h2 class="red underline">Static activation license keys</h2>
 
 <p>Keyman Desktop 9.0 and earlier versions are now available for free. We have made special builds of two older versions of Keyman Desktop available which do not require any activation: 9.0.528.0 and 8.0.361.0. These are feature identical to the Professional Editions.</p>

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -66,6 +66,7 @@
   <form method='get' action='/keyboards' name='f'>
     <input id="search-q" type="text" placeholder="Enter language or keyboard" name="q" autofocus>
     <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="Search" onclick="return do_search()">
+    <input id="search-obsolete" type="hidden" name="obsolete" value="0">
     <input id="search-page" type="hidden" name="page" value="1">
   </form>
 </div>


### PR DESCRIPTION
Added a link into the archive page to give access to obsolete keyboards. By default, they will not be listed.

Relates to keymanapp/api.keyman.com#87.