### PR TITLE
fix missing closing tag on testimonial page

### DIFF
--- a/testimonials/index.md
+++ b/testimonials/index.md
@@ -213,6 +213,7 @@ title: Testimonials
 
 <p class="center">
   <span class="testimonial">"Thank you very much for making my move to a new computer smooth… Absolutely not a penny wasted in purchasing your software."</span>
+</p>
 
 #### Dawn Jacob - March 2012 {.caption}
 


### PR DESCRIPTION
I noticed the bottom of the testimonial page didn't render because of a missing `</p>` tag.