### PR TITLE
fix: use property_exists instead of array_key_exists (continued)

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -94,7 +94,7 @@
 
     protected static function map_license($s) {
       $license_map = ['mit' => 'MIT'];
-      return array_key_exists($s, $license_map) ? $license_map[$s] : $s;
+      return property_exists($license_map, $s) ? $license_map[$s] : $s;
     }
 
     protected static function download_box($platform) {
@@ -205,7 +205,7 @@ END;
         self::$keyboardPlatforms = "<span class='platforms'>";
         $vars = get_object_vars(self::$keyboard->platformSupport);
         foreach ($vars as $var => $value) {
-          if ($value != 'none' && array_key_exists($var, $platformTitles)) {
+          if ($value != 'none' && property_exists($platformTitles, $var)) {
             self::$keyboardPlatforms .= "<span class='platform-$var'>{$platformTitles[$var]}</span>";
           }
         }

--- a/_includes/includes/ui/legacy-keyboard-details.php
+++ b/_includes/includes/ui/legacy-keyboard-details.php
@@ -74,7 +74,7 @@
 
     protected static function map_license($s) {
       $license_map = ['mit' => 'MIT'];
-      return array_key_exists($s, $license_map) ? $license_map[$s] : $s;
+      return property_exists($license_map, $s) ? $license_map[$s] : $s;
     }
 
     protected static function download_box($url, $title, $description, $class, $linktitle, $platform, $mode='standalone') {
@@ -323,7 +323,7 @@ END;
         self::$keyboardPlatforms = '';
         $vars = get_object_vars(self::$keyboard->platformSupport);
         foreach ($vars as $var => $value) {
-          if ($value != 'none' && array_key_exists($var, $platformTitles)) {
+          if ($value != 'none' && property_exists($platformTitles, $var)) {
             self::$keyboardPlatforms .= (self::$keyboardPlatforms == '' ? '' : ', ') . $platformTitles[$var];
           }
         }
@@ -441,7 +441,7 @@ END;
         "Android" => "self::WriteAndroidBoxes"
       );
 
-      $text = (isset($pageDevice) && array_key_exists($pageDevice, $deviceboxfuncs)) ? $deviceboxfuncs[$pageDevice] : '';
+      $text = (isset($pageDevice) && property_exists($deviceboxfuncs, $pageDevice)) ? $deviceboxfuncs[$pageDevice] : '';
       $webtext = self::WriteWebBoxes();
 
       if ($text) {


### PR DESCRIPTION
Follows #513 and replaces the rest of the deprecated references of `array_key_exists` with `property_exists`.

Involves swapping parameters...