### PR TITLE
feat: Configure `en_US` locale in Dockerfile 📡

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,21 @@ COPY resources/keyman-site.conf /etc/apache2/conf-available/
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 RUN chown -R www-data:www-data /var/www/html/
 
+# Because the base Docker image doesn't include locales, install these to generate locale files.
+# gettext needed to compile .po files to .mo with msgfmt
+RUN apt-get update && apt-get install -y \
+    locales \ 
+    gettext
+
+# Install PHP-extension gettext for localization at runtime
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-enable gettext
+
+# Only enable en_US locale in /etc/locale.gen
+# PHP will use textdomain() to specify "localization" .mo files
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && update-locale
+
 COPY --from=composer-builder /composer/vendor /var/www/vendor
 RUN a2enmod rewrite headers; a2enconf keyman-site

--- a/_includes/locale/README.md
+++ b/_includes/locale/README.md
@@ -1,0 +1,45 @@
+### Setup for Localization
+
+[init-container.sh](../../resources/init-container.sh) contains steps for the Docker container to compile .po files to .mo files which PHP uses for `gettext()`.
+
+If you want to compile the files on your host machine, install `gettext`.
+
+```bash
+sudo apt-get install gettext
+```
+
+### Adding locales
+
+The Docker image has the "en_US.UTF-8" locale enabled in `/etc/locale.gen`
+We'll use `textdomain` to specify filenames for "switching" localization. 
+The filenames will include the `%locale%` as defined in the [crowdin.com project](https://crowdin.com/project/keymancom).
+
+Note: the details below will get refactored to use a Locale.php class
+
+In the example below, the English file `keyboards-en.po` is copied to `keyboards-fr-FR.po` for French.
+
+1. In `/_includes/locale/en/LC_MESSAGES/`
+    * Copy `keyboards-en.po` file and rename to the `keyboards-fr-FR.po`.
+    * Translate/upload the new .po file to crowdin
+    * Convert .po file to .mo with the following
+
+```bash
+msgfmt keyboards-fr-FR.po --output-file=keyboards-fr-FR.mo
+```
+
+(The container handles the msgfmt step in init-container.sh)
+
+2. Add the file to the PHP (path is relative the PHP file)
+
+```php
+bindtextdomain("keyboards-fr-FR", "../_includes/locale");
+```
+
+3. To use French,
+```php
+textdomain('keyboards-fr-FR');
+```
+
+----
+
+For formatted string, use the PHP wrapper [`_s(msgstr, $args)`](./locale.php).

--- a/_includes/locale/en/LC_MESSAGES/.gitignore
+++ b/_includes/locale/en/LC_MESSAGES/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated files from msgfmt
+*.mo

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -20,7 +20,7 @@ find . -type f -name '*.mo' -delete
 # Compile .po to .mo localization files
 for filename in `find . -type f -name "*.po"`; do
   # Remove the .po extension
-  base_name=`echo ${filename} | sed 's/\.[^.]*$//'`
+  base_name="${filename%.po}"
   msgfmt "${base_name}.po" --output-file="${base_name}".mo
   retVal=$?
   if [[ ${retVal} -ne 0 ]]; then

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -10,3 +10,20 @@ else
   echo "Skip Generating CDN and clean CDN cache"
   rm -rf cdn/deploy
 fi
+
+echo "---- Generating .mo localization files ----"
+cd _includes/locale/en/LC_MESSAGES/
+
+# cleanup previous .mo files
+find . -type f -name '*.mo' -delete
+
+# Compile .po to .mo localization files
+for filename in `find . -type f -name "*.po"`; do
+  # Remove the .po extension
+  base_name=`echo ${filename} | sed 's/\.[^.]*$//'`
+  msgfmt "${base_name}.po" --output-file="${base_name}".mo
+  retVal=$?
+  if [[ ${retVal} -ne 0 ]]; then
+    exit 1
+  fi
+done


### PR DESCRIPTION
Some prep work towards #384 of localizing the keyboard search

This brings in the Dockerfile updates from #500 to set up the en_US locale and install the PHP gettext.

The locale/README.md is just capturing an initial setup and will be refined in future PR's.

The .po localization files will also be added on separate PR's and reside in /_includes/locale/en/LC_MESSAGES/

