### PR TITLE
chore: Use new SIL Global name

### DIFF
--- a/_includes/2020/templates/Foot.php
+++ b/_includes/2020/templates/Foot.php
@@ -60,7 +60,7 @@
         <div class="footer-third sil-logo">
             <br>
             <a href="/about/"><img id="sil-logo" src="<?php echo Util::cdn("img/sil-logo-blue-2017_1.png"); ?>" alt='SIL' /></a>
-            <p>Created by <a href="/about/">SIL International</a></p>
+            <p>Created by <a href="/about/">SIL Global</a></p>
         </div>
     </div>
 </div>

--- a/about/index.md
+++ b/about/index.md
@@ -11,17 +11,17 @@ means keyboard layouts can be intelligent and make it simple to type even the mo
 Keyboard layouts are distributed through an open catalog to all major desktop and mobile platforms.
 
 
-## About SIL International
+## About SIL Global
 
 <!--div style=style='float:left; margin: 0 16px 0 0'-->
 ![](/cdn/dev/img/sil-logo-blue-2017_1.png)
 
-Keyman is created by SIL International. Partners in Language Development,
-SIL International is a faith-based nonprofit organization committed to serving language communities
+Keyman is created by SIL Global (formerly SIL International). Partners in Language Development,
+SIL Global is a faith-based nonprofit organization committed to serving language communities
 worldwide as they build capacity for sustainable language development. SIL does this primarily
 through research, translation, training and materials development.
 
-You can learn more about SIL International on the [SIL International web site](https://www.sil.org/about).
+You can learn more about SIL Global on the [SIL Global web site](https://www.sil.org/about).
 
 ## About National Polytechnic Institute of Cambodia
 

--- a/contact/index.php
+++ b/contact/index.php
@@ -35,7 +35,7 @@
 
 <h2 class="red underline">Postal Address</h2>
 <p>
-  SIL International
+  SIL Global
   <br/>
   7500 W Camp Wisdom Rd
   <br/>

--- a/ldml/index.md
+++ b/ldml/index.md
@@ -11,7 +11,7 @@ SIL Keyman is adding support for the LDML Keyboard specification.
 
 LDML is the Locale Data Markup Language. It it an XML-based format specified as the Unicode Consortium’s specification UTS#35, maintained by the Common Locale Data Repository (CLDR) Technical Commitee. Part 7 of UTS#35 pertains to keyboard layouts. This specification is currently being rewritten and further developed by the [CLDR Keyboard Subcommittee](https://cldr.unicode.org/index/keyboard-workgroup).
 
-Like the [Keyman Keyboard Language](https://help.keyman.com/developer/language/) (`.kmn`) format, the LDML Keyboard format defines how keystrokes are interpreted and how keys are laid out in a virtual keyboard.  The LDML format has been defined from the beginning to become a cross-platform industry standard, with active participation from several Unicode member organizations including SIL International.  The intention is to provide a draft specification as a technical preview for public review in mid-2023, with a first release later in 2023.
+Like the [Keyman Keyboard Language](https://help.keyman.com/developer/language/) (`.kmn`) format, the LDML Keyboard format defines how keystrokes are interpreted and how keys are laid out in a virtual keyboard.  The LDML format has been defined from the beginning to become a cross-platform industry standard, with active participation from several Unicode member organizations including SIL Global.  The intention is to provide a draft specification as a technical preview for public review in mid-2023, with a first release later in 2023.
 
 ```xml
 <!-- Example: French AZERTY Keyboard in LDML format -->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.com.git"
   },
-  "author": "SIL International",
+  "author": "SIL Global",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/keymanapp/keyman.com/issues"


### PR DESCRIPTION
Related to #463 

Reflects the name change from "SIL International" to "SIL Global" as of August 2024 from
https://www.sil.org/about/news/new-name-90-sil-international-becomes-sil-global

Not changing historical pages