### PR TITLE
fix: Add HTML lang tags for dedicated keyboard landing page examples 📓

### DIFF
--- a/keyboards/h/amharic/index.php
+++ b/keyboards/h/amharic/index.php
@@ -220,7 +220,7 @@
           <kbd>a</kbd>
           <kbd>m</kbd>
           produces:
-          <span class="example">ሰላም</span>
+          <span class="example" lang="am">ሰላም</span>
           <br>
           Typing
           <kbd>T</kbd>
@@ -234,11 +234,11 @@
           <kbd>l</kbd>
           <kbd>N</kbd>
           produces:
-          <span class="example">ጤናይስጥልኝ</span>
+          <span class="example" lang="am">ጤናይስጥልኝ</span>
         </li>
         <li>
           Ge'ez default punctuation with Western default space. (Ge'ez space '
-          <span class="example">፡</span>
+          <span class="example" lang="am">፡</span>
           ' available with
           <kbd>SHIFT</kbd>
           +
@@ -255,13 +255,13 @@
     <span class="question">What is the difference between Tigrigna (Eritrea) and Tigrigna (Ethiopia)?</span>
     <span class="answer">
       The two Tigrigna keyboards differ slightly. Tigrigna (Ethiopia) includes three sets of characters which are not in Tigrigna (Eritrea) —
-      <span class="example">ሥ</span>
+      <span class="example" lang="ti-et">ሥ</span>
       ,
-      <span class="example">ኅ</span>
+      <span class="example" lang="ti-et">ኅ</span>
       ,
-      <span class="example">ፅ</span>
+      <span class="example" lang="ti-et">ፅ</span>
       — as well as the single character
-      <span class="example">ኧ</span>
+      <span class="example" lang="ti-et">ኧ</span>
       . The two keyboards also differ on the punctuation they offer:
     </span>
     <table id="ethiopic-punctuation">
@@ -305,26 +305,26 @@
         </tr>
         <tr>
           <th>Tigrigna (Eritrea) result</th>
-          <td class="example">፡</td>
-          <td class="example">,</td>
+          <td class="example" lang="ti-er">፡</td>
+          <td class="example" lang="ti-er">,</td>
           <td class="nil"></td>
-          <td class="example">፣</td>
-          <td class="example">;</td>
-          <td class="example">፡</td>
-          <td class="example">።</td>
-          <td class="example">፦</td>
-          <td class="example">፧</td>
+          <td class="example" lang="ti-er">፣</td>
+          <td class="example" lang="ti-er">;</td>
+          <td class="example" lang="ti-er">፡</td>
+          <td class="example" lang="ti-er">።</td>
+          <td class="example" lang="ti-er">፦</td>
+          <td class="example" lang="ti-er">፧</td>
         </tr>
         <tr>
           <th>Tigrignia (Ethiopia) result</th>
-          <td class="example">፣</td>
-          <td class="example">፥</td>
-          <td class="example">,</td>
-          <td class="example">፤</td>
-          <td class="example">;</td>
-          <td class="example">፡</td>
-          <td class="example">።</td>
-          <td class="example">፦</td>
+          <td class="example" lang="ti-et">፣</td>
+          <td class="example" lang="ti-et">፥</td>
+          <td class="example" lang="ti-et">,</td>
+          <td class="example" lang="ti-et">፤</td>
+          <td class="example" lang="ti-et">;</td>
+          <td class="example" lang="ti-et">፡</td>
+          <td class="example" lang="ti-et">።</td>
+          <td class="example" lang="ti-et">፦</td>
           <td class="nil"></td>
         </tr>
       </tbody>

--- a/keyboards/h/ipa/index.php
+++ b/keyboards/h/ipa/index.php
@@ -36,7 +36,7 @@
 
   <div id='intro'>
     <h1 class="red">IPA Keyboards</h1>
