### PR TITLE
fix: non-unicode keyboards are obsolete too

### DIFF
--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -328,7 +328,7 @@ var load_search_count = 0, load_search = function() {
 };
 
 function isKeyboardObsolete(kbd) {
-  return kbd.deprecated || (typeof kbd.encodings.includes === 'function' && kbd.encodings.includes('ansi'));
+  return kbd.deprecated || (typeof kbd.encodings.includes === 'function' && !kbd.encodings.includes('unicode'));
 }
 
 window.addEventListener('load', load_search, false);

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -142,7 +142,7 @@ function process_response(q, obsolete, res) {
 
       // Remove irrelevant keyboards
 
-      if(kbd.deprecated && !deprecatedElement) {
+      if(isKeyboardObsolete(kbd) && !deprecatedElement) {
         // TODO: make title change depending on whether deprecated keyboards are shown or hidden
         deprecatedElement = $(
           '<div class="keyboards-deprecated"><h4 class="red underline">Obsolete keyboards</h4></div>');
@@ -326,5 +326,9 @@ var load_search_count = 0, load_search = function() {
 
   return init(q, page, obsolete);
 };
+
+function isKeyboardObsolete(kbd) {
+  return kbd.deprecated || (typeof kbd.encodings.includes === 'function' && kbd.encodings.includes('ansi'));
+}
 
 window.addEventListener('load', load_search, false);


### PR DESCRIPTION
While these keyboards were already excluded from the search if the obsolete flag was not set, the presentation did not necessarily put them below the "Obsolete" heading.

Relates to keymanapp/api.keyman.com#87