### PR TITLE
chore: fixup internal keyboard links

### DIFF
--- a/keyboards/h/greek/index.php
+++ b/keyboards/h/greek/index.php
@@ -425,7 +425,7 @@ foreach ($keyboardlayouts as $n => $kl) {
     <p class='desc'><?= $kl['desc'] ?></p>
     <div class='down'>
       <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/keyboard/<?= $kl['help'] ?>'><img src="<?= cdn('img/details_button.png'); ?>" alt='Details' title='More information about the <?= $kl['name'] ?> keyboard' /></a>
-      <a href='<?= KeymanHosts::Instance()->keyman_com ?>/keyboard/<?= $kl['id'] ?>'><img src="<?= cdn('img/download_button.png'); ?>" alt='Download' title='Download the <?= $kl['name'] ?> keyboard now' /></a>
+      <a href='<?= KeymanHosts::Instance()->keyman_com ?>/keyboards/<?= $kl['id'] ?>'><img src="<?= cdn('img/download_button.png'); ?>" alt='Download' title='Download the <?= $kl['name'] ?> keyboard now' /></a>
     </div>
   </div>
 <?php

--- a/keyboards/h/ipa/index.php
+++ b/keyboards/h/ipa/index.php
@@ -84,7 +84,7 @@
           <h3 class='red'><?= $kl['name'] ?></h3>
           <p class='desc' ><?= $kl['desc'] ?></p>
           <div class='down'>
-            <a href='/keyboard/<?= $kl['id'] ?>'><img
+            <a href='/keyboards/<?= $kl['id'] ?>'><img
               src='<?= cdn('img/download_button.png') ?>' alt='Download' title='Download the <?= $kl['name'] ?> keyboard now' /></a>
             <a href='<?= $helpLink ?>'><img src='<?= cdn('img/details_button.png') ?>' alt='Details' title='More information about the <?= $kl['name'] ?> keyboard' /></a>
           </div>


### PR DESCRIPTION
While the old links work, they involve an unnecessary redirect and make maintenance harder.