### PR TITLE
fix: h1 styling for mobile layout

### DIFF
--- a/cdn/dev/css/index.css
+++ b/cdn/dev/css/index.css
@@ -770,7 +770,7 @@
 		margin-right: auto;
 		margin-top: 10px;
 		padding: 0px;
-		font-size: 50pt;
+		font-size: 35pt;
 		text-shadow: 2px 2px #000;
 	}
 	#main-banner{


### PR DESCRIPTION
Addresses the styling issue @mcdurdin reported

### Before (live):
![before](https://github.com/keymanapp/keyman.com/assets/7358010/1f4d3577-9f09-4597-a62e-2fceda2fda9f)


### After:
![image](https://github.com/keymanapp/keyman.com/assets/7358010/2c188b08-9218-4a19-99af-050a9b8b3cd6)
