### PR TITLE
fix: Redirected queries missing parameters

### DIFF
--- a/go/android/.htaccess
+++ b/go/android/.htaccess
@@ -2,7 +2,7 @@
 # Links for Android 14.0 onward
 
 # /go/android/X.Y/download-keyboards/languages"
-RedirectMatch "/go/android/([1-9][0-9]\.[0-9])/download-keyboards/languages/(.*)" "/keyboards/languages/$2?embed=android&embed_version=$1"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards/languages/(.*)" "/keyboards/languages/$2?embed=android&embed_version=$1" [R,QSA]
 
 # "/go/android/X.Y/download-keyboards"
-RedirectMatch "/go/android/([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=android&embed_version=$1"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=android&embed_version=$1" [R,QSA]

--- a/go/desktop/.htaccess
+++ b/go/desktop/.htaccess
@@ -2,50 +2,50 @@
 # Links for Desktop 10.0-13.0 (for 14.0 onward, see ../windows/web.config)
 
 # /go/desktop/13.0/download-keyboards"
-RedirectMatch "/go/desktop/(7|8|9|10|11|12|13)\.0/download-keyboards" "/_legacy/keyboards/?embed=windows"
+RewriteRule "^(7|8|9|10|11|12|13)\.0/download-keyboards" "/_legacy/keyboards/?embed=windows" [R,QSA]
 
 
 # /go/desktop/X.Y/download-keyboards"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=windows"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=windows" [R,QSA]
 
 
 # /go/desktop/X.Y/keep-in-touch"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/keep-in-touch" "/desktop/keepintouch-100"
+RewriteRule "^([1-9][0-9]\.[0-9])/keep-in-touch" "/desktop/keepintouch-100" [R,QSA]
 
 
 # /go/desktop/X.Y/forums"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/forums" "https://community.software.sil.org/c/keyman"
+RewriteRule "^([1-9][0-9]\.[0-9])/forums" "https://community.software.sil.org/c/keyman" [R,QSA]
 
 
 # /go/desktop/X.Y/issue-1285"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/issue-1285" "https://blog.keyman.com/2018/11/keyman-windows-10-1803-and-amharic-tigrinya-sinhala"
+RewriteRule "^([1-9][0-9]\.[0-9])/issue-1285" "https://blog.keyman.com/2018/11/keyman-windows-10-1803-and-amharic-tigrinya-sinhala" [R,QSA]
 
 
 # /go/desktop/X.Y/support"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/support" "/support"
+RewriteRule "^([1-9][0-9]\.[0-9])/support" "/support" [R,QSA]
 
 
 # /go/desktop/X.Y/create-locale"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/create-locale" "https://secure.tavultesoft.com/keyman/support/locale/"
+RewriteRule "^([1-9][0-9]\.[0-9])/create-locale" "https://secure.tavultesoft.com/keyman/support/locale/" [R,QSA]
 
 
 # /go/desktop/X.Y/view-exception/ to /contact/exception"
 # This endpoint is not used in 14.0 or later
-RedirectMatch 301 "/go/desktop/1[0123]\.0/view-exception(/)?$" "/contact/exception.php"
+RewriteRule "^1[0123]\.0/view-exception(/)?$" "/contact/exception.php" [R=301,QSA]
 
 
 # /go/desktop/X.Y/view-exception?id="
 # This endpoint is not used in 14.0 or later -->
-RedirectMatch "/go/desktop/1[0123]\.0/view-exception?id=(.+)$" "/contact/exception.php?id=$1"
+RewriteRule "^1[0123]\.0/view-exception?id=(.+)$" "/contact/exception.php?id=$1" [R,QSA]
 
 
 # /go/desktop/X.Y/home"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/home" "/desktop/"
+RewriteRule "^([1-9][0-9]\.[0-9])/home" "/desktop/" [R,QSA]
 
 
 # /go/desktop/X.Y/archived-downloads"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/archived-downloads" "/downloads/archive"
+RewriteRule "^([1-9][0-9]\.[0-9])/archived-downloads" "/downloads/archive" [R,QSA]
 
 
 # /go/desktop/X.Y/privacy"
-RedirectMatch "/go/desktop/([1-9][0-9]\.[0-9])/privacy" "/privacy"
+RewriteRule "^([1-9][0-9]\.[0-9])/privacy" "/privacy" [R,QSA]

