### PR TITLE
fix: give iOS downloads for iOS Safari in desktop mode

### DIFF
--- a/cdn/dev/keyboard-search/keyboard-details.js
+++ b/cdn/dev/keyboard-search/keyboard-details.js
@@ -8,11 +8,15 @@
   const params = typeof URLSearchParams == 'function' ?
     new URLSearchParams(location.search) : null;
   const bowserParser = bowser.getParser(window.navigator.userAgent);
-  const platform = params && params.get('platform-override') ?
-    params.get('platform-override') :
-    bowserParser.getOSName({toLowerCase: true});
   const browser = bowserParser.getBrowser();
   const engine = bowserParser.getEngine();
+  const os = bowserParser.getOSName({toLowerCase: true});
+  const platform = params && params.get('platform-override') ?
+    params.get('platform-override') :
+    (
+      // Detect iOS Safari in 'Desktop Mode' -- we still want iOS downloads!
+      os == 'macos' && navigator.maxTouchPoints > 1 && browser == 'Safari' ? 'ios' : os
+    );
 
   document.documentElement.setAttribute("data-platform",
     platform === 'chrome os' ? 'android' : // This is not ideal but works on most Chromebooks for now


### PR DESCRIPTION
When a user visits keyman.com in Safari on iPad or iPhone, they can request 'Desktop Mode'. In this situation, keyman.com was returning downloads for macOS instead of for iOS. This patch returns instead the iOS download if it detects a touch screen, which Macs do not support. If a touch-screen Mac is released, we'll have to revisit this.