### PR TITLE
fix: Update deprecated links for featured keyboards

### DIFF
--- a/keyboards/h/sinhala/garp/index.php
+++ b/keyboards/h/sinhala/garp/index.php
@@ -49,7 +49,7 @@
     <a class="download-cta-more" href="/mac/">Learn more about Keyman for macOS</a>
   </div>
 </div>
-<div id="download-cta" data-language='si' data-keyboard='helabasauni'>
+<div id="download-cta" data-language='si' data-keyboard='helabasauni'> <!-- Is this basic_kbdsn1 ? -->
   <div class="download-cta-big iPhone" id="cta-big-iPhone">
     <h3>Sinhala Keyman for iPhone</h3>
     <div class="download-cta-button">

--- a/keyboards/h/sinhala/garp/index.php
+++ b/keyboards/h/sinhala/garp/index.php
@@ -49,7 +49,7 @@
     <a class="download-cta-more" href="/mac/">Learn more about Keyman for macOS</a>
   </div>
 </div>
-<div id="download-cta" data-language='si' data-keyboard='helabasauni'> <!-- Is this basic_kbdsn1 ? -->
+<div id="download-cta" data-language='si' data-keyboard='helabasauni'> <!-- TODO: use a better mobile version -->
   <div class="download-cta-big iPhone" id="cta-big-iPhone">
     <h3>Sinhala Keyman for iPhone</h3>
     <div class="download-cta-button">

--- a/keyboards/h/sinhala/sipon/index.php
+++ b/keyboards/h/sinhala/sipon/index.php
@@ -21,7 +21,7 @@
 	වෙබ් බ්‍රවුසර්, ඊ-මේල්, වර්ඩ්, එක්සෙල්, අවුට්ලුක් සහ තවත් බොහෝ ප්‍රියතම පරිගණක වැඩසටහන් මත සිංහල පහසුවෙන් යතුරු ලියනය කරන්න. ඔබගේ පරිගණකයේ දෘඩාංග වල කිසිදු වෙනසක් සිදු නොකර මෙම යතුරු පුවරු සහ යෙදුම් භාවිතයෙන් සිංහල යතුරු ලියනය කල හැකිය. සියලුම යතුරු පුවරු <a href='http://www.unicode.org/standard/WhatIsUnicode.html' target='_blank'>Unicode</a> නීති වලින් සමන්විත වේ.
 </p>
 
-<div id="download-cta" data-language='si' data-keyboard='sipon phonetic'>
+<div id="download-cta" data-language='si' data-keyboard='sipon%20phonetic%20sinhala'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" alt="." />
   </div>
@@ -49,7 +49,7 @@
     <a class="download-cta-more" href="/mac/">Learn more about Keyman for macOS</a>
   </div>
 </div>
-<div id="download-cta" data-language='si' data-keyboard='helabasauni'>
+<div id="download-cta" data-language='si' data-keyboard='helabasauni'> <!-- Is this basic_kbdsn1 ? -->
   <div class="download-cta-big iPhone" id="cta-big-iPhone">
     <h3>Sinhala Keyman for iPhone</h3>
     <div class="download-cta-button">

--- a/keyboards/h/sinhala/sipon/index.php
+++ b/keyboards/h/sinhala/sipon/index.php
@@ -49,7 +49,7 @@
     <a class="download-cta-more" href="/mac/">Learn more about Keyman for macOS</a>
   </div>
 </div>
-<div id="download-cta" data-language='si' data-keyboard='helabasauni'> <!-- Is this basic_kbdsn1 ? -->
+<div id="download-cta" data-language='si' data-keyboard='helabasauni'> <!-- TODO: use a better mobile version -->
   <div class="download-cta-big iPhone" id="cta-big-iPhone">
     <h3>Sinhala Keyman for iPhone</h3>
     <div class="download-cta-button">

