### PR TITLE
fix: clean CDN cache on --debug

### DIFF
--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -7,5 +7,6 @@ if [[ ! $1 =~ "debug" ]]; then
   php -d include_path=/var/www/html/_includes:. cdnrefresh.php
   cd ..
 else
-  echo "Skip Generating CDN"
+  echo "Skip Generating CDN and clean CDN cache"
+  rm -rf cdn/deploy
 fi


### PR DESCRIPTION
Follows #471 and mirrors keymanapp/help.keyman.com@5a99378654b42bc88ccc4cc3dbc889cdc409da7b
of removing /cdn/deploy if it exists (e.g. from a previous run)