### PR TITLE
fix: filter keyboards for platform

### DIFF
--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -392,3 +392,7 @@ html[data-platform='unknown'] .download.download-unknown {
 #search-results:empty + #search-results-empty {
   display: unset;
 }
+
+.embed#search-results-container .platforms {
+  display: none;
+}

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -51,7 +51,7 @@ function wrapSearch(localCounter, updateHistory) {
   var url = base+'/search/2.0?p='+page+'&q='+encodeURIComponent(stripCommonWords(q));
 
   if(embed) {
-    url += '&embed='+embed;
+    url += '&platform='+embed;
   }
 
   if(obsolete) {

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -69,7 +69,7 @@
   </form>
 </div>
 
-<div id='search-results-container'>
+<div id='search-results-container' class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
 <div id='search-results'></div>
 <div id='search-results-empty'>
   <p>Enter the name of a keyboard or language to search for. (<a href="?q=p:*">Popular keyboards</a>)</p>


### PR DESCRIPTION
Relates to keymanapp/api.keyman.com#87.

When embedded, only show keyboards for that platform (fixes misnamed parameter).

Also, hides platform icons in search results when embedded.