### PR TITLE
chore: Add img alt descriptions for main page

### DIFF
--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -101,7 +101,7 @@ END;
 
 <div id="container" class="page-<?=$fields->pageClass?>">
     <div class="header">
-        <img id="show-phone-menu" src="<?php echo Util::cdn("img/phonehide.png"); ?>" />
+        <img id="show-phone-menu" src="<?php echo Util::cdn("img/phonehide.png"); ?>" alt="menu toggle" />
         <a id="home-link" href="/"><img id="logo" src="<?php echo Util::cdn(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_PRODUCTION ? "img/logo2.png" : "img/logo2dev.png"); ?>" alt='Keyman Logo' /></a>
         <img id="header-bottom" src="<?php echo Util::cdn("img/headerbar.png"); ?>" alt='Header bottom' />
         <div id="help">
@@ -119,7 +119,7 @@ END;
     </div>
     <div id="top-menu-bg"></div>
     <div id="top-menu1">
-        <a href="/"><img id="top-menu-icon" src="<?php echo Util::cdn("img/icon1.png"); ?>" /></a>
+        <a href="/"><img id="top-menu-icon" src="<?php echo Util::cdn("img/icon1.png"); ?>" alt="Keyman logo" /></a>
         <div id='help1'>
           <form action="/search/" method="get" role="search">
             <div class="search-wrap">

--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -38,7 +38,7 @@ END;
             <h3>Keyboards</h3>
             <form method="get" action="/keyboards" name="fsearch">
                 <input id="language-search2" type="text" placeholder="Enter language" name="q">
-                <input id="search-submit2" type="image" src="<?php echo Util::cdn("img/search-button.png"); ?>" value="Search" onclick="if(document.getElementById('language-search2').value==''){return false;}">
+                <input id="search-submit2" type="image" src="<?php echo Util::cdn("img/search-button.png"); ?>" alt="search button" value="Search" onclick="if(document.getElementById('language-search2').value==''){return false;}">
             </form>
         </div>
         <div class="phone-menu-item">
@@ -114,7 +114,7 @@ END;
             </div>
           </form>
           <p id="donate"><a href="/donate">Donate</a></p>
-          <p><a href="<?= KeymanHosts::Instance()->help_keyman_com ?>" target="blank">Support<img src="<?php echo Util::cdn("img/helpIcon.png"); ?>"></a></p>
+          <p><a href="<?= KeymanHosts::Instance()->help_keyman_com ?>" target="blank">Support<img src="<?php echo Util::cdn("img/helpIcon.png"); ?>" alt="help icon"></a></p>
         </div>
     </div>
     <div id="top-menu-bg"></div>
@@ -129,11 +129,11 @@ END;
             </div>
           </form>
           <a id='help1-donate' href="/donate">Donate</a>
-          <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>"><img id="top-menu-icon2" src="<?php echo Util::cdn("img/helpIcon.png"); ?>" /></a>
+          <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>"><img id="top-menu-icon2" src="<?php echo Util::cdn("img/helpIcon.png"); ?>" alt="help icon" /></a>
         </div>
         <div class="wrapper">
             <div class="menu-item" id="keyboards">
-                <h3>Keyboards<span class="header-triangle"><img src="<?php echo Util::cdn("img/img_trans.png"); ?>" /></span></h3>
+                <h3>Keyboards<span class="header-triangle"><img src="<?php echo Util::cdn("img/img_trans.png"); ?>" alt="keyboards dropdown" /></span></h3>
                 <div class="menu-item-dropdown">
                     <div class="menu-dropdown-inner">
                         <h4>(2000+ languages)</h4>
@@ -161,7 +161,7 @@ END;
                 </div>
             </div>
             <div class="menu-item" id="products">
-                <h3>Products<span class="header-triangle"><img src="<?php echo Util::cdn("img/img_trans.png"); ?>" /></span></h3>
+                <h3>Products<span class="header-triangle"><img src="<?php echo Util::cdn("img/img_trans.png"); ?>" alt="products dropdown" /></span></h3>
                 <div class="menu-item-dropdown">
                     <div class="menu-dropdown-inner">
                         <h4>Core Products</h4>
@@ -184,7 +184,7 @@ END;
                 </div>
             </div>
             <div class="menu-item" id="tavultesoft">
-                <h3>About<span class="header-triangle"><img src="<?php echo Util::cdn("img/img_trans.png"); ?>" /></span></h3>
+                <h3>About<span class="header-triangle"><img src="<?php echo Util::cdn("img/img_trans.png"); ?>" alt="About dropdown" /></span></h3>
                 <div class="menu-item-dropdown">
                     <div class="menu-dropdown-inner">
                         <ul>
@@ -209,7 +209,7 @@ END;
                 </div>
             </div>
         </div>
-        <img id="top-menu-bottom" src="<?php echo Util::cdn("img/headerbar.png"); ?>" />
+        <img id="top-menu-bottom" src="<?php echo Util::cdn("img/headerbar.png"); ?>" alt="Header bottom" />
     </div>
     <div id="phone-header-spacer"></div>
 

--- a/_includes/includes/ui/download-links.php
+++ b/_includes/includes/ui/download-links.php
@@ -8,7 +8,7 @@
     <a class="language desktop" href="/cheyenne">Cheyenne <span class="pipe">|</span> <span lang="chy" class="lang-example">Tsėhesenėstsestotse</span></a>
     <a class="language" href="/dinka">Dinka <span class="pipe">|</span> <span lang="din" class="lang-example">Thuɔŋjäŋ</span></a>
     <a class="language desktop" href="/dutch">Dutch <span class="pipe">|</span> <span lang="nl" class="lang-example">Nederlands</span></a>
