### PR TITLE
fix: hide package download link where appropriate

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -435,10 +435,16 @@ END;
 
           <table id='keyboard-details'>
             <tbody>
+<?php
+              if(isset(self::$keyboard->packageFilename)) {
+?>
             <tr>
               <th>Package Download</th>
               <td><a href="<?= self::$kmpDownloadUrl ?>"><?= self::$keyboard->id ?>.kmp</a></td>
             </tr>
+<?php
+              }
+?>
             <tr>
               <th>Monthly Downloads</th>
               <td><?= self::$downloadCount ?></td>


### PR DESCRIPTION
Fixes #207.

If a keyboard package result does not include a package, hide the package download link (e.g. `ipauni11`).