### PR TITLE
fix: append query strings for some other redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -20,10 +20,10 @@ AddType application/json apple-app-site-association
 RewriteRule "^.well-known/apple-app-site-association$" "/.well-known/apple-app-site-association.json" [L]
 
 # macosx and macos to mac (ignore case)
-RedirectMatch 301 "^(?i)/(macosx|macos)\b(.*)$" "/mac$2"
+RewriteRule "^(macosx|macos)\b(.*)$" "/mac$2" [NC,R=301,END,QSA]
 
 # Redirect deprecated Google Plus link
-RedirectMatch 301 "^(?i)/plus.*" "/"
+RewriteRule "^plus.*" "/" [NC,R=301,END,QSA]
 
 # /donate -> donate.keyman.com
 RedirectMatch 301 "^(?i)/donate(\/.*)?" "https://donate.keyman.com"
@@ -32,7 +32,7 @@ RedirectMatch 301 "^(?i)/donate(\/.*)?" "https://donate.keyman.com"
 RedirectMatch 301 "^(?i)/privacy(\/.*)?" "https://software.sil.org/language-software-privacy-policy/"
 
 # desktop to windows
-RedirectMatch 301 "^(?i)/desktop(\/.*)?" "/windows$1"
+RewriteRule "^desktop(/.*)?" "/windows$1" [NC,R=301,END,QSA]
 
 # releases-tier/download
 # note: the tier is currently ignored

--- a/go/download/.htaccess
+++ b/go/download/.htaccess
@@ -2,4 +2,4 @@
 # Links for Developer 10.0 onward
 
 # /go/download/program
-RewriteRule "^(?!_download.php)(.+)$" "/go/download/_download.php?object=$1" [END]
+RewriteRule "^(?!_download.php)(.+)$" "/go/download/_download.php?object=$1" [END,QSA]


### PR DESCRIPTION
Follows #429 
Audited the .htaccess Redirect rules to see if I missed other instances where query string needs to be appended.

## References to Previous web.config files

### /.htaccess
https://github.com/keymanapp/keyman.com/blob/ab3d0a4dfcb1915a9dafd10e2d98fff0a90b4d03/web.config#L39-L47

https://github.com/keymanapp/keyman.com/blob/ab3d0a4dfcb1915a9dafd10e2d98fff0a90b4d03/web.config#L59-L62


### /go/download/.htaccess

https://github.com/keymanapp/keyman.com/blob/ab3d0a4dfcb1915a9dafd10e2d98fff0a90b4d03/go/download/web.config#L8-L11

