### PR TITLE
fix: bookmarklet list missing many keyboards

### DIFF
--- a/bookmarklet/index.php
+++ b/bookmarklet/index.php
@@ -2,9 +2,10 @@
   require_once('includes/template.php');
   require_once __DIR__ . '/../_includes/autoload.php';
   use Keyman\Site\Common\KeymanHosts;
+  use Keyman\Site\com\keyman\KeymanVersion;
 
-  $lang = isset($_GET['language']) ? $_GET['language'] : '';
-  $kbd = isset($_GET['keyboard']) ? $_GET['keyboard'] : '';
+  $lang = isset($_GET['language']) ? json_encode($_GET['language']) : '""';
+  $kbd = isset($_GET['keyboard']) ? json_encode($_GET['keyboard']) : '""';
 
   // Required
   head([
@@ -15,9 +16,12 @@
 ?>
 
 <script type="text/javascript">
-  var resourceBase="<?php echo $KeymanHosts->r_keymanweb_com; ?>";
-  var kbdname = '<?= $kbd ?>';
-  var languageCode = '<?= $lang ?>';
+  const bookmarkletParameters = {
+    keymanVersion: "<?= KeymanVersion::stable_version ?>",
+    resourceBase: "<?= KeymanHosts::Instance()->r_keymanweb_com ?>",
+    keyboardId: <?= $kbd ?>,
+    languageId: <?= $lang ?>
+  };
 </script>
 <script type='text/javascript' src='install-bookmarklet.js'></script>
 

--- a/bookmarklet/install-bookmarklet.js
+++ b/bookmarklet/install-bookmarklet.js
@@ -3,7 +3,7 @@ var loaded = false;
 function getBookmarkletCode(lang, kbd) {
   var code =
     "javascript:void((function(){try{var%20e=document.createElement('script');e.type='text/javascript';"+
-    "e.src='"+resourceBase+"/code/bml20.php"+
+    "e.src='"+bookmarkletParameters.resourceBase+"/code/bml20.php"+
     "?langid="+encodeURIComponent(lang.id)+
     "&amp;keyboard="+encodeURIComponent(kbd.id)+
     "';document.body.appendChild(e);}catch(v){}})())";
@@ -46,8 +46,8 @@ window.addEventListener('load', function() {
     .on('keyup', filterList)
     .on('change', filterList);
 
-  if (languageCode == '' || kbdname == '') {
-    $.get(resourceBase+'/api/4.0/languages?languageidtype=bcp47', function(data) {
+  if (bookmarkletParameters.languageId == '' || bookmarkletParameters.keyboardId == '') {
+    $.get(bookmarkletParameters.resourceBase+'/api/4.0/languages?version='+bookmarkletParameters.keymanVersion+'&languageidtype=bcp47', function(data) {
       $('#bookmarklet-search #spinner').hide();
       data.languages.languages.forEach(function(lang) {
         lang.keyboards.forEach(function(kbd) {
@@ -58,7 +58,8 @@ window.addEventListener('load', function() {
       filterList();
     });
   } else {
-    $.get(resourceBase+'/api/4.0/languages/'+languageCode+'/'+kbdname, function(data) {
+    $('#bookmarklet-search').hide();
+    $.get(bookmarkletParameters.resourceBase+'/api/4.0/languages/'+bookmarkletParameters.languageId+'/'+bookmarkletParameters.keyboardId+'?version='+bookmarkletParameters.keymanVersion+'&languageidtype=bcp47', function(data) {
       createSingleBookmarklet(data.language, data.language.keyboards[0]);
     });
   }


### PR DESCRIPTION
Fixes keymanapp/api.keyman.com#47.

This adds the version parameter to the api call in order to get all keyboards compatible with the current version. Also tidied up global variables for future maintainability.

There has long been a hidden feature which we have not really used, so I will highlight out again here: you can pass in a `keyboard` and `language` parameter into the page to get the page to show just a single keyboard, for example:

https://keyman.com/bookmarklet/?keyboard=tibetan_direct_input&language=adi-tibt

I can see this being useful in a variety of possible situations in the future.