### PR TITLE
chore: Fix *ZWNJ* typo

### DIFF
--- a/developer/features.php
+++ b/developer/features.php
@@ -34,7 +34,7 @@
         These will allow predictive-text suggestions to detect and preserve capitalization when appropriate (#4291, 4299).</li>
       <li>Add support for notany() and context() (#3816)</li>
       <li>Remove IE dependency from Developer setup (#3839)</li>
-      <li>New touch layout special key caps *RTLEnter*, *RTLBkSp*, *ZWSP*, ... (#3878)</li>
+      <li>New touch layout special key caps *RTLEnter*, *RTLBkSp*, *ZWNJ*, ... (#3878)</li>
       <li>Improved BCP 47 support and script mapping (#3818, #4563)</li>
       <li>Model compiler merges duplicate words and normalizes when compiling (#3338)</li>
       <li>Support ISO9995 key identifiers (e.g. E01) (#2741)</li>


### PR DESCRIPTION
As @bennylin points out on 
https://community.software.sil.org/t/zwsp-in-keyman-14/4582/3

The Keyman Developer 14.0 features page should list adding `*ZWNJ*` instead of `*ZWSP*`