-    <div id='ipa'>
+    <div id='ipa' lang="und-fonipa">
       <p>tʰaɪpʰ ɪn <a href='https://www.internationalphoneticassociation.org/content/ipa-chart' target='_blank'>aɪ pʰiː eɪ</a> kʰeɹɛktɚz ɪn ɔl jɚ  faɪvɹɪt̚ pɹogɹæmz <!--ɪŋkludɪŋ jɚ imeɪl, wɛb bɹaʊzɚ, wɚd, ɛksɛl, aʊtlʊk ænd mɛni mɛni moɹ...--></p>
       <p>tʰaɪp̚ wɪðaʊt̚ tʃeɪndʒɪŋ jɚ hɔɹdwɛɹ wɪð ðiz <a href='http://www.unicode.org/standard/WhatIsUnicode.html'>junəkod</a> kiboɹdz</p>
     </div>

--- a/keyboards/h/tigrigna/eritrean.php
+++ b/keyboards/h/tigrigna/eritrean.php
@@ -203,7 +203,7 @@
           <kbd>a</kbd>
           <kbd>m</kbd>
           produces:
-          <span class="example">ሰላም</span>
+          <span class="example" lang="am">ሰላም</span>
           <br>
           Typing
           <kbd>T</kbd>
@@ -217,11 +217,11 @@
           <kbd>l</kbd>
           <kbd>N</kbd>
           produces:
-          <span class="example">ጤናይስጥልኝ</span>
+          <span class="example" lang="am">ጤናይስጥልኝ</span>
         </li>
         <li>
           Ge'ez default punctuation with Western default space. (Ge'ez space '
-          <span class="example">፡</span>
+          <span class="example" lang="am">፡</span>
           ' available with
           <kbd>SHIFT</kbd>
           +
@@ -238,13 +238,13 @@
     <span class="question">What is the difference between Tigrigna (Eritrea) and Tigrigna (Ethiopia)?</span>
     <span class="answer">
       The two Tigrigna keyboards differ slightly. Tigrigna (Ethiopia) includes three sets of characters which are not in Tigrigna (Eritrea) —
-      <span class="example">ሥ</span>
+      <span class="example" lang="ti-et">ሥ</span>
       ,
-      <span class="example">ኅ</span>
+      <span class="example" lang="ti-et">ኅ</span>
       ,
-      <span class="example">ፅ</span>
+      <span class="example" lang="ti-et">ፅ</span>
       — as well as the single character
-      <span class="example">ኧ</span>
+      <span class="example" lang="ti-et">ኧ</span>
       . The two keyboards also differ on the punctuation they offer:
     </span>
     <table id="ethiopic-punctuation">
@@ -288,26 +288,26 @@
         </tr>
         <tr>
           <th>Tigrigna (Eritrea) result</th>
-          <td class="example">፡</td>
-          <td class="example">,</td>
+          <td class="example" lang="ti-er">፡</td>
+          <td class="example" lang="ti-er">,</td>
           <td class="nil"></td>
-          <td class="example">፣</td>
-          <td class="example">;</td>
-          <td class="example">፡</td>
-          <td class="example">።</td>
-          <td class="example">፦</td>
-          <td class="example">፧</td>
+          <td class="example" lang="ti-er">፣</td>
+          <td class="example" lang="ti-er">;</td>
+          <td class="example" lang="ti-er">፡</td>
+          <td class="example" lang="ti-er">።</td>
+          <td class="example" lang="ti-er">፦</td>
+          <td class="example" lang="ti-er">፧</td>
         </tr>
         <tr>
           <th>Tigrignia (Ethiopia) result</th>
-          <td class="example">፣</td>
-          <td class="example">፥</td>
-          <td class="example">,</td>
-          <td class="example">፤</td>
-          <td class="example">;</td>
-          <td class="example">፡</td>
-          <td class="example">።</td>
-          <td class="example">፦</td>
+          <td class="example" lang="ti-et">፣</td>
+          <td class="example" lang="ti-et">፥</td>
+          <td class="example" lang="ti-et">,</td>
+          <td class="example" lang="ti-et">፤</td>
+          <td class="example" lang="ti-et">;</td>
+          <td class="example" lang="ti-et">፡</td>
+          <td class="example" lang="ti-et">።</td>
+          <td class="example" lang="ti-et">፦</td>
           <td class="nil"></td>
         </tr>
       </tbody>

