### PR TITLE
fix: keyboard install page for macOS

### DIFF
--- a/cdn/dev/keyboard-search/install.css
+++ b/cdn/dev/keyboard-search/install.css
@@ -10,12 +10,18 @@ ol {
   font-size: 16pt;
 }
 
+#section2 ol li a.download-link {
+  padding-top: 6px;
+  height: 40px;
+}
+
 ol li a {
   font-size: 16pt;
 }
 
 #step2 div {
-  margin-left: 30px;
+  margin: 0 0 0 20px;
+  line-height: 1.6em;
 }
 
 .download.download-linux[keyman-installed='true'] div#keyman-installed,

--- a/keyboards/install.php
+++ b/keyboards/install.php
@@ -137,14 +137,56 @@ END;
     }
 
     protected static function WriteMacOSBoxes() {
-      return self::download_box(
-        'Keyman for macOS',
-        KeymanDownloadVersions::getDownloadUrl('mac'), // note inconsistent platform name :(
-        htmlentities(self::$keyboard->name) . ' for macOS',
-        'Installs only ' . htmlentities(self::$keyboard->name) . '. <a href="/macosx">Keyman for Mac</a> must be installed first.',
-        'download-kmp-macos',
-        'Install keyboard',
-        'macos');
+      $keyboard = self::$keyboard;
+      $tier = self::$tier;
+      $version = self::$versions->mac->$tier;
+
+      $e = [
+        'name' => $keyboard->name,
+        'host' => KeymanHosts::Instance()->downloads_keyman_com,
+        'tier' => $tier,
+        'version' => $version,
+        'id' => $keyboard->id,
+        'bcp47' => empty(self::$bcp47) ? '' : self::$bcp47,
+      ];
+
+      $u = array_map('rawurlencode', $e);
+      $hu = array_map('htmlentities', $u);
+      $h = array_map('htmlentities', $e);
+
+      // Note, we don't need to capture an event for the keyboard download here, because we'll
+      // capture it in the /go/package/download step
+
+      $downloadLink = KeymanHosts::Instance()->keyman_com . "/go/package/download/{$hu['id']}" .
+        "?platform=macos&version={$hu['version']}&tier={$hu['tier']}" .
+        (empty($hu['bcp47']) ? "" : "&bcp47={$hu['bcp47']}");
+
+      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/mac/current-version/start/install-keyboard";
+
+      $keyboardHomeUrl = "/keyboards/{$hu['id']}" .
+        (empty($hu['bcp47']) ? "" : "?bcp47=" . $hu['bcp47']);
+
+      $downloadKeymanUrl = KeymanHosts::Instance()->keyman_com . '/mac/download';
+
+      $result = <<<END
+        <div id='content' class='download download-macos'>
+          <div>
+            <p>If you have not yet installed Keyman for macOS, please install it first before installing the keyboard.</p>
+            <ol>
+              <li id='step1'><a href='$downloadKeymanUrl' title='Download and install Keyman'>Install Keyman for macOS</a></li>
+              <li id='step2'><a class='download-link binary-download' href='$downloadLink'>
+                <span>Install keyboard</span></a>
+                <div class='download-description'>Downloads {$h['name']} for macOS.</div>
+              </li>
+            </ol>
+            <ul>
+              <li><a href='$helpLink'>Help on installing a keyboard</a></li>
+              <li><a href='$keyboardHomeUrl'>{$h['name']} keyboard home</a></li>
+            </ul>
+          </div>
+        </div>
+END;
+      return $result;
     }
 
     protected static function WriteLinuxBoxes() {
@@ -190,7 +232,7 @@ END;
               startAfterPageLoad_Linux(document.currentScript.dataset);
             </script>
             <ul>
-              <li><a href='$helpLink'>Help on installing Keyman</a></li>
+              <li><a href='$helpLink'>Help on installing a keyboard</a></li>
               <li><a href='$keyboardHomeUrl'>{$h['name']} keyboard home</a></li>
             </ul>
           </div>


### PR DESCRIPTION
Fixes the layout and links on the keyboard install page for macOS. Does not include any automatic install universal link
patterns. Also fixes wording for Linux page.

Part of #109.

![image](https://user-images.githubusercontent.com/4498365/93827547-d0731980-fcac-11ea-8f8a-a374534bd842.png)
