### PR TITLE
chore: keyman windows installer filename (production)

### DIFF
--- a/downloads/pre-release/index.php
+++ b/downloads/pre-release/index.php
@@ -40,7 +40,7 @@
 <p><a href='<?=$helphost?>/version-history'>Keyman version history</a> (all products)</p>
 
 <?php
-  downloadSection('Keyman Desktop for Windows', 'windows', 'keymandesktop-$version.exe', 'beta alpha');
+  downloadSection('Keyman Desktop for Windows', 'windows', 'keyman-$version.exe', 'beta alpha');
   downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', 'beta alpha');
 ?>
 


### PR DESCRIPTION
This mirrors the work in #187, just for the production site. We only need to change the pre-release page for this update; stable versions of course haven't changed.