--- a/go/developer/.htaccess
+++ b/go/developer/.htaccess
@@ -2,52 +2,52 @@
 # Links for Developer 10.0 onward
 
 # "/go/developer/X.Y/help-keyboards"
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/help-keyboards" "https://help.keyman.com/developer/keyboards/"
+RewriteRule "^([1-9][0-9]\.[0-9])/help-keyboards" "https://help.keyman.com/developer/keyboards/" [R,QSA]
 
 
 # Direct help to the major version
 # "/go/developer/X.Y/help-(mobile|packages)"
-RedirectMatch "/go/developer/([1-9][0-9])\.([0-9])/help-(mobile|packages)" "https://help.keyman.com/developer/$1.0/guides/distribute/packages"
+RewriteRule "^([1-9][0-9])\.([0-9])/help-(mobile|packages)" "https://help.keyman.com/developer/$1.0/guides/distribute/packages" [R,QSA]
 
 # "/go/developer/X.Y/keymanweb"
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/keymanweb" "/developer/keymanweb/"
+RewriteRule "^([1-9][0-9]\.[0-9])/keymanweb" "/developer/keymanweb/" [R,QSA]
 
 # "/go/developer/X.Y/keyman-engine-home"
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/keyman-engine-home" "/engine/"
+RewriteRule "^([1-9][0-9]\.[0-9])/keyman-engine-home" "/engine/" [R,QSA]
 
-                
+
 # "/go/developer/X.Y/language-lookup"
-RedirectMatch 301 "/go/developer/([1-9][0-9]\.[0-9])/language-lookup" "https://www.ethnologue.com/"
+RewriteRule "^([1-9][0-9]\.[0-9])/language-lookup" "https://www.ethnologue.com/" [R=301,QSA]
 
 
 # "/go/developer/X.Y/view-exception/ to /contact/exception"
-RedirectMatch 301 "/go/developer/([1-9][0-9]\.[0-9])/view-exception(/)?$" "/contact/exception.php"
+RewriteRule "^([1-9][0-9]\.[0-9])/view-exception(/)?$" "/contact/exception.php" [R=301,QSA]
 
 
 # "/go/developer/X.Y/view-exception?id="
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/view-exception?id=(.+)$" "/contact/exception.php?id=$2"
+RewriteRule "^([1-9][0-9]\.[0-9])/view-exception?id=(.+)$" "/contact/exception.php?id=$2" [R,QSA]
 
 
 # Context-sensitive help in Keyman Developer
 
 # "/go/developer/X.Y/docs/language" <!-- kmn language redirect -->
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/docs/language(\/?(.*))" "https://help.keyman.com/developer/language/$3"
+RewriteRule "^([1-9][0-9]\.[0-9])/docs/language(\/?(.*))" "https://help.keyman.com/developer/language/$3" [R,QSA]
 
 
 # All other context help, direct to the major version
 # "/go/developer/X.Y/docs"
-RedirectMatch "/go/developer/([1-9][0-9])\.[0-9]/docs(\/?(.*))" "https://help.keyman.com/developer/$1.0/$3"
+RewriteRule "^([1-9][0-9])\.[0-9]/docs(\/?(.*))" "https://help.keyman.com/developer/$1.0/$3" [R,QSA]
 
 
 # "/go/developer/X.Y/home"
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/home" "/developer/"
+RewriteRule "^([1-9][0-9]\.[0-9])/home" "/developer/" [R,QSA]
 
-                
+
 # "/go/developer/X.Y/ios-app"
 # see includes/appstore.php
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/ios-app" "https://itunes.apple.com/us/app/keyman/id933676545?ls=1&mt=8"
+RewriteRule "^([1-9][0-9]\.[0-9])/ios-app" "https://itunes.apple.com/us/app/keyman/id933676545?ls=1&mt=8" [R,QSA]
 
 
 # "/go/developer/X.Y/android-app"
 # see includes/playstore.php
-RedirectMatch "/go/developer/([1-9][0-9]\.[0-9])/android-app" "https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro"
+RewriteRule "^([1-9][0-9]\.[0-9])/android-app" "https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro" [R,QSA]

--- a/go/ios/.htaccess
+++ b/go/ios/.htaccess
@@ -2,7 +2,7 @@
 # Links for iOS 14.0 onward
 
 # "/go/ios/X.Y/download-keyboards/languages"
-RedirectMatch "/go/ios/([1-9][0-9]\.[0-9])/download-keyboards/languages/(.*)" "/keyboards/languages/$2?embed=ios&embed_version=$1"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards/languages/(.*)" "/keyboards/languages/$2?embed=ios&embed_version=$1" [R,QSA]
 
 # "/go/ios/X.Y/download-keyboards"
