### PR TITLE
fix: Check languageName exists before printing in keyboard details

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -518,11 +518,13 @@ END;
                         echo " <a id='expand-languages' href='#expand-languages'>Expand $count more &gt;&gt;</a>";
                         echo "<a id='collapse-languages' href='#collapse-languages'>&lt;&lt; Collapse</a> <span class='expand-languages'>";
                       }
-                      echo
-                        "<a href='/keyboards?q=l:id:".htmlspecialchars(rawurlencode($bcp47)).
-                        "' title='".htmlspecialchars($bcp47).": ".htmlspecialchars($detail->displayName)."'>" .
-                        (!strcasecmp($bcp47, self::$bcp47) ? "<mark>".htmlspecialchars($detail->languageName)."</mark>" : htmlspecialchars($detail->languageName)).
-                        "</a> ";
+                      if (array_key_exists('languageName', $detail)) {
+                        echo
+                          "<a href='/keyboards?q=l:id:".htmlspecialchars(rawurlencode($bcp47)).
+                          "' title='".htmlspecialchars($bcp47).": ".htmlspecialchars($detail->displayName)."'>" .
+                          (!strcasecmp($bcp47, self::$bcp47) ? "<mark>".htmlspecialchars($detail->languageName)."</mark>" : htmlspecialchars($detail->languageName)).
+                          "</a> ";
+                      }    
                       $n++;
                     }
                     if($n >= 3) {


### PR DESCRIPTION
I was testing #502 locally and saw this PHP error on
http://keyman.com.localhost/keyboards/sil_ipa

![image](https://github.com/user-attachments/assets/69b7d0a8-cf8f-4162-b2c6-e6500fc1fd0c)

This adds a check for `languageName` before printing them in keyboard details.
