### PR TITLE
fix(windows): disable text selection in embeded frames

### DIFF
--- a/windows/keepintouch-100.php
+++ b/windows/keepintouch-100.php
@@ -95,6 +95,7 @@
     
     html.embed.frame p.message {
       display: none;
+      user-select: none;
     }
     
     html.embed.frame #ribbon {
@@ -106,6 +107,11 @@
       padding: 4px 0 8px 60px;
       background: url('/cdn/dev/img/keyman-48.png') 8px 8px no-repeat;
       background-color: #D6D6D6;
+      user-select: none;
+    }
+    
+    html.embed.frame .content {
+      user-select: none;
     }
     
     /* Formatting */

--- a/windows/keepintouch-140.php
+++ b/windows/keepintouch-140.php
@@ -67,8 +67,9 @@
 
     html.embed.frame p.message {
       display: none;
+      user-select: none;
     }
-
+    
     html.embed.frame #ribbon {
       display: none;
     }
@@ -78,6 +79,11 @@
       padding: 4px 0 8px 60px;
       background: url('/cdn/dev/img/keyman-48.png') 8px 8px no-repeat;
       background-color: #D6D6D6;
+      user-select: none;
+    }
+    
+    html.embed.frame .content {
+      user-select: none;
     }
 
     /* Formatting */


### PR DESCRIPTION
Add the `user-select: none;` property for embedded frames for the `keep in touch page` used in Keyman Configuration for windows. Made the same change for the web-hosted version again only if it is `embedded`.