### PR TITLE
feat: Add metadata description content to headers 📓

### DIFF
--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -27,6 +27,9 @@ class Head {
 <head>
   <meta charset="utf-8">
   <?php
+  if(isset($fields->description)) {
+    echo "<meta name='description' content='" . $fields->description . "'>\n";
+  }
   if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_STAGING) {
     echo '    <meta name="robots" content="none">';
   }

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -27,7 +27,7 @@ class Head {
 <head>
   <meta charset="utf-8">
   <?php
-  if(isset($fields->description)) {
+  if(isset($fields->description) && !empty($fields->description)) {
     echo "<meta name='description' content='" . $fields->description . "'>\n";
   }
   if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_STAGING) {

--- a/_includes/includes/md/mdhost.php
+++ b/_includes/includes/md/mdhost.php
@@ -14,6 +14,7 @@
     'title' => $md->PageTitle(),
     'css' => ['template.css','prism.css'],
     'showMenu' => $md->ShowMenu(),
+    'description' => $md->PageDescription(),
     'js' => ['prism.js']
   ]);
 

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -49,6 +49,9 @@
     }else{
         $title = 'Keyman | Type to the world in your language';
     }
+    if(isset($args['description'])) {
+      $description = $args['description'];
+    }
     if(isset($args['css'])){
       $css = array();
       foreach($args['css'] as $cssFile){
@@ -80,6 +83,7 @@
     // This avoids the global variable plague of earlier templates!
     $head = [];
     if(isset($title)) $head['title'] = $title;
+    if(isset($description)) $head['description'] = $description;
     if(isset($favicon)) $head['favicon'] = $favicon;
     if(isset($css)) $head['css'] = $css;
     if(isset($js)) $head['js'] = $js;

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.10
+readonly BOOTSTRAP_VERSION=chore/v0.11
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=chore/v0.11
+readonly BOOTSTRAP_VERSION=v0.11
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 


### PR DESCRIPTION
In preparation for #383 and depends on keymanapp/shared-sites#34 in handling optional page description fields that can be written to the HTML header.

**Note**: CI Link checker fails until keymanapp/shared-sites#34 gets merged into chore/v0.11

This can be seen in the page sources of the various `/_test/` Markdown pages since they already include 
```yml
---
title: ...
description: ...
---
```

An example of a page without a description is
`/14/keyman-engine-changes`
