### PR TITLE
fix: menu disappears with mouse move

### DIFF
--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -516,22 +516,28 @@ input[type="search"] {
 	overflow-y: visible;
 }
 
-#top-menu1 .menu-item:hover, #top-menu1 .menu-item img:hover{
+#top-menu1 .menu-item:hover,
+#top-menu1 .menu-item img:hover,
+#top-menu1 .menu-item.menu-item-force {
 	color: #B92034;
 }
 
-#top-menu1 .menu-item:hover{
+#top-menu1 .menu-item:hover,
+#top-menu1 .menu-item.menu-item-force {
 	background: #f2f2f2;
 	box-shadow: 1px 1px 4px #000;
 	position: relative;
 	z-index: 2;
 }
 
-#top-menu1 .menu-item:hover .menu-item-dropdown{
+#top-menu1 .menu-item:hover .menu-item-dropdown,
+#top-menu1 .menu-item.menu-item-force .menu-item-dropdown {
 	display: block !important;
 }
 
-#top-menu1 .menu-item:hover .header-triangle img{
+#top-menu1 .menu-item:hover .header-triangle img,
+#top-menu1 .menu-item-force .header-triangle img
+{
 	background: url('../img/triangle.png') 17px 0;
 }
 

--- a/cdn/dev/js/kmlive.js
+++ b/cdn/dev/js/kmlive.js
@@ -349,6 +349,14 @@ function loaded(){
         }
     });
   });
+
+  /* While search box in Keyboards menu is focused, make its parent always visible */
+
+  $("#language-search").on('focus', function() {
+    $('#keyboards').addClass('menu-item-force');
+  }).on('blur', function() {
+    $('#keyboards').removeClass('menu-item-force');
+  });
 }
 
 /* Handling deprecated keyboards */


### PR DESCRIPTION
Fixes #45. When the keyboard search within the Keyboards menu is focused, moving the mouse can cause the menu to disappear, which is confusing for the user.