### PR TITLE
chore: Fix broken link to download and install Keyman

### DIFF
--- a/keyboards/install.php
+++ b/keyboards/install.php
@@ -108,7 +108,7 @@
         (empty($hu['bcp47']) ? "" : ".{$hu['bcp47']}") .
         ".exe";
 
-      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/windows/current-version/docs/start_download-install_keyman";
+      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/windows/current-version/start/download-and-install-keyman";
 
       $keyboardHomeUrl = "/keyboards/{$hu['id']}" .
         (empty($hu['bcp47']) ? "" : "?bcp47=" . $hu['bcp47']);


### PR DESCRIPTION
Fixes #351 

Similar to the bug in #352, some of the keyman.com cross-site links need to update to the Markdown directory structures on help.keyman.com.

Since the link is for current-version, I don't think we need logic for Keyman 13.0 and earlier.