### PR TITLE
fix: Skip CDN for --debug builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=chore/v0.10
+readonly BOOTSTRAP_VERSION=v0.10
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.8
+readonly BOOTSTRAP_VERSION=chore/v0.10
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 
@@ -45,6 +45,6 @@ builder_run_action configure  bootstrap_configure
 builder_run_action clean      clean_docker_container $KEYMAN_IMAGE_NAME $KEYMAN_CONTAINER_NAME
 builder_run_action stop       stop_docker_container  $KEYMAN_IMAGE_NAME $KEYMAN_CONTAINER_NAME
 builder_run_action build      build_docker_container $KEYMAN_IMAGE_NAME $KEYMAN_CONTAINER_NAME
-builder_run_action start      start_docker_container $KEYMAN_IMAGE_NAME $KEYMAN_CONTAINER_NAME $KEYMAN_CONTAINER_DESC $HOST_KEYMAN_COM $PORT_KEYMAN_COM
+builder_run_action start      start_docker_container $KEYMAN_IMAGE_NAME $KEYMAN_CONTAINER_NAME $KEYMAN_CONTAINER_DESC $HOST_KEYMAN_COM $PORT_KEYMAN_COM $BUILDER_CONFIGURATION
 
 builder_run_action test       test_docker_container

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-echo "---- Generating CDN ---"
-rm -rf cdn/deploy
-cd cdn
-php -d include_path=/var/www/html/_includes:. cdnrefresh.php
-cd ..
+if [[ ! $1 =~ "debug" ]]; then
+  echo "---- Generating CDN ---"
+  rm -rf cdn/deploy
+  cd cdn
+  php -d include_path=/var/www/html/_includes:. cdnrefresh.php
+  cd ..
+else
+  echo "Skip Generating CDN"
+fi


### PR DESCRIPTION
Fixes #470 to skip generating CDN if `./build.sh --debug`

Since this is changing `BOOTSTRAP_VERSION` to `chore/v0.10`, I'm unsure if we want to merge this to master. Or have a separate branch while the Logo work is in flux...

(edit)
BOOSTRAP_VERSION v0.10 is published so updating PR to use that.