### PR TITLE
fix: exclude /donate from broken link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   [pull_request]
 jobs:
 
@@ -34,7 +34,7 @@ jobs:
       run: |
         set +e;
         set +o pipefail;
-        npx broken-link-checker http://localhost:8053/_test --ordered --recursive --host-requests 50 -e --filter-level 3 | \
+        npx broken-link-checker http://localhost:8053/_test --ordered --recursive --host-requests 50 -e --filter-level 3 --exclude '*/donate' | \
           grep -E "BROKEN|Getting links from" | \
           grep -B 1 "BROKEN"
         exit ${PIPESTATUS[0]}

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ function test_docker_container() {
   echo "---- Testing links ----"
   set +e;
   set +o pipefail;
-  npx broken-link-checker http://localhost:8053/_test --recursive --ordered ---host-requests 50 -e --filter-level 3 | \
+  npx broken-link-checker http://localhost:8053/_test --recursive --ordered ---host-requests 50 -e --filter-level 3 --exclude '*/donate' | \
     grep -E "BROKEN|Getting links from" | \
     grep -B 1 "BROKEN";
 

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
       "test": "vendor\\bin\\phpunit --testdox",
       "check-links": [
         "Composer\\Config::disableProcessTimeout",
-        "npx broken-link-checker http://keyman.com.localhost --ordered --recursive --host-requests 10 -e --filter-level 3"
+        "npx broken-link-checker http://keyman.com.localhost --ordered --recursive --host-requests 10 -e --filter-level 3 --exclude '*/donate'"
       ],
       "check-docker-links": [
         "Composer\\Config::disableProcessTimeout",
-        "npx broken-link-checker http://localhost:8053 --ordered --recursive --host-requests 10 -e --filter-level 3"
-      ],      
+        "npx broken-link-checker http://localhost:8053 --ordered --recursive --host-requests 10 -e --filter-level 3 --exclude '*/donate'"
+      ],
       "lint": "find . -name '*.php' | grep -v '/vendor/' | xargs -n 1 -d '\\n' php -l"
     }
 }


### PR DESCRIPTION
/donate redirects to another site that gives a 403 forbidden response to bots, which breaks the link checker. So just exclude it.

Fixes: #488