### PR TITLE
feat(android): Google Play Install Referrer link

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -301,8 +301,7 @@ END;
 
         <div id='search-box'>
           <form method='get' action='/keyboards' name='f'>
-            <div id='search-title'><a href='/keyboards'>Keyboard Search</a>:</div>
-            <input id="search-q" type="text" placeholder="(new search)" name="q">
+            <input id="search-q" type="text" placeholder="New keyboard search" name="q">
             <input id='search-page' type='hidden' name='page'>
             <input id="search-f" type="image" src="<?= cdn('img/search-button.png') ?>" value="Search">
           </form>

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -2176,7 +2176,7 @@ button.feedback{
 
 @media all and (min-width: 10px) and (max-width: 600px){
 	.wrapper{
-		width: 320px;
+		width: auto;
 	}
 	/* Header */
 	#top-menu-bg{

--- a/cdn/dev/keyboard-search/install.css
+++ b/cdn/dev/keyboard-search/install.css
@@ -10,7 +10,7 @@ ol {
   font-size: 16pt;
 }
 
-#section2 ol li a.download-link {
+#section2 a.download-link {
   padding-top: 6px;
   height: 40px;
 }
@@ -34,28 +34,33 @@ ol li a {
   display: none;
 }
 
+html .download a.download-link {
+  margin: 0;
+  display: inline-block;
+  float: none;
+  vertical-align: top;
+}
+
+html .download a.download-link span {
+  display: inline-block;
+  vertical-align: top;
+  line-height: 1em;
+  margin-top: 0.33em;
+}
+
 @media only screen and (max-width: 640px) {
   #section2 ol li {
     margin-left: 0;
     font-size: 24pt;
   }
 
-  ol li a {
-    font-size: 12pt;
+  /* Make the link text slightly smaller to fit longer string */
+  html .download a.download-link {
     margin-left: 8px;
+    font-size: 15pt;
   }
 
-  html .download a.download-link {
-      margin: 0;
-      display: inline-block;
-      float: none;
-      vertical-align: top;
-  }  
-
-  html .download a.download-link span {
-    display: inline-block;
-    vertical-align: top;
-    line-height: 1em;
-    margin-top: 0.33em;
+  .download div.download-description {
+    margin: 8px 0 8px 10px;
   }
 }

--- a/cdn/dev/keyboard-search/keyboard-details.js
+++ b/cdn/dev/keyboard-search/keyboard-details.js
@@ -3,8 +3,14 @@
  * so that we can use it for CSS selectors to display the appropriate content.
  */
 (function() {
+  // Allow for a platform-override parameter for testing of
+  // the keyboard install page.
+  const params = typeof URLSearchParams == 'function' ?
+    new URLSearchParams(location.search) : null;
   const bowserParser = bowser.getParser(window.navigator.userAgent);
-  const platform = bowserParser.getOSName({toLowerCase: true});
+  const platform = params && params.get('platform-override') ?
+    params.get('platform-override') :
+    bowserParser.getOSName({toLowerCase: true});
   const browser = bowserParser.getBrowser();
   const engine = bowserParser.getEngine();
 

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -288,7 +288,7 @@ h2 a {
   }
 
   html #search-box #search-q {
-    width: 120px;
+    width: 160px;
   }
 
   /* Responsive display of table data on mobile */

--- a/keyboards/install.php
+++ b/keyboards/install.php
@@ -163,7 +163,7 @@ END;
       $downloadKeymanUrl = KeymanHosts::Instance()->keyman_com . '/mac/download';
 
       $result = <<<END
-        <div id='content' class='download download-macos'>
+        <div class='download download-macos'>
           <div>
             <p>If you have not yet installed Keyman for macOS, please install it first before installing the keyboard.</p>
             <ol>
@@ -215,7 +215,7 @@ END;
       $downloadKeymanUrl = KeymanHosts::Instance()->keyman_com . '/linux/download';
 
       $result = <<<END
-        <div id='content' class='download download-linux'>
+        <div class='download download-linux'>
           <script data-id="{$h['id']}" data-bcp47="{$h['bcp47']}">
             startAfterPageLoad_Linux(document.currentScript.dataset);
           </script>
@@ -227,12 +227,12 @@ END;
                 <span>Install keyboard</span></a>
               </li>
             </ol>
-          </div>
-          <br>
-          <ul>
-            <li><a href='$helpLink'>Help on installing a keyboard</a></li>
-            <li><a href='$keyboardHomeUrl'>{$h['name']} keyboard home</a></li>
-          </ul>
+
+            <br>
+            <ul>
+              <li><a href='$helpLink'>Help on installing a keyboard</a></li>
+              <li><a href='$keyboardHomeUrl'>{$h['name']} keyboard home</a></li>
+            </ul>
           </div>
         </div>
 END;
@@ -268,19 +268,23 @@ END;
       $keyboardHomeUrl = "/keyboards/{$hu['id']}" .
         (empty($hu['bcp47']) ? "" : "?bcp47=" . $hu['bcp47']);
 
-      $downloadKeymanUrl = PlayStore::url;
+      // Build a Google Play Install Referrer URL parameter; this will be passed
+      // in to Keyman on its first start. Note that the double-encoding is intentional.
+      $referrer = "source=keyman&package={$u['id']}";
+      if(!empty($u['bcp47'])) $referrer .= "&bcp47={$u['bcp47']}";
+
+      $downloadKeymanUrl = PlayStore::url . "&referrer=" . rawurlencode($referrer);
 
       $result = <<<END
-        <div id='content' class='download download-android'>
+        <div class='download download-android'>
+          <p></p>
           <div>
-            <p>If you have not yet installed Keyman for Android, please install it first before installing the keyboard.</p>
-            <ol>
-              <li id='step1'><a href='$downloadKeymanUrl' title='Download and install Keyman'>Install Keyman for Android</a></li>
-              <li id='step2'><a class='download-link binary-download' rel="nofollow" href='$downloadLink'>
-                <span>Install keyboard</span></a>
-                <div class='download-description'>Downloads {$h['name']} for Android.</div>
-              </li>
-            </ol>
+            <p>Install Keyman together with {$h['name']} keyboard through the Google Play Store:</p>
+            <a class='download-link binary-download' href='$downloadKeymanUrl' title='Download and install Keyman'><span>Install from Play Store</span></a>
+            <div class='download-description'>Installs Keyman and {$h['name']} keyboard for Android</div>
+            <br>
+            <p>Keyman already installed? <a rel="nofollow" href='$downloadLink'>Download just this keyboard</a> and then install in the app.
+            </p>
             <ul>
               <li><a href='$helpLink'>Help on installing a keyboard</a></li>
               <li><a href='$keyboardHomeUrl'>{$h['name']} keyboard home</a></li>
@@ -324,7 +328,7 @@ END;
       $downloadKeymanUrl = AppStore::url;
 
       $result = <<<END
-        <div id='content' class='download download-ios'>
+        <div class='download download-ios'>
           <div>
             <p>If you have not yet installed Keyman for iPhone and iPad, please install it first before installing the keyboard.</p>
             <ol>


### PR DESCRIPTION
* Relates to keymanapp/keyman#5219.
* Goes with keymanapp/keyman#5230.

Add the link for Google Play Install Referrer and reorganise the install page for Android to make the one-step install clear.

Also cleans up a few bits and pieces with the look and feel of the install, fixing a HTML layout error and tweaking some CSS to make the page easier to understand.

## Before

![image](https://user-images.githubusercontent.com/4498365/120941614-df302c80-c766-11eb-9acb-824480adc56a.png)

## After

![image](https://user-images.githubusercontent.com/4498365/120941659-1bfc2380-c767-11eb-9cf0-fdeeeb21c0b1.png)

## Before - Keyboard Details page:

![image](https://user-images.githubusercontent.com/4498365/120941697-5e256500-c767-11eb-9b23-a706b2962e8f.png)

## After - Keyboard Details page:

![image](https://user-images.githubusercontent.com/4498365/120941685-4948d180-c767-11eb-92af-5780eaefb89b.png)

Note that the keyboard search box at the top no longer wraps, and the left and right borders have been removed.
