### PR TITLE
feat: rework download keyboard dialog style

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -275,12 +275,10 @@ END;
       if ($embed != 'none') {
         ?>
 
-        <div id='navigation'>
-          <a class='nav-right' target='_blank' href='/keyboards'>Go to <?= KeymanHosts::Instance()->keyman_com ?></a>
-          <a href='/keyboards<?= $session_query_q ?>'>Home</a>
+        <div id='search-box'>
+          <label id='search-new'><a href='/keyboards<?= $session_query_q ?>'>New search</a></label>
+          <h1 class='red'><?= self::$title ?></h1>
         </div>
-
-        <h1 class='red underline'><?= self::$title ?></h1>
 
         <?php
       } else if (!self::$landingPage) {

--- a/cdn/dev/keyboard-search/embed.css
+++ b/cdn/dev/keyboard-search/embed.css
@@ -1,38 +1,27 @@
-#section2 h2:first-child {
+/* These controls are only for embedded pages */
+
+#section2 h1 {
+  padding-top: 6px;
+  padding-bottom: 0;
+  font-size: 24px;
+}
+
+#search-box {
+  margin-bottom: 12px;
+}
+
+#section2 h2 {
   margin-top: 0;
   padding-top: 4px;
+  padding-left: 0;
   text-align: left;
-}
-
-#search-results .keyboard .title {
-    margin-top: 24px;
-}
-#search-results .title {
-  margin-top: 2px;
-}
-
-#navigation {
-  border-bottom: solid 1px #666666;
-  background: #cccccc;
-  padding: 4px;
-}
-
-#navigation a {
-  display: inline-block;
-  border: solid 1px #888888;
-  padding: 4px;
-  box-shadow: 1px 1px 2px rgba(0,0,0,0.6);
-  background: #888888;
-  text-decoration: none;
-  color: white;
-  margin: 4px;
-}
-
-#navigation a.nav-right {
-  display: block;
-  float: right;
+  font-size: 24px;
 }
 
 .wrapper {
   width: auto;
+}
+
+#section2 .col {
+  float: none;
 }

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -2,11 +2,6 @@
  Search box
 */
 
-#search-box {
-  padding: 10px;
-
-}
-
 h2 a {
   color: #B92034;
   text-decoration: none;
@@ -50,9 +45,12 @@ h2 a {
 }
 
 #search-box {
+  padding: 10px;
   background: white;
+  border-top: solid 1px #666666;
   border-bottom: solid 1px #666666;
-  min-height: 36px;
+  min-height: 54px;
+  box-sizing: border-box;
 }
 
 #search-box #search-title {
@@ -78,6 +76,20 @@ h2 a {
   border-radius: 0px;
   border: solid 1px gray;
   padding-left: 10px;
+  font-family: Cabin, sans-serif;
+  font-size: 16px;
+}
+
+#search-box label {
+  float: left;
+  height: 32px;
+  display: block;
+  padding: 8px 8px 0 0;
+  box-sizing: border-box;
+}
+
+#search-box label#search-new {
+  float: right;
 }
 
 #search-box #search-f {
@@ -105,7 +117,7 @@ h2 a {
 }
 
 #search-results .title {
-  margin-top: 24px;
+  margin-top: 16px;
   padding: 0 8px 2px;
   font-size: 13pt;
 }
@@ -183,6 +195,8 @@ h2 a {
 }
 
 #search-results .statistics {
+  margin: 8px 0 0 8px;
+  font-size: 13px;
   color: #444444;
 }
 
@@ -216,6 +230,7 @@ h2 a {
 #keyboard-details-col .col {
   float: left;
   max-width: 50%;
+  box-sizing: border-box;
 }
 
 #keyboard-details .supported-languages {
@@ -248,7 +263,15 @@ h2 a {
   clear: left;
 }
 
-@media only screen and (max-width: 760px), (min-device-width: 768px) and (max-device-width: 1024px) {
+@media only screen and (max-width: 640px) {
+  #search-box label[for=search-q] {
+    display: none;
+  }
+
+  html #search-box #search-q {
+    width: 120px;
+  }
+
   /* Responsive display of table data on mobile */
 
   #keyboard-details-col .col {
@@ -393,6 +416,16 @@ html[data-platform='unknown'] .download.download-unknown {
   display: unset;
 }
 
-.embed#search-results-container .platforms {
+/* Embedded formatting */
+
+.embed #search-results-container .platforms,
+.embed h2 {
   display: none;
+}
+
+.embed #search-results .keyboard .title {
+  margin-top: 24px;
+}
+.embed #search-results .title {
+margin-top: 2px;
 }

