### PR TITLE
Fix: keyboard landing pages when viewed on mobile

### DIFF
--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -2280,6 +2280,10 @@ button.feedback{
 	.download-cta-big{
 		height: auto;
 	}
+	.download-cta-big p{
+		width: auto;
+	}
+
 	.download-cta-small{
 		display: none;
 	}

--- a/keyboards/h/burmese/index.php
+++ b/keyboards/h/burmese/index.php
@@ -25,7 +25,8 @@
 ?>
 
   <div id='intro'>
-    <img title="Mandalay Hill 3 &mdash; Image Courtesy of Stefan Fussan" src="<?= cdn('img/Mandalay_Hill_3.jpg') ?>" id="photo" style='float:right; margin: 8px 0px 8px 24px; width: 50%' />
+    <img title="Mandalay Hill 3 &mdash; Image Courtesy of Stefan Fussan" src="<?= cdn('img/Mandalay_Hill_3.jpg') ?>"
+         id="photo" style='float:right; margin: 8px 0px 8px 24px; width: 50%' />
 
     <h1 class="red">Burmese Keyboards</h1>
     <p>Type Burmese in all your favourite applications from your own hardware keyboard.</p>

--- a/keyboards/h/cameroon/index.php
+++ b/keyboards/h/cameroon/index.php
@@ -26,7 +26,7 @@
 
   <div id='intro'>
     <img title="Mont Mbapit14 &mdash; Image Courtesy of Noel Coston" src="<?= cdn('img/Mont_Mbapit14.jpg') ?>"
-         id="photo" style='float:right; margin: 8px 0px 8px 24px' />
+         id="photo" style='float:right; margin: 8px 0px 8px 24px; width: 50%' />
 
     <h1 class="red underline">Cameroon Keyboards</h1>
 

--- a/keyboards/h/greek/index.php
+++ b/keyboards/h/greek/index.php
@@ -133,7 +133,7 @@
 
   #greek {
     font: 12pt "Palatino Linotype",Tahoma !important; border: solid 1px #D6AE7C; background: #FAF2E8;
-    padding: 2px 3px; width:500px; margin: 15px 5px -5px;
+    padding: 2px 3px 2px 3px; margin: 15px 5px -5px;
     border-radius: 6px; -moz-border-radius: 6px; -webkit-border-radius: 6px
   }
   #greek div {

--- a/keyboards/h/sinhala/index.php
+++ b/keyboards/h/sinhala/index.php
@@ -1,8 +1,8 @@
 <?php
     $user_agent = $_SERVER['HTTP_USER_AGENT'];
     if(preg_match('/(ipad)|(iphone)|(android)/i',$user_agent)) {
-      /* TODO: Fix this broken link */
-      header('Location: /helabasa/');
+      /* TODO: Use a better mobile version */
+      header('Location: /basic_kbdsn1/');
     }
     else {
       header('Location: /sinhala/garp/');

--- a/keyboards/h/sinhala/index.php
+++ b/keyboards/h/sinhala/index.php
@@ -1,6 +1,7 @@
 <?php
     $user_agent = $_SERVER['HTTP_USER_AGENT'];
     if(preg_match('/(ipad)|(iphone)|(android)/i',$user_agent)) {
+      /* TODO: Fix this broken link */
       header('Location: /helabasa/');
     }
     else {

--- a/keyboards/h/tibetan/index.php
+++ b/keyboards/h/tibetan/index.php
@@ -26,7 +26,7 @@
 
   <div id='intro'>
     <img title="Chiyu Gompa and Mount Kailash &mdash; Image Courtesy of Reurinkjan" src="<?= cdn('img/Mount_Kailash_-_reurinkjan.jpg') ?>"
-         id="photo" style='float:right; margin: 8px 0px 8px 24px' />
+         id="photo" style='float:right; margin: 8px 0px 8px 24px; width: 50%' />
 
     <h1 class="red underline">Tibetan Keyboards</h1>
 

--- a/keyboards/h/urdu/index.php
+++ b/keyboards/h/urdu/index.php
@@ -111,7 +111,7 @@
 <div class="spacer"></div>
 <h2 class='red underline'>Screenshots</h2>
 <h3>Urdu on Windows</h3>
-<img src="<?php echo cdn('img/urdu-desktop.png'); ?>" style='width:50%' />
+<img src="<?php echo cdn('img/urdu-desktop.png'); ?>"' />
 <br/><br/>
 <h3>Urdu on iPhone</h3>
 <img src="<?php echo cdn('img/urdu-keyboard-iphone5-small.png'); ?>" />

--- a/web.config
+++ b/web.config
@@ -205,6 +205,7 @@
                 <rule name="ancient-hebrew">  <match url="^ancient-hebrew(/?)$" />  <action type="Redirect" url="/keyboards/galaxie_greek_hebrew_mnemonic" /></rule>
                 <rule name="arabic">          <match url="^arabic(/?)$" />          <action type="Redirect" url="/keyboards/basic_kbda1" /></rule>
                 <rule name="assamese">        <match url="^assamese(/?)$" />        <action type="Redirect" url="/keyboards/isis_bangla" /></rule>
+                <rule name="basic_kbdsn1">    <match url="^basic_kbdsn1(/?)$" />    <action type="Redirect" url="/keyboards/basic_kbdsn1" /></rule>
                 <rule name="bengali">         <match url="^bengali(/?)$" />         <action type="Redirect" url="/keyboards/basic_kbdinbe2" /></rule>
                 <rule name="cherokee">        <match url="^cherokee(/?)$" />        <action type="Redirect" url="/keyboards/cherokee6" /></rule>
                 <rule name="cheyenne">        <match url="^cheyenne(/?)$" />        <action type="Redirect" url="/keyboards/sil_cheyenne" /></rule>


### PR DESCRIPTION
Fixes #174 to improve viewing the keyboard landing pages on mobile

Amharic (width of download text)
![amharic](https://user-images.githubusercontent.com/7358010/111116162-31aee200-8598-11eb-8181-7d33396b7bbc.PNG)

Cameroon (scale the picture)
![cameroon](https://user-images.githubusercontent.com/7358010/111116273-5c993600-8598-11eb-9f5d-7642a63cdfeb.PNG)


Greek (quote)
![greek](https://user-images.githubusercontent.com/7358010/111116314-6f136f80-8598-11eb-95f0-db779574ce69.PNG)


Urdu (Window screenshot)
![urdu](https://user-images.githubusercontent.com/7358010/111116473-a6821c00-8598-11eb-91be-f7d57bf48b13.PNG)


