### PR TITLE
feat(linux): Rename onboard package

### DIFF
--- a/14/index.php
+++ b/14/index.php
@@ -116,14 +116,12 @@ downloadSection('Keyman 14 for macOS',   'mac',     'keyman-$version.dmg', 'beta
   <li>Open a .kmp file with Keyman Config (#3183)</li>
   <li>Now supports Ubuntu 20.10 (Groovy) (#3876)</li>
   <li>Improved user interface</li>
-  <li>Improved support for KDE, Gnome, Fedora, Arch Linux</li>
+  <li>Improved support for KDE, Gnome, Arch Linux</li>
 </ul>
 
 <li>Ubuntu, Wasta-Linux: Keyman for Linux can be installed via launchpad:</li>
-<blockquote><pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman-nightly
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install keyman onboard</code></pre></blockquote>
+<blockquote><pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman
+sudo apt install keyman onboard-keyman</code></pre></blockquote>
 
 
 <?php

--- a/downloads/_downloads.php
+++ b/downloads/_downloads.php
@@ -16,9 +16,7 @@
 
 <li>Ubuntu, Wasta-Linux: Keyman for Linux can be installed via launchpad:</li>
 <blockquote><pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install keyman ibus-keyman onboard</code></pre></blockquote>
+sudo apt install keyman onboard-keyman</code></pre></blockquote>
 
 <h2 class='red underline large'>Products for Software Developers</h2>
 

--- a/downloads/pre-release/index.php
+++ b/downloads/pre-release/index.php
@@ -48,8 +48,7 @@
 <p>Ubuntu: Keyman for Linux can be installed via <a href='https://launchpad.net/~keymanapp/+archive/ubuntu/keyman-daily'>launchpad</a>:</p>
 <pre class='language-bash code'><code>
 sudo add-apt-repository ppa:keymanapp/keyman-daily
-sudo apt-get update
-sudo apt-get install keyman onboard</code></pre>
+sudo apt install keyman onboard-keyman</code></pre>
 
 <?php
   downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', 'beta alpha');

--- a/linux/download.php
+++ b/linux/download.php
@@ -23,9 +23,7 @@
   Keyman for Linux is currently available via Launchpad:
 </p>
 <pre><code class='language-bash'>sudo add-apt-repository ppa:keymanapp/keyman
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install keyman ibus-keyman onboard</code></pre>
+sudo apt install keyman onboard-keyman</code></pre>
 
 <h3 class='red underline'>Debian</h3>
 

--- a/linux/index.php
+++ b/linux/index.php
@@ -115,9 +115,7 @@
 <p>
     <span class="red">A.</span> Ubuntu: Keyman for Linux can be installed via launchpad:
 <pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install keyman ibus-keyman onboard</code></pre>
+sudo apt install keyman onboard-keyman</code></pre>
 </p>
 
 <br/>
@@ -159,9 +157,7 @@ sudo apt-get install keyman ibus-keyman onboard</code></pre>
 <p>
     <span class="red">A.</span> Yes. To install KMFL on Ubuntu:
 <pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install ibus-kmfl</code></pre>
+sudo apt install ibus-kmfl</code></pre>
 </p>
 
 <br/>


### PR DESCRIPTION
Update instructions how to install the on-screen keyboard for Keyman. The package name is now `onboard-keyman` instead of `onboard`. Part of keymanapp/keyman#3966.

Also modernized installation command, and removed Fedora (there are no packages for Fedora yet).