-RedirectMatch "/go/ios/([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=ios&embed_version=$1"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=ios&embed_version=$1" [R,QSA]

--- a/go/linux/.htaccess
+++ b/go/linux/.htaccess
@@ -2,17 +2,17 @@
 # Redirects for Keyman for Linux 11.0 onward
 
 # "/go/linux/X.Y/download-keyboards"
-RedirectMatch "/go/linux/([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=linux"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=linux" [R,QSA]
 
 # "/go/linux/X.Y/forums" stopProcessing="true">
-RedirectMatch "/go/linux/([1-9][0-9]\.[0-9])/forums" "https://community.software.sil.org/c/keyman"
+RewriteRule "^([1-9][0-9]\.[0-9])/forums" "https://community.software.sil.org/c/keyman" [R,QSA]
 
 # "/go/linux/X.Y/support" stopProcessing="true">
-RedirectMatch "/go/linux/([1-9][0-9]\.[0-9])/support" "/support"
+RewriteRule "^([1-9][0-9]\.[0-9])/support" "/support" [R,QSA]
 
 # "/go/linux/X.Y/privacy" stopProcessing="true">
-RedirectMatch "/go/linux/([1-9][0-9]\.[0-9])/privacy" "/privacy"
+RewriteRule "^([1-9][0-9]\.[0-9])/privacy" "/privacy" [R,QSA]
 
 # permanent link to screenshot of linux-configuration
 # "/go/linux/X.Y/linux-configuration.png"
-RedirectMatch "/go/linux/([1-9][0-9]\.[0-9])/linux-configuration.png" "/cdn/dev/img/linux-configuration.png"
+RewriteRule "^([1-9][0-9]\.[0-9])/linux-configuration.png" "/cdn/dev/img/linux-configuration.png" [R,QSA]

--- a/go/macos/.htaccess
+++ b/go/macos/.htaccess
@@ -2,4 +2,4 @@
 # Redirects for Keyman 10.0 for macOS onward
 
 # /go/macos/X.Y/download-keyboards
-RedirectMatch "/go/macos/([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=macos"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=macos" [R,QSA]

--- a/go/windows/.htaccess
+++ b/go/windows/.htaccess
@@ -2,19 +2,19 @@
 # Links for Keyman for Windows 14.0 onward
 
 # "/go/windows/X.Y/download-keyboards" stopProcessing="true">
-RedirectMatch "/go/windows/([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=windows"
+RewriteRule "^([1-9][0-9]\.[0-9])/download-keyboards" "/keyboards?embed=windows" [R,QSA]
 
 # "/go/windows/X.Y/keep-in-touch" stopProcessing="true">0
-RedirectMatch "/go/windows/([1-9][0-9]\.[0-9])/keep-in-touch" "/windows/keepintouch-140"
+RewriteRule "([1-9][0-9]\.[0-9])/keep-in-touch" "/windows/keepintouch-140" [R,QSA]
 
 # "/go/windows/X.Y/issue-1285" stopProcessing="true">
-RedirectMatch "/go/windows/([1-9][0-9]\.[0-9])/issue-1285" "https://blog.keyman.com/2018/11/keyman-windows-10-1803-and-amharic-tigrinya-sinhala"
+RewriteRule "^([1-9][0-9]\.[0-9])/issue-1285" "https://blog.keyman.com/2018/11/keyman-windows-10-1803-and-amharic-tigrinya-sinhala" [R,QSA]
 
 # "/go/windows/X.Y/create-locale" stopProcessing="true">
-RedirectMatch "/go/windows/([1-9][0-9]\.[0-9])/create-locale" "https://translate.keyman.com/"
+RewriteRule "^([1-9][0-9]\.[0-9])/create-locale" "https://translate.keyman.com/" [R,QSA]
 
 # "/go/windows/X.Y/home" stopProcessing="true">
-RedirectMatch "/go/windows/([1-9][0-9]\.[0-9])/home" "/windows/"
+RewriteRule "^([1-9][0-9]\.[0-9])/home" "/windows/" [R,QSA]
 
 # "/go/windows/X.Y/archived-downloads" stopProcessing="true">
-RedirectMatch "/go/windows/([1-9][0-9]\.[0-9])/archived-downloads" "/downloads/archive"
+RewriteRule "/go/windows/([1-9][0-9]\.[0-9])/archived-downloads" "/downloads/archive" [R,QSA]


### PR DESCRIPTION
Fixes keymanapp/keyman#10746.

`RedirectMatch` does not forward parameters; instead need to use `RewriteRule`.