--- a/keyboards/h/tamil/anjal-paangu/index.php
+++ b/keyboards/h/tamil/anjal-paangu/index.php
@@ -21,7 +21,7 @@
     கணினி விண்டோ திரையில் வுள்ள ஈமெயில், வோர்ட், அச்செச்ஸ், எக்ஸ்செல், அவுட்லுக், இன்டர்நெட் எக்ஸ்ப்லோறேர், போஎர் பாக்ஸ் , மற்றும் இவை போன்றவைகளில் தமிழில் டைப் செய்யவும். இந்த கணினி தட்டச்சில் உள்ள வரிசைகள் தமிழில் டைப் செய்ய உதவும் அனால் ஏற்கனவே உள்ள கணினி தட்டச்சில் எந்த வித மாற்றமும் வராது. இவை முழுமையான <a href="http://www.unicode.org/standard/translations/tamil.html" target="_blank">யூனிக்கோடு</a> (Unicode) விதி முறைக்கு கட்டுப்பட்டது
 </p>
 <img id="ezana-stone" style="height:488px" src="<?php echo cdn('img/thanjavur_temple.jpg'); ?>" title="Thanjavur Temple — Image courtesy of Venu62" />
-<div id="download-cta" data-language='ta' data-keyboard='ekwunitamil'>
+<div id="download-cta" data-language='ta' data-keyboard='thamizha_anjal_paangu'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" />
   </div>

--- a/keyboards/h/tamil/new-typewriter/index.php
+++ b/keyboards/h/tamil/new-typewriter/index.php
@@ -21,7 +21,7 @@
     கணினி விண்டோ திரையில் வுள்ள ஈமெயில், வோர்ட், அச்செச்ஸ், எக்ஸ்செல், அவுட்லுக், இன்டர்நெட் எக்ஸ்ப்லோறேர், போஎர் பாக்ஸ் , மற்றும் இவை போன்றவைகளில் தமிழில் டைப் செய்யவும். இந்த கணினி தட்டச்சில் உள்ள வரிசைகள் தமிழில் டைப் செய்ய உதவும் அனால் ஏற்கனவே உள்ள கணினி தட்டச்சில் எந்த வித மாற்றமும் வராது. இவை முழுமையான <a href="http://www.unicode.org/standard/translations/tamil.html" target="_blank">யூனிக்கோடு</a> (Unicode) விதி முறைக்கு கட்டுப்பட்டது
 </p>
 <img id="ezana-stone" style="height:488px" src="<?php echo cdn('img/thanjavur_temple.jpg'); ?>" title="Thanjavur Temple — Image courtesy of Venu62" />
-<div id="download-cta" data-language='ta' data-keyboard='ekwnewtwuni'>
+<div id="download-cta" data-language='ta' data-keyboard='thamizha_new_typewriter'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" />
   </div>

--- a/keyboards/h/tamil/suratha-bamuni/index.php
+++ b/keyboards/h/tamil/suratha-bamuni/index.php
@@ -21,7 +21,7 @@
     கணினி விண்டோ திரையில் வுள்ள ஈமெயில், வோர்ட், அச்செச்ஸ், எக்ஸ்செல், அவுட்லுக், இன்டர்நெட் எக்ஸ்ப்லோறேர், போஎர் பாக்ஸ் , மற்றும் இவை போன்றவைகளில் தமிழில் டைப் செய்யவும். இந்த கணினி தட்டச்சில் உள்ள வரிசைகள் தமிழில் டைப் செய்ய உதவும் அனால் ஏற்கனவே உள்ள கணினி தட்டச்சில் எந்த வித மாற்றமும் வராது. இவை முழுமையான <a href="http://www.unicode.org/standard/translations/tamil.html" target="_blank">யூனிக்கோடு</a> (Unicode) விதி முறைக்கு கட்டுப்பட்டது
 </p>
 <img id="ezana-stone" style="height:488px" src="<?php echo cdn('img/thanjavur_temple.jpg'); ?>" title="Thanjavur Temple — Image courtesy of Venu62" />
-<div id="download-cta" data-language='ta' data-keyboard='ekwbamuni'>
+<div id="download-cta" data-language='ta' data-keyboard='thamizha_bamini'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" />
   </div>

