### PR TITLE
feat: Add Locale.php class to set current locale 📡

### DIFF
--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -3,11 +3,9 @@
 
   // *Don't* use autoloader here because of potential side-effects in older pages
   require_once(__DIR__ . '/../2020/Util.php');
-  //require_once(__DIR__ . '/../locale/Locale.php');
+  require_once(__DIR__ . '/../locale/Locale.php');
   require_once(__DIR__ . '/../2020/KeymanVersion.php');
   require_once(__DIR__ . '/../2020/templates/Head.php');
-
-  use Keyman\Site\com\keyman\Locale;
 
   function template_finish($foot) {
     //ob_end_flush();

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -3,8 +3,11 @@
 
   // *Don't* use autoloader here because of potential side-effects in older pages
   require_once(__DIR__ . '/../2020/Util.php');
+  //require_once(__DIR__ . '/../locale/Locale.php');
   require_once(__DIR__ . '/../2020/KeymanVersion.php');
   require_once(__DIR__ . '/../2020/templates/Head.php');
+
+  use Keyman\Site\com\keyman\Locale;
 
   function template_finish($foot) {
     //ob_end_flush();

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -4,32 +4,21 @@
   namespace Keyman\Site\com\keyman;
 
   class Locale {
-    private $currentLocale;
-
-    private static $instance;
-
-    public static function Instance(): Locale {
-      if(!self::$instance)
-        self::Rebuild();
-      return self::$instance;
-    }
+    private static $currentLocale = 'en';
 
     /**
      * Return the current locale. Fallback to 'en'
+     * @return $currentLocale
      */
-    static function CurrentLocale() {
-      return $this->currentLocale;
+    public static function currentLocale() {
+      return Locale::$currentLocale;
     }
 
-    public static function Rebuild() {
-      self::$instance = new Locale();
-    }
-
-    public function overrideCurrentLocale($locale) {
-      $this->currentLocale = $locale;
-    }
-
-    function __construct() {
-      $this->currentLocale = 'en';
+    /**
+     * Override the current locale
+     * @param $locale - the new current locale
+     */
+    public static function overrideCurrentLocale($locale) {
+      Locale::$currentLocale = $locale;
     }
   }

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -1,0 +1,35 @@
+<?php
+  declare(strict_types=1);
+
+  namespace Keyman\Site\com\keyman;
+
+  class Locale {
+    private $currentLocale;
+
+    private static $instance;
+
+    public static function Instance(): Locale {
+      if(!self::$instance)
+        self::Rebuild();
+      return self::$instance;
+    }
+
+    /**
+     * Return the current locale. Fallback to 'en'
+     */
+    static function CurrentLocale() {
+      return $this->currentLocale;
+    }
+
+    public static function Rebuild() {
+      self::$instance = new Locale();
+    }
+
+    public function overrideCurrentLocale($locale) {
+      $this->currentLocale = $locale;
+    }
+
+    function __construct() {
+      $this->currentLocale = 'en';
+    }
+  }

--- a/_includes/locale/README.md
+++ b/_includes/locale/README.md
@@ -42,4 +42,4 @@ textdomain('keyboards-fr-FR');
 
 ----
 
-For formatted string, use the PHP wrapper [`_s(msgstr, $args)`](./locale.php).
+For formatted string, use the PHP wrapper [`_s(msgstr, $args)`](./Locale.php).

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -7,6 +7,7 @@
   use Keyman\Site\com\keyman\templates\Menu;
   use Keyman\Site\com\keyman\templates\Body;
   use Keyman\Site\com\keyman\templates\Foot;
+  use Keyman\Site\com\keyman\Locale;
 
   $head_options = [
     'title' =>'Keyboard Search',
@@ -70,8 +71,6 @@
       <li>You can apply prefixes <code>k:</code> (keyboards), <code>l:</code> (languages), <code>s:</code> (scripts, writing systems)
       or <code>c:</code> (countries) to filter your search results. For example <code>c:thailand</code> searches for keyboards for languages used in Thailand.</li>
       <li>Use prefix <code>l:id:</code> to search for a BCP 47 language tag, for example <code>l:id:ti-et</code> searches for Tigrigna (Ethiopia).</li>
-      <li>Current locale is <?= Locale::Instance()->getCurrentLocale() ?></li>";
-      ?>
     </ul>
   </div>
 </div>

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -70,6 +70,8 @@
       <li>You can apply prefixes <code>k:</code> (keyboards), <code>l:</code> (languages), <code>s:</code> (scripts, writing systems)
       or <code>c:</code> (countries) to filter your search results. For example <code>c:thailand</code> searches for keyboards for languages used in Thailand.</li>
       <li>Use prefix <code>l:id:</code> to search for a BCP 47 language tag, for example <code>l:id:ti-et</code> searches for Tigrigna (Ethiopia).</li>
+      <li>Current locale is <?= Locale::Instance()->getCurrentLocale() ?></li>";
+      ?>
     </ul>
   </div>
 </div>

--- a/keyboards/session.php
+++ b/keyboards/session.php
@@ -31,8 +31,8 @@
   $embed_android = $embed == 'android';
   $embed_ios = $embed == 'ios';
 
-  if(isset($_REQUEST['locale'])) {
-    \Keyman\Site\com\keyman\Locale::overrideCurrentLocale($_REQUEST['locale']);
+  if(isset($_REQUEST['lang'])) {
+    \Keyman\Site\com\keyman\Locale::overrideCurrentLocale($_REQUEST['lang']);
   }
 
   if($embed != 'none') {

--- a/keyboards/session.php
+++ b/keyboards/session.php
@@ -31,6 +31,10 @@
   $embed_android = $embed == 'android';
   $embed_ios = $embed == 'ios';
 
+  if(isset($_Request['locale'])) {
+    Locale::Instance()->overrideCurrentLocale($_REQUEST['locale']);
+  }
+
   if($embed != 'none') {
     // Poor man's session control because IE embedded in downlevel Windows destroys cookie support by
     // default, including in existing versions of Keyman.

--- a/keyboards/session.php
+++ b/keyboards/session.php
@@ -33,7 +33,10 @@
 
   if(isset($_REQUEST['lang'])) {
     \Keyman\Site\com\keyman\Locale::overrideCurrentLocale($_REQUEST['lang']);
+  } else if (isset($_SESSION['lang'])) {
+    \Keyman\Site\com\keyman\Locale::overrideCurrentLocale($_SESSION['lang']);
   }
+  $_SESSION['lang'] = \Keyman\Site\com\keyman\Locale::currentLocale();
 
   if($embed != 'none') {
     // Poor man's session control because IE embedded in downlevel Windows destroys cookie support by

--- a/keyboards/session.php
+++ b/keyboards/session.php
@@ -31,8 +31,8 @@
   $embed_android = $embed == 'android';
   $embed_ios = $embed == 'ios';
 
-  if(isset($_Request['locale'])) {
-    Locale::Instance()->overrideCurrentLocale($_REQUEST['locale']);
+  if(isset($_REQUEST['locale'])) {
+    \Keyman\Site\com\keyman\Locale::overrideCurrentLocale($_REQUEST['locale']);
   }
 
   if($embed != 'none') {


### PR DESCRIPTION
Continues #384

This starts a Locale.php class which will expand to handle pointing to the localized.po files.
For now, it allows the current locale to be set with a query parameter like `lang=fr-FR` (previously was `locale`)

And confirmed with test code on keyboards/index.php
```php
      <li>Current locale is <?= Locale::currentLocale() ?></li>      
```
