### PR TITLE
fix: Add descriptions for dedicated keyboard landing pages

### DIFF
--- a/keyboards/h/amharic/index.php
+++ b/keyboards/h/amharic/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Amharic | አማርኛ ይጻፉ',
-    'description' => 'Keyman keyboards for Amharic and other Ethiopic languages',
+    'description' => 'Free and open source Amharic and Ethiopic keyboard layouts for Windows, macOS, Linux, Android, iOS and web',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/amharic/index.php
+++ b/keyboards/h/amharic/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Amharic | አማርኛ ይጻፉ',
+    'description' => 'Keyman keyboards for Amharic and other Ethiopic languages',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/burmese/index.php
+++ b/keyboards/h/burmese/index.php
@@ -6,7 +6,7 @@
 
   $head_options = [
     'title' =>'Burmese Keyboards',
-    'description' => 'Keyman keyboards for Burmese (Myanmar)'
+    'description' => 'Free and open source Burmese (Myanmar) keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Based on WinMyanmar and Myanmar3 layouts'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/burmese/index.php
+++ b/keyboards/h/burmese/index.php
@@ -5,7 +5,8 @@
   use Keyman\Site\Common\KeymanHosts;
 
   $head_options = [
-    'title' =>'Burmese Keyboards'
+    'title' =>'Burmese Keyboards',
+    'description' => 'Keyman keyboards for Burmese (Myanmar)'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/cameroon/index.php
+++ b/keyboards/h/cameroon/index.php
@@ -6,7 +6,7 @@
 
   $head_options = [
     'title' =>'Cameroon Keyboards',
-    'description' => 'Keyman keyboards for Cameroon: QWERTY or AZERTY'
+    'description' => 'Free and open source Cameroon keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Available for QWERTY (US) and AZERTY (French) layouts.'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/cameroon/index.php
+++ b/keyboards/h/cameroon/index.php
@@ -5,7 +5,8 @@
   use Keyman\Site\Common\KeymanHosts;
 
   $head_options = [
-    'title' =>'Cameroon Keyboards'
+    'title' =>'Cameroon Keyboards',
+    'description' => 'Keyman keyboards for Cameroon: QWERTY or AZERTY'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/greek/index.php
+++ b/keyboards/h/greek/index.php
@@ -6,7 +6,7 @@
 
   $head_options = [
     'title' =>'Classical Greek Keyboards',
-    'description' => 'Keyman keyboards for Classical (Biblical) and Polytonic Greek'
+    'description' => 'Free and open source Classical (Biblical) and Polytonic Greek keyboard layouts for Windows, macOS, Linux, Android, iOS and web.'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/greek/index.php
+++ b/keyboards/h/greek/index.php
@@ -5,7 +5,8 @@
   use Keyman\Site\Common\KeymanHosts;
 
   $head_options = [
-    'title' =>'Classical Greek Keyboards'
+    'title' =>'Classical Greek Keyboards',
+    'description' => 'Keyman keyboards for Classical (Biblical) and Polytonic Greek'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/ipa/index.php
+++ b/keyboards/h/ipa/index.php
@@ -6,7 +6,7 @@
 
   $head_options = [
     'title' =>'IPA Keyboards',
-    'description' => 'Keyman keyboards for IPA - International Phonetic Alphabet'
+    'description' => 'Free and open source IPA (International Phonetic Alphabet) keyboard layouts for Windows, macOS, Linux, Android, iOS and web'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/ipa/index.php
+++ b/keyboards/h/ipa/index.php
@@ -5,7 +5,8 @@
   use Keyman\Site\Common\KeymanHosts;
 
   $head_options = [
-    'title' =>'IPA Keyboards'
+    'title' =>'IPA Keyboards',
+    'description' => 'Keyman keyboards for IPA - International Phonetic Alphabet'
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/sinhala/garp/index.php
+++ b/keyboards/h/sinhala/garp/index.php
@@ -4,6 +4,7 @@
   // Required
   head([
     'title' =>'Keyman for Sinhala',
+    'description' => 'Keyman keyboard for Garp Sinhala',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/sinhala/garp/index.php
+++ b/keyboards/h/sinhala/garp/index.php
@@ -4,7 +4,7 @@
   // Required
   head([
     'title' =>'Keyman for Sinhala',
-    'description' => 'Keyman keyboard for Garp Sinhala',
+    'description' => 'Free and open source Garp Sinhala keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Phonetic keyboard for QWERTY layout',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/sinhala/sipon/index.php
+++ b/keyboards/h/sinhala/sipon/index.php
@@ -4,6 +4,7 @@
   // Required
   head([
     'title' =>'Keyman for Sinhala',
+    'description' => 'Keyman keyboard for Sipon Phonetic Sinhala',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/sinhala/sipon/index.php
+++ b/keyboards/h/sinhala/sipon/index.php
@@ -4,7 +4,7 @@
   // Required
   head([
     'title' =>'Keyman for Sinhala',
-    'description' => 'Keyman keyboard for Sipon Phonetic Sinhala',
+    'description' => 'Free and open source Sipon Phonetic Sinhala keyboard layouts for Windows, macOS, Linux, Android, iOS and web. For QWERTY layouts',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/anjal-paangu/index.php
+++ b/keyboards/h/tamil/anjal-paangu/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Anjal Paangu',
+    'description' => 'Keyman keyboard for Tamil Anjal Paangu',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/anjal-paangu/index.php
+++ b/keyboards/h/tamil/anjal-paangu/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Anjal Paangu',
-    'description' => 'Keyman keyboard for Tamil Anjal Paangu',
+    'description' => 'Free and open source Tamil Anjal Paangu keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Popularly used in eKalappai and follows the Anjal phonetic standard.',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/index.php
+++ b/keyboards/h/tamil/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil99',
+    'description' => 'Keyman keyboard for Tamil that follows Tamil99 standard',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/index.php
+++ b/keyboards/h/tamil/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil99',
-    'description' => 'Keyman keyboard for Tamil that follows Tamil99 standard',
+    'description' => 'Free and open source Tamil keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Popularly used in eKalappai, this keyboard follows the Tamil99 standard recommended by the Tamil Nadu government',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/isis/index.php
+++ b/keyboards/h/tamil/isis/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil (ISIS)',
-    'description' => 'Keyman keyboard for Tamil (ISIS)',
+    'description' => 'Free and open source Tmail keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Phonetic (Romanised) layouts that come in the ISIS keyboard package',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/isis/index.php
+++ b/keyboards/h/tamil/isis/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil (ISIS)',
+    'description' => 'Keyman keyboard for Tamil (ISIS)',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/new-typewriter/index.php
+++ b/keyboards/h/tamil/new-typewriter/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil New Typewriter',
-    'description' => 'Keyman keyboard for Tamil New Typrwriter',
+    'description' => 'Free and open source Tamil keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Popularly used in eKalappai, this keyboard follows the standard Tamil typewriter layout',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/new-typewriter/index.php
+++ b/keyboards/h/tamil/new-typewriter/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil New Typewriter',
+    'description' => 'Keyman keyboard for Tamil New Typrwriter',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/suratha-bamuni/index.php
+++ b/keyboards/h/tamil/suratha-bamuni/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Suratha Bamuni',
+    'description' => 'Keyman keyboard for Tamil Suratha Bamuni',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/suratha-bamuni/index.php
+++ b/keyboards/h/tamil/suratha-bamuni/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Suratha Bamuni',
-    'description' => 'Keyman keyboard for Tamil Suratha Bamuni',
+    'description' => 'Free and open source Tamil keyboard layouts for Windows, macOS, Linux, Android, iOS and web. Popularly used in eKalappai, this keyboard follows the Bamini standard common in Sri Lanka, based on old Tamil typewriters',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/visual-media-modular/index.php
+++ b/keyboards/h/tamil/visual-media-modular/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Visual Media (Modular)',
-    'description' => 'Keyman keyboard for Tamil Visual Media (Modular)',
+    'description' => 'Free and open source Tamil keyboard layouts for Windows, macOS, Linux, Android, iOS and web. This follows the popular Modular layout standard.',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/visual-media-modular/index.php
+++ b/keyboards/h/tamil/visual-media-modular/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Visual Media (Modular)',
+    'description' => 'Keyman keyboard for Tamil Visual Media (Modular)',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/visual-media-typewriter/index.php
+++ b/keyboards/h/tamil/visual-media-typewriter/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Visual Media (Typewriter)',
+    'description' => 'Keyman keyboard for Tamil Visual Media (Typewriter)',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tamil/visual-media-typewriter/index.php
+++ b/keyboards/h/tamil/visual-media-typewriter/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tamil Visual Media (Typewriter)',
-    'description' => 'Keyman keyboard for Tamil Visual Media (Typewriter)',
+    'description' => 'Free and open source Tamil keyboard layouts for Windows, macOS, Linux, Android, iOS and web. This follows the standard Tamil typewriter layout',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tibetan/index.php
+++ b/keyboards/h/tibetan/index.php
@@ -6,7 +6,7 @@
 
   $head_options = [
     'title' =>'Tibetan Keyboards',
-    'description' => 'Keyman keyboards for Tibetan',
+    'description' => 'Free and open source Tibetan keyboard layouts for Windows, macOS, Linux, Android, iOS and web',
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/tibetan/index.php
+++ b/keyboards/h/tibetan/index.php
@@ -5,7 +5,8 @@
   use Keyman\Site\Common\KeymanHosts;
 
   $head_options = [
-    'title' =>'Tibetan Keyboards'
+    'title' =>'Tibetan Keyboards',
+    'description' => 'Keyman keyboards for Tibetan',
   ];
 
   if($embed != 'none') {

--- a/keyboards/h/tigrigna/eritrean.php
+++ b/keyboards/h/tigrigna/eritrean.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tigrigna (Eritrea)',
+    'description' => 'Keyman keyboard for Tigrigna (Eritrea)',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tigrigna/eritrean.php
+++ b/keyboards/h/tigrigna/eritrean.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tigrigna (Eritrea)',
-    'description' => 'Keyman keyboard for Tigrigna (Eritrea)',
+    'description' => 'Free and open source Tigrigna (Eritrea) keyboard layouts for Windows, macOS, Linux, Android, iOS and web.',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tigrigna/index.php
+++ b/keyboards/h/tigrigna/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tigrigna (Ethiopia)',
-    'description' => 'Keyman keyboard for Tigrigna (Ethiopia)',
+    'description' => 'Free and open source Tigrigna (Ethiopia) keyboard layouts for Windows, macOS, Linux, Android, iOS and web',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/tigrigna/index.php
+++ b/keyboards/h/tigrigna/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Tigrigna (Ethiopia)',
+    'description' => 'Keyman keyboard for Tigrigna (Ethiopia)',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/urdu/index.php
+++ b/keyboards/h/urdu/index.php
@@ -6,7 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Urdu',
-    'description' => 'Keyman keyboard for Urdu',
+    'description' => 'Free and open source Urdu keyboard layouts for Windows, macOS, Linux, Android, iOS and web',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);

--- a/keyboards/h/urdu/index.php
+++ b/keyboards/h/urdu/index.php
@@ -6,6 +6,7 @@
   // Required
   head([
     'title' =>'Keyman for Urdu',
+    'description' => 'Keyman keyboard for Urdu',
     'css' => ['template.css','index.css'],
     'showMenu' => true
   ]);


### PR DESCRIPTION
Addresses part of #383

Follows #486 for adding metadata descriptions to the dedicated keyboard landing pages.
