### PR TITLE
chore: Rename Windows download links

### DIFF
--- a/downloads/_downloads.php
+++ b/downloads/_downloads.php
@@ -1,6 +1,5 @@
 <?php
-  // TODO #186: 14.0 stable release requires rename here
-  downloadSection('Keyman for Windows',         'windows', 'keymandesktop-$version.exe', 'stable');
+  downloadSection('Keyman for Windows',         'windows', 'keymand-$version.exe', 'stable');
   downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', 'stable');
   downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', 'stable');
 ?>

--- a/downloads/archive/index.php
+++ b/downloads/archive/index.php
@@ -13,13 +13,15 @@
   require_once('./static-keys.php');
 
   // These variables should be progressively added if we update older versions.
+  $ver_windows_13 = "13.0.118.0";
   $ver_windows_12 = "12.0.66.0";
   $ver_windows_11 = "11.0.1361.0";
   $ver_windows_10 = "10.0.1208.0";
 ?>
 <h2 class="red underline">Keyman Desktop Download Archive</h2>
 <ul>
-    <!-- TODO: use downloads API to get the latest 12.0 version -->
+    <!-- TODO: use downloads API to get the latest 13.0 version -->
+    <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_13 ?>/keymandesktop-<?= $ver_windows_13 ?>.exe">Keyman Desktop <?= $ver_windows_13 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_12 ?>/keymandesktop-<?= $ver_windows_12 ?>.exe">Keyman Desktop <?= $ver_windows_12 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_11 ?>/keymandesktop-<?= $ver_windows_11 ?>.exe">Keyman Desktop <?= $ver_windows_11 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_10 ?>/keymandesktop-<?= $ver_windows_10 ?>.exe">Keyman Desktop <?= $ver_windows_10 ?> Download</a> (No activation required)</li>
@@ -33,7 +35,8 @@
 
 <h2 class="red underline">Keyman Developer Download Archive</h2>
 <ul>
-    <!-- TODO: use downloads API to get the latest 12.0 version -->
+    <!-- TODO: use downloads API to get the latest 13.0 version -->
+    <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_13 ?>/keymandeveloper-<?= $ver_windows_13 ?>.exe">Keyman Developer <?= $ver_windows_13 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_12 ?>/keymandeveloper-<?= $ver_windows_12 ?>.exe">Keyman Developer <?= $ver_windows_12 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_11 ?>/keymandeveloper-<?= $ver_windows_11 ?>.exe">Keyman Developer <?= $ver_windows_11 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_10 ?>/keymandeveloper-<?= $ver_windows_10 ?>.exe">Keyman Developer <?= $ver_windows_10 ?> Download</a> (No activation required)</li>

--- a/downloads/releases/_version_downloads.php
+++ b/downloads/releases/_version_downloads.php
@@ -55,7 +55,7 @@
     exit;
   }
 
-  downloadSection('Keyman Desktop for Windows',   'windows',   ['keyman-$version.exe', 'keymandesktop-$version.exe'], $tier);
+  downloadSection('Keyman for Windows',         'windows',   ['keyman-$version.exe', 'keymandesktop-$version.exe'], $tier);
   downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', $tier);
   downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', $tier);
 ?>

--- a/windows/download.php
+++ b/windows/download.php
@@ -44,6 +44,5 @@
 
 <a id='standalone'></a>
 <?php
-  // TODO #186: 14.0 stable release requires rename here
-  downloadLargeCTA('Keyman for Windows', 'windows', 'stable', 'keymandesktop-$version.exe');
+  downloadLargeCTA('Keyman for Windows', 'windows', 'stable', 'keyman-$version.exe');
 ?>


### PR DESCRIPTION
In prep for releasing to stable:

* Fixes #186 to update Windows installer names
* Add 13.0 stable links to archive page
