### PR TITLE
chore: https for dev hosts and secure session for keyboard search

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -88,7 +88,7 @@
         break;
       case KeymanHosts::TIER_DEVELOPMENT:
         $site_suffix = '.local';
-        $site_protocol = 'http://';
+        $site_protocol = 'https://';
         break;
       }
 

--- a/keyboards/session.php
+++ b/keyboards/session.php
@@ -1,5 +1,9 @@
 <?php
-  if(!isset($_SESSION)) session_start();
+  if(!isset($_SESSION)) {
+    session_set_cookie_params(["SameSite" => "None"]);   // Allow use in iframe, needed for Download Keyboards dialog
+    session_set_cookie_params(["Secure" => "true"]);     // None requires Secure to be set
+    session_start();
+  }
 
   if(isset($_REQUEST['embed'])) {
     $embed = $_REQUEST['embed'];
@@ -20,13 +24,13 @@
   }
   $_SESSION['embed'] = $embed;
   $_SESSION['embed_version'] = $embed_version;
-  
+
   $embed_win = $embed == 'windows';
   $embed_mac = $embed == 'macos';
   $embed_linux = $embed == 'linux';
   $embed_android = $embed == 'android';
   $embed_ios = $embed == 'ios';
-  
+
   if($embed != 'none') {
     // Poor man's session control because IE embedded in downlevel Windows destroys cookie support by
     // default, including in existing versions of Keyman.
@@ -40,7 +44,7 @@
     $session_query_q = '';
   }
 
-  // We'd like to show the search box. But, we have a bug in the IE embedded dialog 
+  // We'd like to show the search box. But, we have a bug in the IE embedded dialog
   // that forces us to show a list of languages and disable input boxes...
   // $embed_uselist = $embed_win && version_compare($embed_version, '10.0.699.0') < 0;
 ?>


### PR DESCRIPTION
Groundwork required for Chrome 90+ and SameSite cookies.

Fixes keymanapp/keyman#5193.

Without this, cookies within an iframe in the Download Keyboard dialog will be silently blocked, which causes styling and other aspects of the keyboard search to go wrong, as we use session variables to maintain the embedded state of the keyboard search, per platform.

In order to allow us to test locally, this means we need to upgrade our localhost (keyman.com.local, etc) sites to https. This is a good thing, overall, as it reduces the difference between local dev and live sites slightly further.