--- a/keyboards/h/tigrigna/index.php
+++ b/keyboards/h/tigrigna/index.php
@@ -203,7 +203,7 @@
           <kbd>a</kbd>
           <kbd>m</kbd>
           produces:
-          <span class="example">ሰላም</span>
+          <span class="example" lang="am">ሰላም</span>
           <br>
           Typing
           <kbd>T</kbd>
@@ -217,11 +217,11 @@
           <kbd>l</kbd>
           <kbd>N</kbd>
           produces:
-          <span class="example">ጤናይስጥልኝ</span>
+          <span class="example" lang="am">ጤናይስጥልኝ</span>
         </li>
         <li>
           Ge'ez default punctuation with Western default space. (Ge'ez space '
-          <span class="example">፡</span>
+          <span class="example" lang="am">፡</span>
           ' available with
           <kbd>SHIFT</kbd>
           +
@@ -238,13 +238,13 @@
     <span class="question">What is the difference between Tigrigna (Eritrea) and Tigrigna (Ethiopia)?</span>
     <span class="answer">
       The two Tigrigna keyboards differ slightly. Tigrigna (Ethiopia) includes three sets of characters which are not in Tigrigna (Eritrea) —
-      <span class="example">ሥ</span>
+      <span class="example" lang="ti-et">ሥ</span>
       ,
-      <span class="example">ኅ</span>
+      <span class="example" lang="ti-et">ኅ</span>
       ,
-      <span class="example">ፅ</span>
+      <span class="example" lang="ti-et">ፅ</span>
       — as well as the single character
-      <span class="example">ኧ</span>
+      <span class="example" lang="ti-et">ኧ</span>
       . The two keyboards also differ on the punctuation they offer:
     </span>
     <table id="ethiopic-punctuation">
@@ -288,26 +288,26 @@
         </tr>
         <tr>
           <th>Tigrigna (Eritrea) result</th>
-          <td class="example">፡</td>
-          <td class="example">,</td>
+          <td class="example" lang="ti-er">፡</td>
+          <td class="example" lang="ti-er">,</td>
           <td class="nil"></td>
-          <td class="example">፣</td>
-          <td class="example">;</td>
-          <td class="example">፡</td>
-          <td class="example">።</td>
-          <td class="example">፦</td>
-          <td class="example">፧</td>
+          <td class="example" lang="ti-er">፣</td>
+          <td class="example" lang="ti-er">;</td>
+          <td class="example" lang="ti-er">፡</td>
+          <td class="example" lang="ti-er">።</td>
+          <td class="example" lang="ti-er">፦</td>
+          <td class="example" lang="ti-er">፧</td>
         </tr>
         <tr>
           <th>Tigrignia (Ethiopia) result</th>
-          <td class="example">፣</td>
-          <td class="example">፥</td>
-          <td class="example">,</td>
-          <td class="example">፤</td>
-          <td class="example">;</td>
-          <td class="example">፡</td>
-          <td class="example">።</td>
-          <td class="example">፦</td>
+          <td class="example" lang="ti-et">፣</td>
+          <td class="example" lang="ti-et">፥</td>
+          <td class="example" lang="ti-et">,</td>
+          <td class="example" lang="ti-et">፤</td>
+          <td class="example" lang="ti-et">;</td>
+          <td class="example" lang="ti-et">፡</td>
+          <td class="example" lang="ti-et">።</td>
+          <td class="example" lang="ti-et">፦</td>
           <td class="nil"></td>
         </tr>
       </tbody>


### PR DESCRIPTION
Follows #489 for #383

This adds HTML lang tags for dedicated keyboard landing page examples. Some of the landing pages already contained lang tags.

Also, on the IPA landing page, using `und-fonipa` (even though the keyboard currently uses und-Latn)


Tagging @dyacob for checking the Amharic, Ethiopic, and Eritrea examples