### PR TITLE
fix: restore path in init-container.sh 📡

### DIFF
--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -27,3 +27,5 @@ for filename in `find . -type f -name "*.po"`; do
     exit 1
   fi
 done
+
+cd ../../../../


### PR DESCRIPTION
Missed this line in #517 to restore the path when init-container.sh is done

