### PR TITLE
fix: Rewrite instead of redirect /downloads/releases

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -36,10 +36,10 @@ RewriteRule "^desktop(/.*)?" "/windows$1" [NC,R=301,END,QSA]
 
 # releases-tier/download
 # note: the tier is currently ignored
-RewriteRule "^downloads/releases/(alpha|beta|stable)/(.+)$" "/downloads/releases/_version_downloads.php?tier=$1&version=$2" [R,END]
+RewriteRule "^downloads/releases/(alpha|beta|stable)/(.+)$" "/downloads/releases/_version_downloads.php?tier=$1&version=$2" [END]
 
 # releases-download
-RewriteRule "^downloads/releases/(?!_version_downloads\b)(.+)$" "/downloads/releases/_version_downloads.php?version=$1" [R,END]
+RewriteRule "^downloads/releases/(.+)$" "/downloads/releases/_version_downloads.php?version=$1" [END]
 
 # index
 RewriteRule "^downloads/releases(\/)?$" "/downloads" [R,END]


### PR DESCRIPTION
Fixes #442 reverting redirects to rewrites

Comparison to legacy /downloads/releaeses/web.config rules

```xml
                <rule name="releases-tier/download" stopProcessing="true">
                  <!-- note: the tier is currently ignored -->
                  <match url="^(alpha|beta|stable)/(.+)$" />
                  <action type="Rewrite" url="_version_downloads.php?tier={R:1}&amp;version={R:2}" />
                </rule>

                <rule name="releases-download" stopProcessing="true">
                  <match url="^(.+)$" />
                  <action type="Rewrite" url="_version_downloads.php?version={R:1}" />
                </rule>

                <rule name="index" stopProcessing="true">
                  <match url="^$" />
                  <action type="Redirect" url=".." />
                </rule>
```