### PR TITLE
fix: go links for model/keyboards 🦭

### DIFF
--- a/_test/go.md
+++ b/_test/go.md
@@ -345,8 +345,41 @@ permanent link to screenshot of linux-configuration
 
 ----
 
-## package (no .htaccess to check)
+## keyboard permalinks
 
+### download-kmp
+
+[keyboard/khmer_angkor/download/kmp](/go/keyboard/khmer_angkor/download/kmp)
+
+[live: keyboard/khmer_angkor/download/kmp](https://keyman.com/go/keyboard/khmer_angkor/download/kmp)
+
+### download-exe
+
+[keyboard/khmer_angkor/download/exe](/go/keyboard/khmer_angkor/download/exe)
+
+[live: keyboard/khmer_angkor/download/exe](https://keyman.com/go/keyboard/khmer_angkor/download/exe)
+
+### download-js
+
+[keyboard/khmer_angkor/download/js](/go/keyboard/khmer_angkor/download/js)
+
+[live: keyboard/khmer_angkor/download/js](https://keyman.com/go/keyboard/khmer_angkor/download/js)
+
+---
+
+## package/download
+
+### model
+
+[nrc.en.mtmt](/go/package/download/model/nrc.en.mtnt)
+
+[live: nrc.en.mtnt](https://keyman.com/go/package/download/model/nrc.en.mtnt)
+
+### keyboard, platform=android&tier=alpha
+
+[khmer_angkor](/go/package/download/khmer_angkor&platform=android&tier=alpha)
+
+[live: khmer_angkor](https://keyman.com/go/package/download/khmer_angkor&platform=android&tier=alpha)
 
 ----
 

--- a/go/.htaccess
+++ b/go/.htaccess
@@ -5,14 +5,27 @@ RedirectMatch "/go/why\/?$" "https://marc.durdin.net/2018/03/the-case-for-keyman
 # Developer 10.0 onward redirects for package guide
 RedirectMatch "/go/(([1-9][0-9])([.]?)([0-9]))/developer-help-(mobile|packages)(/)?" "https://help.keyman.com/developer/$1/guides/distribute/packages"
 
-# TODO: Download redirects for keyboard permalinks (these three rules need refresh)
+# Download redirects for keyboard permalinks (TODO: these three rules need refresh)
+
+# download-kmp
+RedirectMatch "/go/keyboard/([^/?]+)/download/kmp$" "/keyboards/download?id=$1&platform=windows&mode=standalone"
+
+#download-exe
+RedirectMatch "/go/keyboard/([^/?]+)/download/exe$" "/keyboards/download?id=$1&platform=windows&mode=bundle"
+
+# download-js
+RedirectMatch "/go/keyboard/([^/?]+)/download/js$" "/keyboards/download?id=$1&platform=web&mode=standalone"
+
 
 #
 # go/package/download
 #
 
-# download-model/keyboard package
-RedirectMatch "/go/package/download/(model|keyboard)/([^/]+)\/?$" "https://keyman.com/go/package/download.php?type=$1&id=$2"
+# download-model-package
+RewriteRule "^package/download/model/([^/]+)$" "package/download.php?type=model&id=$1" [END,QSA]
+
+# download-package
+RewriteRule "^package/download/(keyboard/)?([^/]+)$" "package/download.php?type=keyboard&id=$2" [END,QSA]
 
 # keyboard/id/share
 RedirectMatch "/go/keyboard/([^/?]+)/share$" "/keyboards/share/$1"


### PR DESCRIPTION
Oops - I built a local Keyman Android app to try to download keyboard packages from keyman-staging and realized I had a few TODO's to handle in /go links

Reference to the missing bits from web.config (currently used on the live site)
https://github.com/keymanapp/keyman.com/blob/ab3d0a4dfcb1915a9dafd10e2d98fff0a90b4d03/go/web.config#L19-L47

* Also updated the _test/go.md test page