### PR TITLE
feat: Add descriptions for major pages 📓

### DIFF
--- a/android/index.php
+++ b/android/index.php
@@ -7,6 +7,7 @@
   // Required
   head([
     'title' =>'Keyman for Android',
+    'description' => 'Keyman for Android',
     'css' => ['template.css','feature-grid.css','app-store-links.css'],
     'showMenu' => true,
     'banner' => [

--- a/downloads/archive/index.php
+++ b/downloads/archive/index.php
@@ -6,12 +6,14 @@
   // Required
   head([
     'title' =>'Download Archives',
+    'description' => 'Keyman download archive: static activation license keys',
     'css' => ['template.css', 'feature-grid.css'],
     'showMenu' => true
   ]);
 
   require_once('./static-keys.php');
-
+',
+    <meta name="description" content=”
   // These variables should be progressively added if we update older versions.
   // 14.0 onward uses 3 numbers instead of 4
   $ver_windows_16 = "16.0.147";

--- a/downloads/archive/index.php
+++ b/downloads/archive/index.php
@@ -12,8 +12,6 @@
   ]);
 
   require_once('./static-keys.php');
-',
-    <meta name="description" content=”
   // These variables should be progressively added if we update older versions.
   // 14.0 onward uses 3 numbers instead of 4
   $ver_windows_16 = "16.0.147";

--- a/downloads/index.php
+++ b/downloads/index.php
@@ -7,6 +7,7 @@
   // Required
   head([
     'title' =>'Keyman Downloads',
+    'description' => 'Keyamn stable downloads',
     'css' => ['template.css','index.css','app-store-links.css', 'prism.css'],
     'js' => ['prism.js'],
     'showMenu' => true

--- a/downloads/index.php
+++ b/downloads/index.php
@@ -7,7 +7,7 @@
   // Required
   head([
     'title' =>'Keyman Downloads',
-    'description' => 'Keyamn stable downloads',
+    'description' => 'Keyman stable downloads',
     'css' => ['template.css','index.css','app-store-links.css', 'prism.css'],
     'js' => ['prism.js'],
     'showMenu' => true

--- a/downloads/pre-release/index.php
+++ b/downloads/pre-release/index.php
@@ -5,6 +5,7 @@
   // Required
   head([
     'title' =>'Keyman Pre-release Versions',
+    'description' => 'Keyman pre-release versions: alpha, beta',
     'css' => ['template.css','index.css', 'app-store-links.css','prism.css'],
     'showMenu' => true
   ]);

--- a/index.php
+++ b/index.php
@@ -5,6 +5,9 @@ require_once __DIR__ . '/_includes/autoload.php';
 // Required
 head([
     'title' =>'Keyman | Type to the world in your language',
+    'description' => 'Unlock the power of your language with Keyman customizable keyboard software. 
+       Available for Windows, Mac, and mobile devices, 
+       we support over 1,000 languages to make communication seamless and meaningful.',
     'css' => ['template.css','index.css'],
     'showMenu' => true,
     'addSection2' => false

--- a/index.php
+++ b/index.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/_includes/autoload.php';
 head([
     'title' =>'Keyman | Type to the world in your language',
     'description' => 'Unlock the power of your language with Keyman customizable keyboard software. 
-       Available for Windows, Mac, and mobile devices, 
-       we support over 1,000 languages to make communication seamless and meaningful.',
+       Available for Windows, Mac, Linux, Android, iPhone, and web, 
+       we support over 2,000 languages to make communication seamless and meaningful.',
     'css' => ['template.css','index.css'],
     'showMenu' => true,
     'addSection2' => false

--- a/iphone-and-ipad/index.php
+++ b/iphone-and-ipad/index.php
@@ -7,6 +7,7 @@
   // Required
   head([
     'title' =>'Keyman for iPhone and iPad',
+    'description' => 'Keyman for iPhone and iPad',
     'css' => ['template.css','feature-grid.css','app-store-links.css'],
     'showMenu' => true,
     'banner' => [

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -10,6 +10,7 @@
 
   $head_options = [
     'title' =>'Keyboard Search',
+    'description' => 'Keyman Keyboard Search',
     'css' => [Util::cdn('css/template.css'), Util::cdn('keyboard-search/search.css')],
     'js' => [Util::cdn('keyboard-search/jquery.mark.js'), Util::cdn('keyboard-search/dedicated-landing-pages.js'),
       Util::cdn('keyboard-search/search.js')]

--- a/linux/index.php
+++ b/linux/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman ' . $stable_version . ' for Linux',
-    'description' => 'Keyman for Linux stable',
+    'description' => 'Keyman for Linux',
     'css' => ['template.css','index.css','desktop.css','feature-grid.css', 'prism.css'],
     'js' => ['prism.js'],
     'showMenu' => true,

--- a/linux/index.php
+++ b/linux/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman ' . $stable_version . ' for Linux',
+    'description' => 'Keyman for Linux stable',
     'css' => ['template.css','index.css','desktop.css','feature-grid.css', 'prism.css'],
     'js' => ['prism.js'],
     'showMenu' => true,

--- a/mac/index.php
+++ b/mac/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman ' . $stable_version . ' for macOS',
-    'description' => 'Keyman for macOS stable',
+    'description' => 'Keyman for macOS',
     'css' => ['template.css','index.css','desktop.css','feature-grid.css'],
     'showMenu' => true,
     'banner' => [

--- a/mac/index.php
+++ b/mac/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman ' . $stable_version . ' for macOS',
+    'description' => 'Keyman for macOS stable',
     'css' => ['template.css','index.css','desktop.css','feature-grid.css'],
     'showMenu' => true,
     'banner' => [

--- a/windows/download.php
+++ b/windows/download.php
@@ -5,6 +5,7 @@
   // Required
   head([
     'title' =>'Download Keyman for Windows ' . $stable_version,
+    'description' => 'Download Keyman for Windows stable',
     'css' => ['template.css','index.css','desktop-download.css'],
     'js' => ['download.js'],
     'showMenu' => true

--- a/windows/download.php
+++ b/windows/download.php
@@ -5,7 +5,7 @@
   // Required
   head([
     'title' =>'Download Keyman for Windows ' . $stable_version,
-    'description' => 'Download Keyman for Windows stable',
+    'description' => 'Download Keyman for Windows',
     'css' => ['template.css','index.css','desktop-download.css'],
     'js' => ['download.js'],
     'showMenu' => true

--- a/windows/features.php
+++ b/windows/features.php
@@ -4,6 +4,7 @@
   // Required
   head([
     'title' =>'Features | Keyman for Windows ' . $stable_version,
+    'description' => 'Keyman for Windows Features',
     'css' => ['template.css','feature-template.css'],
     'showMenu' => true
   ]);

--- a/windows/index.php
+++ b/windows/index.php
@@ -5,6 +5,7 @@
   // Required
   head([
     'title' =>'Keyman for Windows ' . $stable_version,
+    'description' => 'Keyman for Windows',
     'css' => ['template.css','index.css','desktop.css','feature-grid.css'],
     'showMenu' => true,
     'banner' => [


### PR DESCRIPTION
Support for #383, follows  #485

This adds metadata descriptions for the major pages on keyman.com
