### PR TITLE
fix: Use css keyword `initial` instead of `unset` 🍒 

### DIFF
--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -295,7 +295,7 @@ h2 a {
 
   #keyboard-details-col .col {
     float: none;
-    max-width: unset;
+    max-width: initial;
   }
 
   table#keyboard-details,
@@ -439,7 +439,7 @@ html[data-platform='unknown'] .download.download-unknown {
 }
 
 #search-results:empty + #search-results-empty {
-  display: unset;
+  display: initial;
 }
 
 /* Embedded formatting */


### PR DESCRIPTION
Relates to #309 and 🍒 pick of #311 to `staging`

The CSS keyword [unset](https://developer.mozilla.org/en-US/docs/Web/CSS/unset) is invalid on Chrome 37 (Android 5.0).
This was causing the empty search results not to appear. This PR uses `initial` instead.


