### PR TITLE
fix: Handle optional `language` tag in header

### DIFF
--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -26,7 +26,13 @@ class Head {
         $fields->js = [];
       }
 ?><!DOCTYPE html>
-<html lang="<?= $fields->language ?>">
+<?php
+  if (!empty($fields->language)) {
+    echo "<html lang='$fields->language'>";
+  } else {
+    echo "<html>";
+  }
+?>
 <head>
   <meta charset="utf-8">
   <?php

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -52,6 +52,9 @@
     if(isset($args['description'])) {
       $description = $args['description'];
     }
+    if(isset($args['language'])) {
+      $language = $args['language'];
+    }
     if(isset($args['css'])){
       $css = array();
       foreach($args['css'] as $cssFile){
@@ -85,6 +88,7 @@
     if(isset($title)) $head['title'] = $title;
     if(isset($description)) $head['description'] = $description;
     if(isset($favicon)) $head['favicon'] = $favicon;
+    if(isset($language)) $head['language'] = $language;
     if(isset($css)) $head['css'] = $css;
     if(isset($js)) $head['js'] = $js;
     \Keyman\Site\com\keyman\templates\Head::render($head);


### PR DESCRIPTION
Follows #489 fixes #496 and fixes KEYMAN-COM-1CX

where `$fields->language` was undefined.

This also propagates the optional header `language` if it's set. I would expect most pages fallback to `en`
https://github.com/keymanapp/keyman.com/blob/64bfdfdeefa45c94d0e8915b174a24141ea70c7b/_includes/2020/templates/Head.php#L16-L18

