### PR TITLE
chore: Add test page for /go links 🦭

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /.vscode
 cdn/deploy/
 
+tier.txt
+
 vendor*
 /node_modules/
 

--- a/.htaccess
+++ b/.htaccess
@@ -90,7 +90,7 @@ RewriteRule "^keyboards/download/([^/]+)$" "/keyboards/keyboard.php?id=$1" [L]
 
 # /keyboards/share/[id] to /keyboards/share.php
 # if the keyboard exists in the repo, then share.php will redirecct to /keyboards/<id>
-RewriteRule "^keyboards/share/(^/]+)$" "/keyboards/share.php?id=$1" [L]
+RewriteRule "^keyboards/share/([^/]+)$" "/keyboards/share.php?id=$1" [L]
 
 # /keyboards/{id}.json to /keyboards/keyboard.json.php
 RewriteRule "^keyboards/(?!keyboard.json)(.*)\.json$" "/keyboards/keyboard.json.php?id=$1" [L]

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,8 @@ builder_parse "$@"
 
 function test_docker_container() {
   # TODO: lint tests
+  echo "TIER_TEST" > tier.txt
+  echo "---- Testing links ----"
   set +e;
   set +o pipefail;
   npx broken-link-checker http://localhost:8053 --ordered --recursive --host-requests 50 -e --filter-level 3 | \
@@ -36,6 +38,7 @@ function test_docker_container() {
     grep -B 1 "BROKEN";
 
   echo "Done checking links"
+  rm tier.txt
 }
 
 builder_run_action configure  bootstrap_configure

--- a/go/.htaccess
+++ b/go/.htaccess
@@ -12,8 +12,7 @@ RedirectMatch "/go/(([1-9][0-9])([.]?)([0-9]))/developer-help-(mobile|packages)(
 #
 
 # download-model/keyboard package
-#RedirectMatch "/go/package/download/model/([^/]+)$" "https://keyman.com/go/package/download.php?type=model&id=$1"
-RedirectMatch "/go/package/download/(model|keyboard)/([^\/]+)\/?$" "https://keyman.com/go/package/download.php?type=$1&id=$2"
+RedirectMatch "/go/package/download/(model|keyboard)/([^/]+)\/?$" "https://keyman.com/go/package/download.php?type=$1&id=$2"
 
 # keyboard/id/share
 RedirectMatch "/go/keyboard/([^/?]+)/share$" "/keyboards/share/$1"

--- a/go/download/.htaccess
+++ b/go/download/.htaccess
@@ -2,4 +2,4 @@
 # Links for Developer 10.0 onward
 
 # /go/download/program
-RedirectMatch "/go/download/(?!_download.php)(.+)" "/go/download/_download.php?object=$1"
+RewriteRule "^(?!_download.php)(.+)$" "/go/download/_download.php?object=$1" [END]

--- a/test/index.md
+++ b/test/index.md
@@ -1,0 +1,339 @@
+---
+title: Go Test Links
+description: Test page for links
+---
+
+## android
+
+### /go/android/X.Y/download-keyboards/languages
+
+[download-keyboards/languages](/go/android/16.0/download-keyboards/languages/km)
+
+[live: download-keyboards/languages](https://keyman.com/go/android/16.0/download-keyboards/languages/km)
+
+### /go/android/X.Y/download-keyboards
+
+[download-keyboards](/go/android/16.0/download-keyboards)
+
+[live: download-keyboards](https://keyman.com/go/android/16.0/download-keyboards)
+
+------
+
+## desktop
+
+### /go/desktop/13.0/download-keyboards
+
+[download-keyboards](/go/desktop/13.0/download-keyboards)
+
+[live: download-keyboards](https://keyman.com/go/desktop/13.0/download-keyboards)
+
+### /go/desktop/X.Y/download-keyboards
+
+[download-keyboards](/go/desktop/16.0/download-keyboards)
+
+[live: download-keyboards](https://keyman.com/go/desktop/16.0/download-keyboards)
+
+### /go/desktop/X.Y/keep-in-touch
+
+[keep-in-touch](/go/desktop/16.0/keep-in-touch)
+
+[live: keep-in-touch](https://keyman.com/go/desktop/16.0/keep-in-touch)
+
+### /go/desktop/X.Y/forums
+
+[forums](/go/desktop/16.0/forums)
+
+[live: forums](https://keyman.com/go/desktop/16.0/forums)
+
+### /go/desktop/X.Y/issue-1285
+
+[issue-1285](/go/desktop/16.0/issue-1285)
+
+[live: issue-1285](https://keyman.com/go/desktop/16.0/issue-1285)
+
+### /go/desktop/X.Y/support
+
+[support](/go/desktop/16.0/support)
+
+[live: support](https://keyman.com/go/desktop/16.0/support)
+
+### /go/desktop/X.Y/create-locale
+
+[create-locale](/go/desktop/16.0/create-locale) 
+
+[live: create-locale](https://secure.tavultesoft.com/keyman/support/locale/)
+
+
+### /go/desktop/X.Y/view-exception/ to /contact/exception
+
+This endpoint is not used in 14.0 or later
+
+[view-exception](/go/desktop/13.0/view-exception)
+
+[live: view-exception](https://keyman.com/go/desktop/13.0/view-exception)
+
+
+### /go/desktop/X.Y/view-exception?id=
+
+This endpoint is not used in 14.0 or later
+
+[view-excception?id=1234](/go/desktop/13.0/view-exception?id=1234)
+
+[live: view-exception?id=1234](https://keyman.com/go/desktop/13.0/view-exception?id=1234)
+
+
+### /go/desktop/X.Y/home
+
+[home](/go/desktop/16.0/home)
+
+[live: home](https://keyman.com/go/desktop/16.0/home)
+
+
+### /go/desktop/X.Y/archived-downloads
+
+[archived-downloads](/go/desktop/16.0/archived-downloads)
+
+[live: archived-downloads](https://keyman.com/go/desktop/16.0/archived-downloads)
+
+
+### /go/desktop/X.Y/privacy
+
+[privacy](/go/desktop/16.0/privacy)
+
+[live: privacy](https://keyman.com/go/desktop/16.0/privacy)
+
+------
+
+## developer
+
+Links for Developer 10.0 onward
+
+### /go/developer/X.Y/help-keyboards
+
+
+[help-keyboards](/go/developer/16.0/help-keyboards)
+
+[live: help-keyboards](https://keyman.com/go/developer/16.0/help-keyboards)
+
+Direct help to the major version
+
+
+### /go/developer/X.Y/help-(mobile|packages)
+
+[help-mobile](/go/developer/16.0/help-mobile)
+
+[live: help-mobile](https://keyman.com/go/developer/16.0/help-mobile)
+
+[help-packages](/go/developer/16.0/help-mobile)
+
+[live: help-packages](https://keyman.com/go/developer/16.0/help-mobile)
+
+
+### /go/developer/X.Y/keymanweb
+
+[keymanweb](/go/developer/16.0/keymanweb)
+
+[live: keymanweb](https://keyman.com/go/developer/16.0/keymanweb)
+
+
+### /go/developer/X.Y/keyman-engine-home
+
+[keyman-engine-home](/go/developer/16.0/keyman-engine-home)
+
+[live: keyman-engine-home](https://keyman.com/go/developer/16.0/keyman-engine-home)
+
+
+### /go/developer/X.Y/language-lookup
+
+[language-lookup](/go/developer/16.0/language-lookup)
+
+[live: language-lookup](https://keyman.com/go/developer/16.0/language-lookup)
+
+
+### /go/developer/X.Y/view-exception/ to /contact/exception
+
+[view-exception](/go/developer/16.0/view-exception)
+
+[live: view-exception](https://keyman.com/go/developer/16.0/view-exception)
+
+
+### /go/developer/X.Y/view-exception?id=
+
+[view-exception?id=1234](/go/developer/16.0/view-exception?id=1234)
+
+[live: view-exception?id=1234](https://keyman.com/go/developer/16.0/view-exception?id=1234)
+
+
+### /go/developer/X.Y/docs/language
+
+Context-sensitive help in Keyman Developer
+
+[docs/language/guide/rules](/go/developer/16.0/docs/language/guide/rules)
+
+[live: docs/language/guide/rules](https://keyman.com/go/developer/16.0/docs/language/guide/rules)
+
+
+### /go/developer/X.Y/docs
+
+All other context help, direct to the major version
+
+[docs/context/keyboard-editor](/go/developer/16.0/docs/context/keyboard-editor)
+
+[live: docs/context/keyboard-editor](https://keyman.com/go/developer/16.0/docs/context/keyboard-editor)
+
+
+### /go/developer/X.Y/home
+
+[home](/go/developer/16.0/home)
+
+[live: home](https://keyman.com/go/developer/16.0/home)
+                
+### /go/developer/X.Y/ios-app
+
+see includes/appstore.php
+
+[ios-app](/go/developer/16.0/ios-app)
+
+[live: ios-app](https://keyman.com/go/developer/16.0/ios-app)
+
+
+### /go/developer/X.Y/android-app
+
+see includes/playstore.php
+
+[android-app](/go/developer/16.0/android-app)
+
+[live: android-app](https://keyman.com/go/developer/16.0/android-app)
+
+
+----
+
+## download
+
+[keyman-windows](/go/download/keyman-windows)
+
+[live: keyman-windows](https://keyman.com/go/download/keyman-windows)
+
+
+----
+
+## ios
+
+### /go/ios/X.Y/download-keyboards/languages
+
+[download-keyboards/languages/km](/go/ios/16.0/download-keyboards/languages/km)
+
+[live: download-keyboards/languages/km](https://keyman.com/go/ios/16.0/download-keyboards/languages/km)
+
+
+### /go/ios/X.Y/download-keyboards
+
+[download-keyboards](/go/ios/16.0/download-keyboards)
+
+[live: download-keyboards](https://keyman.com/go/ios/16.0/download-keyboards)
+
+
+
+----
+
+## linux
+
+
+### "/go/linux/X.Y/download-keyboards"
+
+[download-keyboards](/go/linux/16.0/download-keyboards)
+
+[live: download-keyboards](https://keyman.com/go/linux/16.0/download-keyboards)
+
+
+### /go/linux/X.Y/forums
+
+[forums](/go/linux/16.0/forums)
+
+[live: forums](https://keyman.com/go/linux/16.0/forums)
+
+### /go/linux/X.Y/support
+
+[support](/go/linux/16.0/support)
+
+[live: support](https://keyman.com/go/linux/16.0/support)
+
+
+### /go/linux/X.Y/privacy
+
+[privacy](/go/linux/16.0/privacy)
+
+[live: privacy](https://keyman.com/go/linux/16.0/privacy)
+
+### /go/linux/X.Y/linux-configuration.png
+
+permanent link to screenshot of linux-configuration
+
+[linux-configuration.png](/go/linux/16.0/linux-configuration.png)
+
+[live: linux-configuration.png](https://keyman.com/go/linux/16.0/linux-configuration.png)
+
+
+----
+
+## macos
+
+### /go/macos/X.Y/download-keyboards
+
+[download-keyboards](/go/macos/16.0/download-keyboards)
+
+[live: download-keyboards](https://keyman.com/go/macos/16.0/download-keyboards)
+
+----
+
+## package (no .htaccess to check)
+
+
+----
+
+## windows
+
+Links for Keyman for Windows 14.0 onward
+
+### /go/windows/X.Y/download-keyboards
+
+[download-keyboards](/go/windows/16.0/download-keyboards)
+
+[live: download-keyboards](/go/windows/16.0/download-keyboards)
+
+
+### /go/windows/X.Y/keep-in-touch
+
+[keep-in-touch](/go/windows/16.0/keep-in-touch)
+
+[live: keep-in-touch](https://keyman.com/go/windows/16.0/keep-in-touch)
+
+
+### /go/windows/X.Y/issue-1285
+
+[issue-1285](/go/windows/16.0/issue-1285)
+
+[live: issue-1285](https://keyman.com/go/windows/16.0/issue-1285)
+
+### /go/windows/X.Y/create-locale
+
+[create-locale](/go/windows/16.0/create-locale)
+
+[live: create-locale](https://keyman.com/go/windows/16.0/create-locale)
+
+
+### /go/windows/X.Y/home
+
+[home](/go/windows/16.0/home)
+
+[live: home](https://keyman.com/go/windows/16.0/home)
+
+
+### /go/windows/X.Y/archived-downloads
+
+[archived-downloads](/go/windows/16.0/archived-downloads)
+
+[live: archived-downloads](https://keyman.com/go/windows/16.0/archived-downloads)
+
+
+----

--- a/test/index.md
+++ b/test/index.md
@@ -3,6 +3,70 @@ title: Go Test Links
 description: Test page for links
 ---
 
+[why](/go/why)
+
+[live: why](https://keyman.com/go/why)
+
+
+### Developer 10.0 onward redirects for package guide
+[developer-help-mobile](/go/16.0/developer-help-mobile)
+
+[live: developer-help-mobile](https://keyman.com/go/16.0/developer-help-mobile)
+
+[developer-help-mobile](/go/16.0/developer-help-packages)
+
+[live: developer-help-mobile](https://keyman.com/go/16.0/developer-help-packages)
+
+----
+
+## package/download
+
+
+### download-model/keyboard package
+
+[package/download/model/nrc.en.mtnt](/go/package/download/model/nrc.en.mtnt)
+
+[live: package/download/model/nrc.en.mtnt](https://keyman.com/go/package/download/model/nrc.en.mtnt)
+
+[package/download/keyboard/sil_ipa](/go/package/download/keyboard/sil_ipa)
+
+[live: package/download/keyboard/sil_ipa](https://keyman.com/go/package/download/keyboard/sil_ipa)
+
+
+
+### keyboard/id/share
+
+[keyboard/sil_ipa/share](/go/keyboard/sil_ipa/share)
+
+[live: keyboard/sil_ipa/share](https://keyman.com/go/keyboard/sil_ipa/share)
+
+
+## Non-app-specific endpoints
+
+
+### go/support
+
+[support](/go/16.0/support)
+
+[live: support](https://keyman.com/go/16.0/support)
+
+
+### go/privacy
+
+[privacy](/go/16.0/privacy)
+
+[live: privacy](https://keyman.com/go/16.0/privacy)
+
+
+### go/community
+
+[community](/go/16.0/community)
+
+[live: community](https://keyman.com/go/16.0/community)
+
+
+----
+
 ## android
 
 ### /go/android/X.Y/download-keyboards/languages
@@ -299,7 +363,7 @@ Links for Keyman for Windows 14.0 onward
 
 [download-keyboards](/go/windows/16.0/download-keyboards)
 
-[live: download-keyboards](/go/windows/16.0/download-keyboards)
+[live: download-keyboards](https://keyman.com/go/windows/16.0/download-keyboards)
 
 
 ### /go/windows/X.Y/keep-in-touch


### PR DESCRIPTION
More updates for #337

Since the broken link checker doesn't exercise the /go redirects, this PR adds a test page.

Each link also has one for the live keyman.com site so we can manually compare.