--- a/keyboards/h/tamil/visual-media-modular/index.php
+++ b/keyboards/h/tamil/visual-media-modular/index.php
@@ -21,7 +21,7 @@
     கணினி விண்டோ திரையில் வுள்ள ஈமெயில், வோர்ட், அச்செச்ஸ், எக்ஸ்செல், அவுட்லுக், இன்டர்நெட் எக்ஸ்ப்லோறேர், போஎர் பாக்ஸ் , மற்றும் இவை போன்றவைகளில் தமிழில் டைப் செய்யவும். இந்த கணினி தட்டச்சில் உள்ள வரிசைகள் தமிழில் டைப் செய்ய உதவும் அனால் ஏற்கனவே உள்ள கணினி தட்டச்சில் எந்த வித மாற்றமும் வராது. இவை முழுமையான <a href="http://www.unicode.org/standard/translations/tamil.html" target="_blank">யூனிக்கோடு</a> (Unicode) விதி முறைக்கு கட்டுப்பட்டது
 </p>
 <img id="ezana-stone" style="height:488px" src="<?php echo cdn('img/thanjavur_temple.jpg'); ?>" title="Thanjavur Temple — Image courtesy of Venu62" />
-<div id="download-cta" data-language='ta' data-keyboard='visual_media_tamil_modular'>
+<div id="download-cta" data-language='ta' data-keyboard='vm_tamil_modular'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" />
   </div>

--- a/keyboards/h/tamil/visual-media-typewriter/index.php
+++ b/keyboards/h/tamil/visual-media-typewriter/index.php
@@ -21,7 +21,7 @@
     கணினி விண்டோ திரையில் வுள்ள ஈமெயில், வோர்ட், அச்செச்ஸ், எக்ஸ்செல், அவுட்லுக், இன்டர்நெட் எக்ஸ்ப்லோறேர், போஎர் பாக்ஸ் , மற்றும் இவை போன்றவைகளில் தமிழில் டைப் செய்யவும். இந்த கணினி தட்டச்சில் உள்ள வரிசைகள் தமிழில் டைப் செய்ய உதவும் அனால் ஏற்கனவே உள்ள கணினி தட்டச்சில் எந்த வித மாற்றமும் வராது. இவை முழுமையான <a href="http://www.unicode.org/standard/translations/tamil.html" target="_blank">யூனிக்கோடு</a> (Unicode) விதி முறைக்கு கட்டுப்பட்டது
 </p>
 <img id="ezana-stone" style="height:488px" src="<?php echo cdn('img/thanjavur_temple.jpg'); ?>" title="Thanjavur Temple — Image courtesy of Venu62" />
-<div id="download-cta" data-language='ta' data-keyboard='visual_media_tamil_typewriter'>
+<div id="download-cta" data-language='ta' data-keyboard='vm_tamil_typewriter'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" />
   </div>

--- a/keyboards/h/urdu/index.php
+++ b/keyboards/h/urdu/index.php
@@ -17,7 +17,7 @@
 <p>
     <a href='<?= KeymanHosts::Instance()->blog_keyman_com ?>/2015/01/an-urdu-keyboard-layout-optimised-for-small-touch-devices/'>Read more on our blog</a>
 </p>
-<div id="download-cta" data-language='ur' data-keyboard='kbdurdu'>
+<div id="download-cta" data-language='ur' data-keyboard='basic_kbdurdu'>
   <div class="download-cta-big" id="cta-big-Holder">
     <img src="<?php echo cdn('img/wait.gif'); ?>" />
   </div>

--- a/web.config
+++ b/web.config
@@ -229,7 +229,7 @@
                 <rule name="sindhi">           <match url="^sindhi(/?)$" />         <action type="Redirect" url="/keyboards/mbsindhi" /></rule>
                 <rule name="thai">             <match url="^thai(/?)$" />           <action type="Redirect" url="/keyboards/thai-uni" /></rule>
                 <rule name="yiddish">          <match url="^yiddish(/?)$" />        <action type="Redirect" url="/keyboards/yiddish_pasekh" /></rule>
-                <rule name="yoruba">           <match url="^yoruba(/?)$" />         <action type="Redirect" url="/keyboards/yoruba8" /></rule>
+                <rule name="yoruba">           <match url="^yoruba(/?)$" />         <action type="Redirect" url="/keyboards/sil_yoruba8" /></rule>
 
                 <rule name="ancient-greek">   <match url="^ancient-greek(/?)$" />   <action type="Redirect" url="/keyboards/h/greek" /></rule>
                 <rule name="eurolatin">        <match url="^(french|german|italian|spanish|swedish)(/?)$" />      <action type="Redirect" url="/keyboards/h/eurolatin" /></rule>


### PR DESCRIPTION
Quite a few of the featured keyboards have since been deprecated.

This updates the keyboard ID's to get the current download links (along with working keymanweb links)