### PR TITLE
fix: don't load search.js on detail page

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -229,13 +229,13 @@ END;
           'showMenu' => false,
           'showHeader' => false,
           'foot' => false,
-          'js' => ['../keyboard-search/search.js', '../keyboard-search/keyboard-details.js', 'qrcode.js'],
+          'js' => ['../keyboard-search/keyboard-details.js', 'qrcode.js'],
           'css' => ['template.css', '../keyboard-search/search.css', '../keyboard-search/embed.css']
         ];
         $embed_target = " target='_blank' ";
       } else {
         $head_options += [
-          'js' => ['../keyboard-search/search.js', '../keyboard-search/keyboard-details.js', 'qrcode.js'],
+          'js' => ['../keyboard-search/keyboard-details.js', 'qrcode.js'],
           'css' => ['template.css', '../keyboard-search/search.css']
         ];
         $embed_target = '';
@@ -244,7 +244,6 @@ END;
 
       if($embed == 'none') { ?>
         <script>
-          var detail_page = true;
           var embed='none';
           var embed_query='';
         </script>
@@ -253,7 +252,6 @@ END;
         global $session_query;
       ?>
         <script>
-          var detail_page = true;
           var embed='<?=$embed?>';
           var embed_query='<?=$session_query?>';
         </script>
@@ -293,8 +291,7 @@ END;
             <div id='search-title'><a href='/keyboards'>Keyboard Search</a>:</div>
             <input id="search-q" type="text" placeholder="(new search)" name="q">
             <input id='search-page' type='hidden' name='page'>
-            <input id="search-f" type="image" src="<?= cdn('img/search-button.png') ?>" value="Search"
-                   onclick="return do_search()">
+            <input id="search-f" type="image" src="<?= cdn('img/search-button.png') ?>" value="Search">
           </form>
         </div>
 <?php

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -58,11 +58,6 @@ function wrapSearch(localCounter, updateHistory) {
     url += '&obsolete='+obsolete;
   }
 
-  if(detail_page) {
-    location.href = getCurrentPath(q, page, obsolete);
-    return false;
-  }
-
   var xhr = createCORSRequest('GET', url);
 
   function stripCommonWords(q) {
@@ -280,22 +275,20 @@ var load_search_count = 0, load_search = function() {
     return false;
   }
 
-  if(!detail_page) {
-    $('#search-q').on('input', function() {
-      if(dynamic_search_timeout) window.clearTimeout(dynamic_search_timeout);
-      dynamic_search_timeout = window.setTimeout(function() {
-        document.f.page.value = 1;
-        search(false);
-      }, 250);
-    });
+  $('#search-q').on('input', function() {
+    if(dynamic_search_timeout) window.clearTimeout(dynamic_search_timeout);
+    dynamic_search_timeout = window.setTimeout(function() {
+      document.f.page.value = 1;
+      search(false);
+    }, 250);
+  });
 
-    $('#search-results-empty code').click(function(tag) {
-      const prefix = this.innerText;
-      document.f.q.value = document.f.q.value.replace(/^.+:([^:]*)$/, '$1') +
-        (document.f.q.value.startsWith(prefix) ? '' : prefix);
-      document.f.q.focus();
-    });
-  }
+  $('#search-results-empty code').click(function(tag) {
+    const prefix = this.innerText;
+    document.f.q.value = document.f.q.value.replace(/^.+:([^:]*)$/, '$1') +
+      (document.f.q.value.startsWith(prefix) ? '' : prefix);
+    document.f.q.focus();
+  });
 
   var init = function(value, page, obsolete, updateHistory) {
     page = parseInt(page, 10);
@@ -303,7 +296,6 @@ var load_search_count = 0, load_search = function() {
     document.f.q.value = decodeURIComponent(value);
     document.f.page.value = page;
     document.f.obsolete.value = obsolete;
-
     search(!!updateHistory);
     return value != '';
   }

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -24,7 +24,6 @@
   if($embed == 'none') {
 ?>
 <script>
-  var detail_page=false;
   var embed='none';
   var embed_query='';
 </script>
@@ -32,7 +31,6 @@
   } else {
 ?>
 <script>
-  var detail_page=false;
   var embed='<?=$embed?>';
   var embed_query='<?=$session_query?>';
 </script>


### PR DESCRIPTION
This fixes a script error in search.js which was assuming the existence of certain elements on the page. It didn't make sense to include the script in the detail page anyway.

```
Uncaught TypeError: Cannot read property 'q' of undefined
at init (search.js:282)
at load_search (search.js:311)
```

Relates to keymanapp/api.keyman.com#87.