### PR TITLE
chore: Update note on Wayland support

### DIFF
--- a/linux/index.php
+++ b/linux/index.php
@@ -156,8 +156,8 @@ sudo apt install keyman onboard-keyman
   <span class="red">Q.</span> Does Keyman for Linux work with Wayland?
 </p>
 <p>
-  <span class="red">A.</span> Currently, there's <a href="https://github.com/keymanapp/keyman/issues/4273">issue #4273</a>
-  to add support for Wayland. As a workaround, use X11.
+  <span class="red">A.</span> Wayland is supported in Keyman 17.0 onward. See <a href="https://github.com/keymanapp/keyman/issues/4273">issue #4273</a>
+  for more information. As a workaround, use X11.
 </p>
 
 <br/>


### PR DESCRIPTION
This updates the note on Wayland support now that it's available in Keyman 17.0 from keymanapp/keyman#4273
