### PR TITLE
fix: Change IPA link to bu_phonetic

### DIFF
--- a/keyboards/h/ipa/index.php
+++ b/keyboards/h/ipa/index.php
@@ -71,9 +71,9 @@
         'id' => 'lingfilsemitica'),
 
       array(
-        'name' => 'BU Keyboard',
-        'desc' => 'This keyboard provides access to a wide range of IPA, Americanist, and European Latin characters, along with arrows and symbols for currency, typesetting, and mathematics.',
-        'id' => 'bu')
+        'name' => 'BU Phonetic',
+        'desc' => 'This keyboard provides access to a wide range of characters for Latin-based scripts in Unicode 4.1.0.',
+        'id' => 'bu_phonetic')
 
       );
 


### PR DESCRIPTION
The bu keyboard has been migrated to bu_phonetic.
By request on the [community site](https://community.software.sil.org/t/cant-find-how-to-type-ipa-pre-nasalized-superscript-nd-usin-new-keyman/2594/9), this changes the link on the IPA landing page accordingly.

Cherrypick the change from 6bb21bd72556d8acf2de1c49dd7408ce8cf80f02 to staging