-    <a class="language desktop" href="/ancient-egyptian">Egyptian <span class="lang-ital">(Ancient)</span> <span class="pipe">|</span> <span lang="egy" class="lang-example"><img id="hiero" src="<?php echo cdn("img/hiero.png"); ?>" /></span></a>
+    <a class="language desktop" href="/ancient-egyptian">Egyptian <span class="lang-ital">(Ancient)</span> <span class="pipe">|</span> <span lang="egy" class="lang-example"><img id="hiero" src="<?php echo cdn("img/hiero.png"); ?>" alt="Hieroglyphs example" /></span></a>
     <a class="language" href="/farsi">Farsi <span class="pipe">|</span> <span lang="pes" class="lang-example">فارسی</span></a>
     <a class="language desktop" href="/french">French <span class="pipe">|</span> <span lang="fr" class="lang-example">Français</span></a>
     <a class="language desktop" href="/german">German <span class="pipe">|</span> <span lang="de" class="lang-example">Deutsch</span></a>

--- a/index.php
+++ b/index.php
@@ -64,7 +64,7 @@ head([
             <form name="fsearch" action="/keyboards" method="get">
                 <h4>Search over 2000 languages</h4>
                 <input type="text" name="q" id="language-search3" placeholder="Enter your language" />
-                <input id="search-submit3" type="image" onclick="if(document.getElementById('language-search3').value==''){return false;}" value="Search" src="<?php echo cdn("img/search-button.png"); ?>">
+                <input id="search-submit3" type="image" onclick="if(document.getElementById('language-search3').value==''){return false;}" value="Search" src="<?php echo cdn("img/search-button.png"); ?>" alt="Search button">
             </form>
         </div>
     </div>
@@ -76,7 +76,7 @@ head([
                 your language, and for over 99% of the global population’s mother tongues!</p>
             <div class="product" id="product-desktop">
                 <a href="/windows">
-                    <img src="<?php echo cdn("img/icon-desktop.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-desktop.png"); ?>" alt="Windows logo" />
                     <h3>Keyman for Windows</h3>
                     <p>
                         Type in your language in all your favourite software applications for Windows.  Keyman for Windows will automatically configure your system for your language.
@@ -85,7 +85,7 @@ head([
             </div>
             <div class="product" id="product-mac">
                 <a href="/mac">
-                    <img src="<?php echo cdn("img/icon-mac.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-mac.png"); ?>" alt="macOS logo" />
                     <h3>Keyman for macOS</h3>
                     <p>
                         Type in your language in all your favourite software applications for macOS.
@@ -94,7 +94,7 @@ head([
             </div>
             <div class="product" id="product-linux">
                 <a href="/linux">
-                    <img src="<?= cdn("img/icon-tux.png"); ?>" />
+                    <img src="<?= cdn("img/icon-tux.png"); ?>" alt="Linux logo" />
                     <h3>Keyman for Linux</h3>
                     <p>
                         Type in your language in all your favourite software applications for Linux.
@@ -103,7 +103,7 @@ head([
             </div>
             <div class="product" id="product-android">
                 <a href="/android">
-                    <img src="<?php echo cdn("img/icon-android2.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-android2.png"); ?>" alt="Android logo" />
                     <h3>Keyman for Android</h3>
                     <p>
                         Type in over 2000 languages on your Android device. Touch enabled keyboards for phone, 7-inch and 10-inch tablets ensure a seamless typing solution across any Android device.
@@ -112,7 +112,7 @@ head([
             </div>
             <div class="product" id="product-iphone">
                 <a href="/iphone-and-ipad">
-                    <img src="<?php echo cdn("img/icon-iphone.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-iphone.png"); ?>" alt="Keyman for iPhone and iPad screenshot" />
                     <h3>Keyman for iPhone and iPad</h3>
                     <p>
                         Type in your language on your iPhone or iPad.  Keyman brings the language experience to life, adding support for many languages and scripts that Apple do not support!
@@ -121,7 +121,7 @@ head([
             </div>
             <div class="product" id="product-web">
                 <a href="/web">
-                    <img src="<?php echo cdn("img/icon-web.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-web.png"); ?>" alt="various browser logos" />
                     <h3>keymanweb.com</h3>
                     <p>
                         Type instantly in your web browser and post to Facebook, Google and more, or copy and paste to use the text anywhere!  No download or configuration is required.
@@ -130,7 +130,7 @@ head([
             </div>
             <div class="product" id="product-bookmarklet">
                 <a href="/bookmarklet">
-                    <img src="<?php echo cdn("img/icon-bookmarklet.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-bookmarklet.png"); ?>" alt="Hebrew Keyboard bookmarklet" />
                     <h3>Keyman Bookmarklet</h3>
                     <p>
                         Add the Keyman Bookmarklet to your web browser to type in your language on every website you visit.
@@ -155,7 +155,7 @@ head([
             <h2 class="section-heading">Developer Tools</h2>
             <div class="developer-half" id="product-developer">
                 <a href="/developer">
-                    <img src="<?php echo cdn("img/icon-developer.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-developer.png"); ?>" alt="Keyman logo" />
                     <h3>Keyman Developer</h3>
                     <p>
                         Create keyboard layouts for every major operating system and device.
@@ -164,7 +164,7 @@ head([
             </div>
             <div class="developer-half" id="product-engine">
                 <a href="/engine">
-                    <img src="<?php echo cdn("img/icon-engine.png"); ?>" />
+                    <img src="<?php echo cdn("img/icon-engine.png"); ?>" alt="Gears" />
                     <h3>Keyman Engine</h3>
                     <p>
                         Integrate custom keyboard layouts into your apps and websites.


### PR DESCRIPTION
Addresses the point on #383

> Use good alternative descriptions (alt attributes) for your images

This adds alt attributes for main page images.

(Not including shared-sites logos)

