### PR TITLE
chore: add version parameter to download direct link

### DIFF
--- a/go/download/_download.php
+++ b/go/download/_download.php
@@ -22,14 +22,17 @@
     Util::Fail("Error: tier must be alpha, beta or stable");
   }
 
-  $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . '/api/version/2.0'));
+  if(isset($_REQUEST['version'])) {
+    $DEVELOPER_VERSION = $_REQUEST['version'];
+    $WINDOWS_VERSION = $_REQUEST['version'];
+    $MAC_VERSION = $_REQUEST['version'];
+  } else {
+    $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . '/api/version/2.0'));
 
-  $DEVELOPER_VERSION = $versions->developer->$TIER->version;
-  $WINDOWS_VERSION = $versions->windows->$TIER->version;
-  $MAC_VERSION = $versions->mac->$TIER->version;
-
-  $kmcompVersion = 'kmcomp-$VERSION.zip';
-  $keymandeveloperVersion = 'keymandeveloper-$VERSION.exe';
+    $DEVELOPER_VERSION = $versions->developer->$TIER->version;
+    $WINDOWS_VERSION = $versions->windows->$TIER->version;
+    $MAC_VERSION = $versions->mac->$TIER->version;
+  }
 
   $packages = [
     "kmcomp" => ["developer", $DEVELOPER_VERSION, "kmcomp-$DEVELOPER_VERSION.zip"],


### PR DESCRIPTION
`https://keyman.com/go/download/<prog>`, where prog can be kmcomp, keyman-developer, keyman-windows, or keyman-mac, now supports the optional query string parameter `version`. This, along with query string parameter `tier`, makes a good permanent URL for downloading Keyman binaries (forwards to downloads.keyman.com at present), e.g.

  https://keyman.com/download/kmcomp?tier=stable&version=15.0.260

This is used in a variety of locations already. The new functionality will be used by the keyboards repository so that we do not need to embed the binaries in the repository any longer.

Ref keymanapp/keyboards#1883