--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -122,7 +122,7 @@ function process_response(q, obsolete, res) {
   if(res.keyboards) {
     var deprecatedElement = null;
 
-    $('<h3>').addClass('red underline').text(res.context.range ? res.context.range : "Keyboards matching '"+q+"'").appendTo(resultsElement);
+    //$('<h3>').addClass('red underline').text(res.context.range ? res.context.range : "Keyboards matching '"+q+"'").appendTo(resultsElement);
 
     $('<div class="statistics">').text(
       res.context.totalRows + (res.context.totalRows == 1 ? ' result' : ' results') +

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -20,65 +20,38 @@
   }
 
   head($head_options);
+?>
 
-  if($embed == 'none') {
-?>
-<script>
-  var embed='none';
-  var embed_query='';
-</script>
-<?php
-  } else {
-?>
 <script>
   var embed='<?=$embed?>';
   var embed_query='<?=$session_query?>';
 </script>
 
-<div id='navigation'>
-<?php
-    if($embed != 'macos') { // TODO: check for Linux
-?>
-  <a class='nav-right' target='_blank' href='/keyboards'>Go to <?= KeymanHosts::Instance()->keyman_com_host ?>&nbsp;</a>
-<?php
-    }
-    else {
-?>
-  <!–– The WebView class does not handle target='_blank' well.
-  Keyman for macOS will be able to interpret the target session query variable
-  and know to pop this page (without that variable) open in the default browser. ––>
-  <a class='nav-right' href='keyman:link?url=<?= KeymanHosts::Instance()->keyman_com ?>/keyboards'>Go to <?= KeymanHosts::Instance()->keyman_com_host ?></a>
-<?php
-    }
-?>
-  <a href='/keyboards<?=$session_query_q?>'>Home</a>
-</div>
+<div class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
 
-<?php
-  }
-?>
+  <h2 class="red underline"><a href='/keyboards'>Keyboard Search</a></h2>
 
-<h2 class="red underline"><a href='/keyboards'>Keyboard Search</a></h2>
+  <div id='search-box'>
+    <form method='get' action='/keyboards' name='f'>
+      <label for="search-q">Keyboard search:</label><input id="search-q" type="text" placeholder="Enter language or keyboard" name="q" autofocus>
+      <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="Search" onclick="return do_search()">
+      <label id="search-new"><a href='/keyboards<?=$session_query_q?>'>New search</a></label>
+      <input id="search-obsolete" type="hidden" name="obsolete" value="0">
+      <input id="search-page" type="hidden" name="page" value="1">
+    </form>
+  </div>
 
-<div id='search-box'>
-  <form method='get' action='/keyboards' name='f'>
-    <input id="search-q" type="text" placeholder="Enter language or keyboard" name="q" autofocus>
-    <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="Search" onclick="return do_search()">
-    <input id="search-obsolete" type="hidden" name="obsolete" value="0">
-    <input id="search-page" type="hidden" name="page" value="1">
-  </form>
-</div>
-
-<div id='search-results-container' class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
-<div id='search-results'></div>
-<div id='search-results-empty'>
-  <p>Enter the name of a keyboard or language to search for. (<a href="?q=p:*">Popular keyboards</a>)</p>
-  <br />
-  <p>Hints</p>
-  <ul>
-    <li>The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.</li>
-    <li>You can apply prefixes <code>k:</code> (keyboards), <code>l:</code> (languages), <code>s:</code> (scripts, writing systems)
-    or <code>c:</code> (countries) to filter your search results.</li>
-    <li>Use prefix <code>l:id:</code> to search for a BCP 47 language tag.</li>
-  </ul>
+  <div id='search-results-container' class=''>
+  <div id='search-results'></div>
+  <div id='search-results-empty'>
+    <p>Enter the name of a keyboard or language to search for. (<a href="?q=p:*">Popular keyboards</a>)</p>
+    <br />
+    <p>Hints</p>
+    <ul>
+      <li>The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.</li>
+      <li>You can apply prefixes <code>k:</code> (keyboards), <code>l:</code> (languages), <code>s:</code> (scripts, writing systems)
+      or <code>c:</code> (countries) to filter your search results.</li>
+      <li>Use prefix <code>l:id:</code> to search for a BCP 47 language tag.</li>
+    </ul>
+  </div>
 </div>


### PR DESCRIPTION
Relates to keymanapp/api.keyman.com#87. Windows-based component at keymanapp/keyman#3463.

This shows screenshots for web-based and mockups for embedded iOS/Android (mockups because they are missing the Keyman app frames):

## Web-based, starting screen

![image](https://user-images.githubusercontent.com/4498365/89489379-b1e4bc00-d7ed-11ea-8757-0cfdc4c326fb.png)

## Search for 'thai'

![image](https://user-images.githubusercontent.com/4498365/89489398-bad58d80-d7ed-11ea-8202-ab73e51eaadf.png)

## Results for Thai Kedmanee (non-ShiftLock)

![image](https://user-images.githubusercontent.com/4498365/89489417-ca54d680-d7ed-11ea-94c3-e404af3eec84.png)

## iOS, starting screen

![image](https://user-images.githubusercontent.com/4498365/89489528-130c8f80-d7ee-11ea-89b1-3d4119e2941c.png)

## iOS, search for 'lao'

![image](https://user-images.githubusercontent.com/4498365/89489559-23bd0580-d7ee-11ea-9353-b16ff7071213.png)

## iOS, 'Lao Basic' details

![image](https://user-images.githubusercontent.com/4498365/89489596-36373f00-d7ee-11ea-921b-e7d312fe20b1.png)
