### PR TITLE
fix: uasort instead of usort

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -474,7 +474,7 @@ END;
                     $n = 0;
                     $count = count(get_object_vars(self::$keyboard->languages)) - 3;
                     $langs = (array) self::$keyboard->languages;
-                    usort($langs, function($i1, $i2) {
+                    uasort($langs, function($i1, $i2) {
                       return strcasecmp($i1->languageName, $i2->languageName);
                     });
 


### PR DESCRIPTION
I introduced a bug so I could do another 1 character PR. Really not really.