### PR TITLE
fix: Specify HTML lang tag "en" 📓

### DIFF
--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -23,7 +23,7 @@ class Head {
         $fields->js = [];
       }
 ?><!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <?php

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -13,7 +13,7 @@ class Head {
       if(!isset($fields->title)) {
         $fields->title = 'Keyman | Type to the world in your language';
       }
-      if(empty($fields->language) {
+      if(empty($fields->language)) {
         $fields->language = 'en'; // Default to English
       }
       if(!isset($fields->favicon)) {

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -13,7 +13,7 @@ class Head {
       if(!isset($fields->title)) {
         $fields->title = 'Keyman | Type to the world in your language';
       }
-      if(!isset($fields->language)) {
+      if(!empty($fields->language)) {
         $fields->language = 'en'; // Default to English
       }
       if(!isset($fields->favicon)) {

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -13,7 +13,7 @@ class Head {
       if(!isset($fields->title)) {
         $fields->title = 'Keyman | Type to the world in your language';
       }
-      if(empty($fields->language()) {
+      if(empty($fields->language) {
         $fields->language = 'en'; // Default to English
       }
       if(!isset($fields->favicon)) {
@@ -26,7 +26,7 @@ class Head {
         $fields->js = [];
       }
 ?><!DOCTYPE html>
-<html lang="<?= $fields->language; ?>">
+<html lang="<?= $fields->language ?>">
 <head>
   <meta charset="utf-8">
   <?php

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -13,6 +13,9 @@ class Head {
       if(!isset($fields->title)) {
         $fields->title = 'Keyman | Type to the world in your language';
       }
+      if(!isset($fields->language)) {
+        $fields->language = 'en'; // Default to English
+      }
       if(!isset($fields->favicon)) {
         $fields->favicon = Util::cdn("img/favicon.ico");
       }
@@ -23,7 +26,7 @@ class Head {
         $fields->js = [];
       }
 ?><!DOCTYPE html>
-<html lang="en">
+<html lang="<?= $fields->language; ?>">
 <head>
   <meta charset="utf-8">
   <?php

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -13,7 +13,7 @@ class Head {
       if(!isset($fields->title)) {
         $fields->title = 'Keyman | Type to the world in your language';
       }
-      if(!empty($fields->language)) {
+      if(empty($fields->language()) {
         $fields->language = 'en'; // Default to English
       }
       if(!isset($fields->favicon)) {


### PR DESCRIPTION
Addresses this point of #383 

> Fix errors regarding the language markup of your webpage
The language is not specified in the HTML markup

We're not yet ready to localize keyman.com, so for now setting the HTMl lang tag to "en".