### PR TITLE
feat(linux): Rename onboard package

### DIFF
--- a/downloads/pre-release/index.php
+++ b/downloads/pre-release/index.php
@@ -49,7 +49,7 @@
 <pre class='language-bash code'><code>
 sudo add-apt-repository ppa:keymanapp/keyman-daily
 sudo apt-get update
-sudo apt-get install keyman onboard</code></pre>
+sudo apt-get install keyman onboard-keyman</code></pre>
 
 <?php
   downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', 'beta alpha');


### PR DESCRIPTION
Update instructions how to install pre-release version of keyman. The package name is now `onboard-keyman` instead of `onboard`. Part of keymanapp/keyman#3966.