### PR TITLE
fix: keyboard search for certain staging domains

### DIFF
--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -86,6 +86,9 @@ function wrapSearch(localCounter, updateHistory) {
   }
 
   var base = location.protocol+'//api.'+location.host; // this works on test sites as well as live, assuming we use the host pattern "keyman.com[.localhost]"
+  if (base.includes('api.com-keyman')) {
+    base.replace('api.com-keyman', 'com-keyman-api');
+  }
   var url = base+'/search/2.0?p='+page+'&q='+encodeURIComponent(stripCommonWords(q));
 
   if(embed) {


### PR DESCRIPTION
The staging sites deployed with k8s have a slightly different naming convention.
This impacts the JS keyboard search in creating the api.keyman query
Previously, we had:

keyman.com -> api.keyman.com
keyman-staging.com -> api.keyman-staging.com

The K8s sites are currently using:
com-keyman.* --> com-keyman-api.*