### PR TITLE
feat: versioned download pages

### DIFF
--- a/downloads/releases/_version_downloads.php
+++ b/downloads/releases/_version_downloads.php
@@ -1,0 +1,76 @@
+<?php
+  require_once('includes/template.php');
+  require_once('includes/ui/downloads.php');
+  require_once('includes/appstore.php');
+  require_once('includes/playstore.php');
+
+  if(!isset($_REQUEST['version'])) {
+    echo "version parameter is required.";
+    exit;
+  }
+
+  $version = $_REQUEST['version'];
+  if(!preg_match('/^\d+\.\d+\.\d+$/', $version)) {
+    echo "Invalid version parameter.";
+    exit;
+  }
+
+  // note: we currently ignore the tier parameter
+
+  $versions = @json_decode(file_get_contents("http://downloads.keyman.com.local/api/version/2.0?targetVersion=$version"));
+
+  if(empty($versions->android))
+    $tier = 'unknown';
+  else {
+    // test against alpha, beta, stable
+    $tier = array_key_first(get_object_vars($versions->android));
+  }
+
+  $versionTier = $version . ($tier == 'stable' ? "" : "-$tier");
+
+  // Required
+  head([
+    'title' =>"Keyman $versionTier Downloads",
+    'css' => ['template.css','index.css','app-store-links.css', 'prism.css'],
+    'js' => ['prism.js'],
+    'showMenu' => true
+  ]);
+?>
+<h2 class="red underline large">Keyman <?= $versionTier ?> Downloads</h2>
+
+<?php
+  if(empty($versions->android)) {
+    echo "<p>Version $version may be invalid, or may not yet be available.</p>";
+    exit;
+  }
+
+  downloadSection('Keyman Desktop for Windows',   'windows',   ['keyman-$version.exe', 'keymandesktop-$version.exe'], $tier);
+  downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', $tier);
+  downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', $tier);
+?>
+
+<p>Keyman for Android is also available on the Play Store.</p>
+<?= $playstoreTable ?>
+
+<h2 id="iOS" class='red underline'>Keyman for iPhone and iPad</h2>
+<p>Keyman for iPhone and iPad can be found on the App Store.</p>
+<?= $appstoreTable ?>
+
+<h2 id='linux' class='red underline'>Keyman for Linux</h2>
+
+<li>Ubuntu, Wasta-Linux: Keyman for Linux can be installed via launchpad:</li>
+<blockquote><pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install keyman ibus-keyman onboard</code></pre></blockquote>
+
+<h2 class='red underline large'>Products for Software Developers</h2>
+
+<?php
+  downloadSection('KeymanWeb',                     'web',       'keymanweb-$version.zip',             $tier);
+  downloadSection('Keyman Developer',              'developer', 'keymandeveloper-$version.exe',       $tier);
+  downloadSection('Keyman Engine for Android',     'android',   'keyman-engine-android-$version.zip', $tier, 'android-engine');
+  downloadSection('Keyman Engine for iOS',         'ios',       'keyman-engine-ios-$version.zip',     $tier, 'ios-engine');
+?>
+
+<br/>

--- a/downloads/releases/_version_downloads.php
+++ b/downloads/releases/_version_downloads.php
@@ -17,7 +17,7 @@
 
   // note: we currently ignore the tier parameter
 
-  $versions = @json_decode(file_get_contents("http://downloads.keyman.com.local/api/version/2.0?targetVersion=$version"));
+  $versions = @json_decode(file_get_contents("https://downloads.keyman.com/api/version/2.0?targetVersion=$version")); // TODO: use KeymanHosts in the future
 
   if(empty($versions->android))
     $tier = 'unknown';

--- a/downloads/releases/web.config
+++ b/downloads/releases/web.config
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <clear />
+
+                <rule name="releases-tier/download" stopProcessing="true">
+                  <!-- note: the tier is currently ignored -->
+                  <match url="^(alpha|beta|stable)/(.+)$" />
+                  <action type="Rewrite" url="_version_downloads.php?tier={R:1}&amp;version={R:2}" />
+                </rule>
+
+                <rule name="releases-download" stopProcessing="true">
+                  <match url="^(.+)$" />
+                  <action type="Rewrite" url="_version_downloads.php?version={R:1}" />
+                </rule>
+
+                <rule name="index" stopProcessing="true">
+                  <match url="^$" />
+                  <action type="Redirect" url=".." />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
This is a very basic landing page for versioned installs which we can use with keymanapp/keyman#4202. Depends on an update to downloads.keyman.com, coming shortly.