### PR TITLE
feat: add landing pages to results

### DIFF
--- a/cdn/dev/keyboard-search/dedicated-landing-pages.js
+++ b/cdn/dev/keyboard-search/dedicated-landing-pages.js
@@ -1,0 +1,66 @@
+//
+// Meta search results for dedicated landing pages
+//
+
+const dedicatedLandingPages = [
+  {
+    id: "/amharic",
+    terms: ['amharic', 'ge\'ez', 'geez', 'ethiopic'],
+    description: "Amharic keyboards recommended by the Keyman team",
+    name: "Amharic Keyboards Home Page"
+  },
+  {
+    id: "/burmese",
+    terms: ['burmese', 'myanmar'],
+    description: "Burmese (Myanmar) keyboards recommended by the Keyman team",
+    name: "Burmese Keyboards Home Page"
+  },
+  {
+    id: "/cameroon",
+    terms: ['cameroon'],
+    description: "Cameroon keyboards recommended by the Keyman team",
+    name: "Cameroon Keyboards Home Page"
+  },
+  {
+    id: "/greek",
+    terms: ['greek', 'ancient greek', 'biblical greek', 'attic greek', 'classical greek', 'polytonic', 'polytonic greek'],
+    description: "Biblical and Classical Greek keyboards recommended by the Keyman team",
+    name: "Classical Greek Keyboards Home Page"
+  },
+  {
+    id: "/ipa",
+    terms: ['ipa', 'phonetic', 'phonetic alphabet', 'international phonetic alphabet', 'transcription'],
+    description: "IPA (International Phonetic Alphabet) keyboards recommended by the Keyman team",
+    name: "IPA Keyboards Home Page"
+  },
+  {
+    id: "/sinhala",
+    terms: ['sinhala', 'sinhalese'],
+    description: "Sinhala keyboards recommended by the Keyman team",
+    name: "Sinhala Keyboards Home Page"
+  },
+  {
+    id: "/tamil",
+    terms: ['tamil'],
+    description: "Tamil keyboards recommended by the Keyman team",
+    name: "Tamil Keyboards Home Page"
+  },
+  {
+    id: "/tibetan",
+    terms: ['tibetan', 'dzongkha'],
+    description: "Tibetan and Dzongkha keyboards recommended by the Keyman team",
+    name: "Tibetan Keyboards Home Page"
+  },
+  {
+    id: "/tigrigna",
+    terms: ['tigrigna', 'tigrinya'],
+    description: "Tigrigna keyboards recommended by the Keyman team",
+    name: "Tigrigna Keyboards Home Page"
+  },
+  {
+    id: "/urdu",
+    terms: ['urdu'],
+    description: "Urdu keyboard recommended by the Keyman team",
+    name: "Urdu Keyboard Home Page"
+  }
+];

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -433,7 +433,7 @@ html[data-platform='unknown'] .download.download-unknown {
   display: none;
 }
 
-.embed #search-results .keyboard .title {
+.embed #search-results .keyboard {
   margin-top: 24px;
 }
 .embed #search-results .title {

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -116,8 +116,11 @@ h2 a {
   margin: 10px 8px 0 0;
 }
 
-#search-results .title {
+#search-results .keyboard {
   margin-top: 16px;
+}
+
+#search-results .title {
   padding: 0 8px 2px;
   font-size: 13pt;
 }
@@ -171,6 +174,13 @@ h2 a {
 
 #search-results .keyboard .detail {
   padding: 0 8px;
+}
+
+#search-results .keyboard.keyboardLandingPage {
+  border: solid 1px #444444;
+  border-radius: 6px;
+  background: white;
+  padding: 8px 0;
 }
 
 #search-results .keyboard .id {

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -7,7 +7,7 @@
   $head_options = [
     'title' =>'Keyboard Search',
     'css' => ['template.css', '../keyboard-search/search.css'],
-    'js' => ['../keyboard-search/jquery.mark.js', '../keyboard-search/search.js']
+    'js' => ['../keyboard-search/jquery.mark.js', '../keyboard-search/dedicated-landing-pages.js', '../keyboard-search/search.js']
 ];
 
   if($embed != 'none') {


### PR DESCRIPTION
Fixes #37. Includes matching landing pages at top of keyboard search results. Matches on partial terms.

![image](https://user-images.githubusercontent.com/4498365/93820348-65234a80-fca0-11ea-8ae5-940478d16b99.png)

![image](https://user-images.githubusercontent.com/4498365/93820386-71a7a300-fca0-11ea-87d5-712582d53569.png)
