### PR TITLE
fix: linux - Clarify architecture

### DIFF
--- a/linux/index.php
+++ b/linux/index.php
@@ -96,6 +96,18 @@
 
 <h2 class="red underline">Frequently Asked Questions</h2>
 <p>
+  <span class="red">Q.</span> What Linux distros will Keyman work with?
+</p>
+<p>
+  <span class="red">A.</span> Keyman is built for amd64 architecture and runs on Debian, Ubuntu, Wasta Linux.
+  It can be compiled to run from source in most distributions.
+</p>
+<p>
+  Note: Keyman packages are unavailable on the Xenial ppa.
+</p>
+
+<br/>
+<p>
     <span class="red">Q.</span> How do I install Keyman for Linux?
 </p>
 <p>
@@ -158,17 +170,6 @@ sudo apt-get install ibus-kmfl</code></pre>
     <span class="red">A.</span> It is good to remove any keyboards from ibus e.g. KMFL keyboards before you remove KMFL.
     Then, to remove KMFL:
 <pre class='language-bash code'><code>sudo dpkg --purge ibus-kmfl libkmfl</code></pre>
-</p>
-
-<br/>
-<p>
-    <span class="red">Q.</span> What Linux distros will Keyman work with?
-</p>
-<p>
-    <span class="red">A.</span> Keyman runs on Debian, Ubuntu, Wasta Linux and can be compiled to run from source in most distributions.
-</p>
-<p>
-    Note: there's currently a limitation where the Keyman packages are incomplete on the Xenial ppa.
 </p>
 
 <br/>


### PR DESCRIPTION
https://community.software.sil.org/t/keyman-launch-pad-code-not-working/3920/3

A Linux user reported not being able to install Keyman for Linux on his configuration
> Im using Ubuntu Mate Release 20.04.1 LTS (Focal Fossa) 32 bit
Kernel Linux 5.4.0-1015-raspi armv7l
Mate 1.24.0

This clarifies Keyman for Linux's architecture as amd64.

TODO: copy to help.keyman.com/products/linux
 