### PR TITLE
feat: Localize keyboards index page 📡

### DIFF
--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -18,11 +18,13 @@
     }
 
     /**
-     * Override the current locale
+     * Validate and override the current locale
      * @param $locale - the new current locale (xx-YY as specified in crowdin %locale%)
      */
     public static function overrideCurrentLocale($locale) {
-      Locale::$currentLocale = $locale;
+      if (Locale::validateLocale($locale)) {
+        Locale::$currentLocale = $locale;
+      }
     }
 
     /**
@@ -32,7 +34,11 @@
      * @return true if valid locale
      */
     public static function validateLocale($locale) {
+      if(preg_match('/^[[:alpha:]]{2,3}(-[[:alpha:]]{2,3})?$/i', $locale)) {
+        return true;
+      }
 
+      return false;
     }
 
     /**

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -6,6 +6,12 @@
   class Locale {
     public const DEFAULT_LOCALE = 'en';
 
+    public const CROWDIN_LOCALES = array(
+      'en',
+      'es-ES',
+      'fr-FR'
+    );
+
     // xx-YY locale as specified in crowdin %locale%
     private static $currentLocale = Locale::DEFAULT_LOCALE;
 
@@ -34,11 +40,7 @@
      * @return true if valid locale
      */
     public static function validateLocale($locale) {
-      if(preg_match('/^[[:alpha:]]{2,3}(-[[:alpha:]]{2,3})?$/i', $locale)) {
-        return true;
-      }
-
-      return false;
+      return in_array($locale, Locale::CROWDIN_LOCALES);
     }
 
     /**
@@ -64,6 +66,36 @@
         //echo "textdomain $fullPath doesn't exist";
         return;
       }
+    }
+
+    /**
+     * Returns an array of localized strings from the specified $domain-locale.po file
+     * for the current locale.
+     * @param $domain - base filename of the .po files (not including -xx-YY locale)
+     * @param $strings - Array of msgid's in the .po files
+     * @return Array of localized strings for the current locale
+     */
+    public static function localize($domain, $strings) {
+      foreach(Locale::CROWDIN_LOCALES as $l) {
+        if ($l == Locale::DEFAULT_LOCALE) {
+          // Skip English
+          continue;
+        }
+
+        bindtextdomain("$domain-$l", __DIR__);
+      }
+
+      $previousTextDomain = textdomain(NULL);
+      Locale::setTextDomain($domain);
+  
+      $result = [];
+      foreach($strings as $s) {
+        $result[$s] = _($s);
+      }
+  
+      // Restore textdomain
+      textdomain($previousTextDomain);
+      return $result;
     }
 
     /**

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -69,13 +69,11 @@
     }
 
     /**
-     * Returns an array of localized strings from the specified $domain-locale.po file
+     * Reads localized strings from the specified $domain-locale.po file
      * for the current locale.
      * @param $domain - base filename of the .po files (not including -xx-YY locale)
-     * @param $strings - Array of msgid's in the .po files
-     * @return Array of localized strings for the current locale
      */
-    public static function localize($domain, $strings) {
+    public static function localize($domain) {
       foreach(Locale::CROWDIN_LOCALES as $l) {
         if ($l == Locale::DEFAULT_LOCALE) {
           // Skip English
@@ -86,16 +84,7 @@
       }
 
       $previousTextDomain = textdomain(NULL);
-      Locale::setTextDomain($domain);
-  
-      $result = [];
-      foreach($strings as $s) {
-        $result[$s] = _($s);
-      }
-  
-      // Restore textdomain
-      textdomain($previousTextDomain);
-      return $result;
+      Locale::setTextDomain($domain); 
     }
 
     /**
@@ -104,6 +93,6 @@
      * @param $args - optional remaining args to the format string
      */ 
     public static function _s($s, ...$args) {
-      return vsprintf($s, $args);
+      return vsprintf(_($s), $args);
     }
   }

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -4,7 +4,10 @@
   namespace Keyman\Site\com\keyman;
 
   class Locale {
-    private static $currentLocale = 'en';
+    public const DEFAULT_LOCALE = 'en';
+
+    // xx-YY locale as specified in crowdin %locale%
+    private static $currentLocale = Locale::DEFAULT_LOCALE;
 
     /**
      * Return the current locale. Fallback to 'en'
@@ -16,9 +19,53 @@
 
     /**
      * Override the current locale
-     * @param $locale - the new current locale
+     * @param $locale - the new current locale (xx-YY as specified in crowdin %locale%)
      */
     public static function overrideCurrentLocale($locale) {
       Locale::$currentLocale = $locale;
+    }
+
+    /**
+     * Validate $locale is an acceptable locale.
+     * Using xx-YY as specified in crowdin %locale%
+     * @param $locale - the locale to validate
+     * @return true if valid locale
+     */
+    public static function validateLocale($locale) {
+
+    }
+
+    /**
+     * Use textdomain to specify the localization file for "localization".
+     * Ignore if locale is "en" or the filename doesn't exist
+     * Filename expected to be "$basename-$locale.mo"
+     * @param $basename - base name of the .mo file to use
+     * @return current message domain
+     */
+    public static function setTextDomain($basename) {
+      // Container uses English locale, and then we use textdomain to change "localization" files
+      setLocale(LC_ALL, 'en_US.UTF-8');
+
+      if (Locale::$currentLocale == Locale::DEFAULT_LOCALE) {
+        return;
+      }
+
+      $filename = sprintf("%s-%s", $basename, Locale::$currentLocale);
+      $fullPath = sprintf("%s/en/LC_MESSAGES/%s.mo", __DIR__, $filename);
+      if(file_exists($fullPath)) {
+        return textdomain($filename);
+      } else {
+        //echo "textdomain $fullPath doesn't exist";
+        return;
+      }
+    }
+
+    /**
+     * Wrapper to format string with gettext '_(' alias and variable args
+     * @param $s - the format string
+     * @param $args - optional remaining args to the format string
+     */ 
+    public static function _s($s, ...$args) {
+      return vsprintf($s, $args);
     }
   }

--- a/_includes/locale/README.md
+++ b/_includes/locale/README.md
@@ -42,4 +42,4 @@ textdomain('keyboards-fr-FR');
 
 ----
 
-For formatted string, use the PHP wrapper [`_s(msgstr, $args)`](./Locale.php).
+For formatted string, use the PHP wrapper [`Locale::_s(msgstr, $args)`](./Locale.php).

--- a/_includes/locale/en/LC_MESSAGES/keyboards-en.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-en.po
@@ -81,5 +81,5 @@ msgid "to search for a BCP 47 language tag, for example"
 msgstr "to search for a BCP 47 language tag, for example"
 
 # Search box hint: BCP 47 language example
-msgid "searches for Tigrigna %1$sEthiopia%2$s"
-msgstr "searches for Tigrigna %1$sEthiopia%2$s"
+msgid "searches for Tigrigna (Ethiopia)"
+msgstr "searches for Tigrigna (Ethiopia)"

--- a/_includes/locale/en/LC_MESSAGES/keyboards-en.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-en.po
@@ -13,8 +13,8 @@ msgid "Keyman Keyboard Search"
 msgstr "Keyman Keyboard Search"
 
 # Keyboard search bar
-msgid "Keyboard search%s"
-msgstr "Keyboard search%s"
+msgid "Keyboard search%1$s"
+msgstr "Keyboard search%1$s"
 
 # Search bar placeholder
 msgid "Enter language or keyboard"
@@ -29,8 +29,8 @@ msgid "New search"
 msgstr "New search"
 
 # Search box prompt
-msgid "Enter the name of a keyboard or language to search for%s"
-msgstr "Enter the name of a keyboard or language to search for%s"
+msgid "Enter the name of a keyboard or language to search for%1$s"
+msgstr "Enter the name of a keyboard or language to search for%1$s"
 
 # Search box link for popular keyboards
 msgid "Popular keyboards"
@@ -53,20 +53,20 @@ msgid "You can apply prefixes"
 msgstr "You can apply prefixes"
 
 # (keyboards)
-msgid "%skeyboards%s"
-msgstr "%skeyboards%s"
+msgid "%1$skeyboards%2$s"
+msgstr "%1$skeyboards%2$s"
 
 # (languages)
-msgid "%slanguages%s"
-msgstr "%slanguages%s"
+msgid "%1$slanguages%2$s"
+msgstr "%1$slanguages%2$s"
 
 # (scripts, writing systems) or...
-msgid "%sscripts, writing systems%s or"
-msgstr "%sscripts, writing systems%s or"
+msgid "%1$sscripts, writing systems%2$s or"
+msgstr "%1$sscripts, writing systems%2$s or"
 
 # (countries) to filter your search results...
-msgid "%scountries%s to filter your search results. For example"
-msgstr "%scountries%s to filter your search results. For example"
+msgid "%1$scountries%2$s to filter your search results. For example"
+msgstr "%1$scountries%2$s to filter your search results. For example"
 
 # Search box hint: example of country search
 msgid "searches for keyboards for languages used in Thailand."
@@ -81,5 +81,5 @@ msgid "to search for a BCP 47 language tag, for example"
 msgstr "to search for a BCP 47 language tag, for example"
 
 # Search box hint: BCP 47 language example
-msgid "searches for Tigrigna %sEthiopia%s"
-msgstr "searches for Tigrigna %sEthiopia%s"
+msgid "searches for Tigrigna %1$sEthiopia%2$s"
+msgstr "searches for Tigrigna %1$sEthiopia%2$s"

--- a/_includes/locale/en/LC_MESSAGES/keyboards-en.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-en.po
@@ -1,0 +1,85 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+# Default English strings for keyboards/index.php
+
+# Page Title
+msgid "Keyboard Search"
+msgstr "Keyboard Search"
+
+# Page Description
+msgid "Keyman Keyboard Search"
+msgstr "Keyman Keyboard Search"
+
+# Keyboard search bar
+msgid "Keyboard search%s"
+msgstr "Keyboard search%s"
+
+# Search bar placeholder
+msgid "Enter language or keyboard"
+msgstr "Enter language or keyboard"
+
+# Search Button Value
+msgid "Search"
+msgstr "Search"
+
+# Link to start a new keyboard search
+msgid "New search"
+msgstr "New search"
+
+# Search box prompt
+msgid "Enter the name of a keyboard or language to search for%s"
+msgstr "Enter the name of a keyboard or language to search for%s"
+
+# Search box link for popular keyboards
+msgid "Popular keyboards"
+msgstr "Popular keyboards"
+
+# Search box link for all Keyman keyboards
+msgid "All keyboards"
+msgstr "All keyboards"
+
+# Search box hint: List header
+msgid "Hints"
+msgstr "Hints"
+
+# Search box hint: Description
+msgid "The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names."
+msgstr "The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names."
+
+# Search box hint: available prefixes to use in the search
+msgid "You can apply prefixes"
+msgstr "You can apply prefixes"
+
+# (keyboards)
+msgid "%skeyboards%s"
+msgstr "%skeyboards%s"
+
+# (languages)
+msgid "%slanguages%s"
+msgstr "%slanguages%s"
+
+# (scripts, writing systems) or...
+msgid "%sscripts, writing systems%s or"
+msgstr "%sscripts, writing systems%s or"
+
+# (countries) to filter your search results...
+msgid "%scountries%s to filter your search results. For example"
+msgstr "%scountries%s to filter your search results. For example"
+
+# Search box hint: example of country search
+msgid "searches for keyboards for languages used in Thailand."
+msgstr "searches for keyboards for languages used in Thailand."
+
+# Search box hint: BCP 47 prefix
+msgid "Use prefix"
+msgstr "Use prefix"
+
+# Seach box hint: BCP 47 language example
+msgid "to search for a BCP 47 language tag, for example"
+msgstr "to search for a BCP 47 language tag, for example"
+
+# Search box hint: BCP 47 language example
+msgid "searches for Tigrigna %sEthiopia%s"
+msgstr "searches for Tigrigna %sEthiopia%s"

--- a/_includes/locale/en/LC_MESSAGES/keyboards-en.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-en.po
@@ -13,8 +13,8 @@ msgid "Keyman Keyboard Search"
 msgstr "Keyman Keyboard Search"
 
 # Keyboard search bar
-msgid "Keyboard search%1$s"
-msgstr "Keyboard search%1$s"
+msgid "Keyboard search:"
+msgstr "Keyboard search:"
 
 # Search bar placeholder
 msgid "Enter language or keyboard"
@@ -53,20 +53,20 @@ msgid "You can apply prefixes"
 msgstr "You can apply prefixes"
 
 # (keyboards)
-msgid "%1$skeyboards%2$s"
-msgstr "%1$skeyboards%2$s"
+msgid "(keyboards)"
+msgstr "(keyboards)"
 
 # (languages)
-msgid "%1$slanguages%2$s"
-msgstr "%1$slanguages%2$s"
+msgid "(languages)"
+msgstr "(languages)"
 
 # (scripts, writing systems) or...
-msgid "%1$sscripts, writing systems%2$s or"
-msgstr "%1$sscripts, writing systems%2$s or"
+msgid "(scripts, writing systems) or"
+msgstr "(scripts, writing systems) or"
 
 # (countries) to filter your search results...
-msgid "%1$scountries%2$s to filter your search results. For example"
-msgstr "%1$scountries%2$s to filter your search results. For example"
+msgid "(countries) to filter your search results. For example"
+msgstr "(countries) to filter your search results. For example"
 
 # Search box hint: example of country search
 msgid "searches for keyboards for languages used in Thailand."

--- a/_includes/locale/en/LC_MESSAGES/keyboards-en.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-en.po
@@ -28,9 +28,9 @@ msgstr "Search"
 msgid "New search"
 msgstr "New search"
 
-# Search box prompt
-msgid "Enter the name of a keyboard or language to search for%1$s"
-msgstr "Enter the name of a keyboard or language to search for%1$s"
+# Search box instruction (Popular keyboards | All keyboards)
+msgid "Enter the name of a keyboard or language to search for"
+msgstr "Enter the name of a keyboard or language to search for"
 
 # Search box link for popular keyboards
 msgid "Popular keyboards"

--- a/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
@@ -21,8 +21,8 @@ msgid "Keyman Keyboard Search"
 msgstr "Keyman Búsqueda por Teclado"
 
 # Keyboard search bar
-msgid "Keyboard search%s"
-msgstr "Búsqueda por teclado%s"
+msgid "Keyboard search:"
+msgstr "Búsqueda por teclado:"
 
 # Search bar placeholder
 msgid "Enter language or keyboard"
@@ -37,8 +37,8 @@ msgid "New search"
 msgstr "Nueva buscar"
 
 # Search box prompt
-msgid "Enter the name of a keyboard or language to search for%s"
-msgstr "Introduzca el nombre de un teclado o idioma para buscar%s"
+msgid "Enter the name of a keyboard or language to search for%1$s"
+msgstr "Introduzca el nombre de un teclado o idioma para buscar%1$s"
 
 # Search box link for popular keyboards
 msgid "Popular keyboards"
@@ -61,20 +61,20 @@ msgid "You can apply prefixes"
 msgstr "Puedes aplicar prefijos"
 
 # (keyboards)
-msgid "%skeyboards%s"
-msgstr "%stescados%s"
+msgid "%1$skeyboards%2$s"
+msgstr "%1$stescados%2$s"
 
 # (languages)
-msgid "%slanguages%s"
-msgstr "%sidiomas%s"
+msgid "%1$slanguages%2$s"
+msgstr "%1$sidiomas%2$s"
 
 # (scripts, writing systems) or...
-msgid "%sscripts, writing systems%s or"
-msgstr "%sguiones, sistemas de escritura%s o"
+msgid "%1$sscripts, writing systems%2$s or"
+msgstr "%1$sguiones, sistemas de escritura%2$s o"
 
 # (countries) to filter your search results...
-msgid "%scountries%s to filter your search results. For example"
-msgstr "%spaíses%s para filtrar los resultados de búsqueda. Por ejemplo"
+msgid "%1$scountries%2$s to filter your search results. For example"
+msgstr "%1$spaíses%2$s para filtrar los resultados de búsqueda. Por ejemplo"
 
 # Search box hint: example of country search
 msgid "searches for keyboards for languages used in Thailand."
@@ -89,6 +89,6 @@ msgid "to search for a BCP 47 language tag, for example"
 msgstr "para buscar una etiqueta de idioma BCP 47, por ejemplo"
 
 # Search box hint: BCP 47 language example
-msgid "searches for Tigrigna %sEthiopia%s"
-msgstr "busca Tigrigna %sEtiopía%s"
+msgid "searches for Tigrigna %1$sEthiopia%2$s"
+msgstr "busca Tigrigna %1$sEtiopía%2$s"
 

--- a/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
@@ -1,0 +1,94 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: keymancom\n"
+"X-Crowdin-Project-ID: 740839\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /master/keyboards/keyboards.po\n"
+"X-Crowdin-File-ID: 2\n"
+"Project-Id-Version: keymancom\n"
+"Language-Team: Spanish\n"
+"Language: es_ES\n"
+"PO-Revision-Date: 2024-11-11 08:20\n"
+
+# Page Title
+msgid "Keyboard Search"
+msgstr "Búsqueda por Teclado"
+
+# Page Description
+msgid "Keyman Keyboard Search"
+msgstr "Keyman Búsqueda por Teclado"
+
+# Keyboard search bar
+msgid "Keyboard search%s"
+msgstr "Búsqueda por teclado%s"
+
+# Search bar placeholder
+msgid "Enter language or keyboard"
+msgstr "Ingresar idioma o teclado"
+
+# Search Button Value
+msgid "Search"
+msgstr "Buscar"
+
+# Link to start a new keyboard search
+msgid "New search"
+msgstr "Nueva buscar"
+
+# Search box prompt
+msgid "Enter the name of a keyboard or language to search for%s"
+msgstr "Introduzca el nombre de un teclado o idioma para buscar%s"
+
+# Search box link for popular keyboards
+msgid "Popular keyboards"
+msgstr "Teclados populares"
+
+# Search box link for all Keyman keyboards
+msgid "All keyboards"
+msgstr "Todos los teclados"
+
+# Search box hint: List header
+msgid "Hints"
+msgstr "Consejos"
+
+# Search box hint: Description
+msgid "The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names."
+msgstr "La búsqueda siempre devuelve una lista de teclados. Busca nombres de teclados y detalles, nombres de idiomas, nombres de países y nombres de alfabetos."
+
+# Search box hint: available prefixes to use in the search
+msgid "You can apply prefixes"
+msgstr "Puedes aplicar prefijos"
+
+# (keyboards)
+msgid "%skeyboards%s"
+msgstr "%stescados%s"
+
+# (languages)
+msgid "%slanguages%s"
+msgstr "%sidiomas%s"
+
+# (scripts, writing systems) or...
+msgid "%sscripts, writing systems%s or"
+msgstr "%sguiones, sistemas de escritura%s o"
+
+# (countries) to filter your search results...
+msgid "%scountries%s to filter your search results. For example"
+msgstr "%spaíses%s para filtrar los resultados de búsqueda. Por ejemplo"
+
+# Search box hint: example of country search
+msgid "searches for keyboards for languages used in Thailand."
+msgstr "busca teclados para los idiomas utilizados en Tailandia."
+
+# Search box hint: BCP 47 prefix
+msgid "Use prefix"
+msgstr "Utilice prefijo"
+
+# Seach box hint: BCP 47 language example
+msgid "to search for a BCP 47 language tag, for example"
+msgstr "para buscar una etiqueta de idioma BCP 47, por ejemplo"
+
+# Search box hint: BCP 47 language example
+msgid "searches for Tigrigna %sEthiopia%s"
+msgstr "busca Tigrigna %sEtiopía%s"
+

--- a/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
@@ -61,20 +61,20 @@ msgid "You can apply prefixes"
 msgstr "Puedes aplicar prefijos"
 
 # (keyboards)
-msgid "%1$skeyboards%2$s"
-msgstr "%1$stescados%2$s"
+msgid "(keyboards)"
+msgstr "(tescados)"
 
 # (languages)
-msgid "%1$slanguages%2$s"
-msgstr "%1$sidiomas%2$s"
+msgid "(languages)"
+msgstr "(idiomas)"
 
 # (scripts, writing systems) or...
-msgid "%1$sscripts, writing systems%2$s or"
-msgstr "%1$sguiones, sistemas de escritura%2$s o"
+msgid "(scripts, writing systems) or"
+msgstr "(guiones, sistemas de escritura) o"
 
 # (countries) to filter your search results...
-msgid "%1$scountries%2$s to filter your search results. For example"
-msgstr "%1$spaíses%2$s para filtrar los resultados de búsqueda. Por ejemplo"
+msgid "(countries) to filter your search results. For example"
+msgstr "(países) para filtrar los resultados de búsqueda. Por ejemplo"
 
 # Search box hint: example of country search
 msgid "searches for keyboards for languages used in Thailand."

--- a/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
@@ -36,9 +36,9 @@ msgstr "Buscar"
 msgid "New search"
 msgstr "Nueva buscar"
 
-# Search box prompt
-msgid "Enter the name of a keyboard or language to search for%1$s"
-msgstr "Introduzca el nombre de un teclado o idioma para buscar%1$s"
+# Search box instruction (Popular keyboards | All keyboards)
+msgid "Enter the name of a keyboard or language to search for"
+msgstr "Introduzca el nombre de un teclado o idioma para buscar"
 
 # Search box link for popular keyboards
 msgid "Popular keyboards"

--- a/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-es-ES.po
@@ -89,6 +89,6 @@ msgid "to search for a BCP 47 language tag, for example"
 msgstr "para buscar una etiqueta de idioma BCP 47, por ejemplo"
 
 # Search box hint: BCP 47 language example
-msgid "searches for Tigrigna %1$sEthiopia%2$s"
-msgstr "busca Tigrigna %1$sEtiopía%2$s"
+msgid "searches for Tigrigna (Ethiopia)"
+msgstr "busca Tigrigna (Etiopía)"
 

--- a/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
@@ -61,20 +61,20 @@ msgid "You can apply prefixes"
 msgstr "Vous pouvez appliquer des préfixes"
 
 # (keyboards)
-msgid "%1$skeyboards%2$s"
-msgstr "%1$sclaviers%2$s"
+msgid "(keyboards)"
+msgstr "(claviers)"
 
 # (languages)
-msgid "%1$slanguages%2$s"
-msgstr "%1$slangues%2$s"
+msgid "(languages)"
+msgstr "(langues)"
 
 # (scripts, writing systems) or...
-msgid "%1$sscripts, writing systems%2$s or"
-msgstr "%1$sscripts, systèmes d'écriture%2$s ou"
+msgid "(scripts, writing systems) or"
+msgstr "(scripts, systèmes d'écriture) ou"
 
 # (countries) to filter your search results...
-msgid "%1$scountries%2$s to filter your search results. For example"
-msgstr "%1$spays%2$s pour filtrer vos résultats de recherche. Par exemple"
+msgid "(countries) to filter your search results. For example"
+msgstr "(pays) pour filtrer vos résultats de recherche. Par exemple"
 
 # Search box hint: example of country search
 msgid "searches for keyboards for languages used in Thailand."

--- a/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
@@ -89,6 +89,6 @@ msgid "to search for a BCP 47 language tag, for example"
 msgstr "pour rechercher une balise de langue BCP 47, par exemple"
 
 # Search box hint: BCP 47 language example
-msgid "searches for Tigrigna %1$sEthiopia%2$s"
-msgstr "busca Tigrigna %1$sEtiopía%2$s"
+msgid "searches for Tigrigna (Ethiopia)"
+msgstr "busca Tigrigna (Etiopía)"
 

--- a/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
@@ -37,7 +37,7 @@ msgid "New search"
 msgstr "Nouvelle recherche"
 
 # Search box instruction (Popular keyboards | All keyboards)
-msgid "Enter the name of a keyboard or language to search for%"
+msgid "Enter the name of a keyboard or language to search for"
 msgstr "Saisissez le nom d'un clavier ou d'une langue à rechercher"
 
 # Search box link for popular keyboards

--- a/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
@@ -1,0 +1,94 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Crowdin-Project: keymancom\n"
+"X-Crowdin-Project-ID: 740839\n"
+"X-Crowdin-Language: fr\n"
+"X-Crowdin-File: /master/keyboards/keyboards.po\n"
+"X-Crowdin-File-ID: 2\n"
+"Project-Id-Version: keymancom\n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"PO-Revision-Date: 2024-11-11 08:15\n"
+
+# Page Title
+msgid "Keyboard Search"
+msgstr "Recherche au clavier"
+
+# Page Description
+msgid "Keyman Keyboard Search"
+msgstr "Recherche de clavier Keyman"
+
+# Keyboard search bar
+msgid "Keyboard search%s"
+msgstr "Recherche au clavier%s"
+
+# Search bar placeholder
+msgid "Enter language or keyboard"
+msgstr "Entrez la langue ou le clavier"
+
+# Search Button Value
+msgid "Search"
+msgstr "Recherche"
+
+# Link to start a new keyboard search
+msgid "New search"
+msgstr "Nouvelle recherche"
+
+# Search box prompt
+msgid "Enter the name of a keyboard or language to search for%s"
+msgstr "Saisissez le nom d'un clavier ou d'une langue à rechercher%s"
+
+# Search box link for popular keyboards
+msgid "Popular keyboards"
+msgstr "Claviers populaires"
+
+# Search box link for all Keyman keyboards
+msgid "All keyboards"
+msgstr "Tous les claviers"
+
+# Search box hint: List header
+msgid "Hints"
+msgstr "Conseils"
+
+# Search box hint: Description
+msgid "The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names."
+msgstr "La recherche renvoie toujours une liste de claviers. Elle recherche les noms et les détails des claviers, les noms de langues, les noms de pays et les noms d'écritures."
+
+# Search box hint: available prefixes to use in the search
+msgid "You can apply prefixes"
+msgstr "Vous pouvez appliquer des préfixes"
+
+# (keyboards)
+msgid "%skeyboards%s"
+msgstr "%sclaviers%s"
+
+# (languages)
+msgid "%slanguages%s"
+msgstr "%slangues%s"
+
+# (scripts, writing systems) or...
+msgid "%sscripts, writing systems%s or"
+msgstr "%sscripts, systèmes d'écriture%s ou"
+
+# (countries) to filter your search results...
+msgid "%scountries%s to filter your search results. For example"
+msgstr "%spays%s pour filtrer vos résultats de recherche. Par exemple"
+
+# Search box hint: example of country search
+msgid "searches for keyboards for languages used in Thailand."
+msgstr "recherche des claviers pour les langues utilisées en Thaïlande."
+
+# Search box hint: BCP 47 prefix
+msgid "Use prefix"
+msgstr "Utiliser le préfixe"
+
+# Seach box hint: BCP 47 language example
+msgid "to search for a BCP 47 language tag, for example"
+msgstr "pour rechercher une balise de langue BCP 47, par exemple"
+
+# Search box hint: BCP 47 language example
+msgid "searches for Tigrigna %sEthiopia%s"
+msgstr "busca Tigrigna %sEtiopía%s"
+

--- a/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
@@ -36,9 +36,9 @@ msgstr "Recherche"
 msgid "New search"
 msgstr "Nouvelle recherche"
 
-# Search box prompt
-msgid "Enter the name of a keyboard or language to search for%1$s"
-msgstr "Saisissez le nom d'un clavier ou d'une langue à rechercher%1$s"
+# Search box instruction (Popular keyboards | All keyboards)
+msgid "Enter the name of a keyboard or language to search for%"
+msgstr "Saisissez le nom d'un clavier ou d'une langue à rechercher"
 
 # Search box link for popular keyboards
 msgid "Popular keyboards"

--- a/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-fr-FR.po
@@ -21,8 +21,8 @@ msgid "Keyman Keyboard Search"
 msgstr "Recherche de clavier Keyman"
 
 # Keyboard search bar
-msgid "Keyboard search%s"
-msgstr "Recherche au clavier%s"
+msgid "Keyboard search:"
+msgstr "Recherche au clavier:"
 
 # Search bar placeholder
 msgid "Enter language or keyboard"
@@ -37,8 +37,8 @@ msgid "New search"
 msgstr "Nouvelle recherche"
 
 # Search box prompt
-msgid "Enter the name of a keyboard or language to search for%s"
-msgstr "Saisissez le nom d'un clavier ou d'une langue à rechercher%s"
+msgid "Enter the name of a keyboard or language to search for%1$s"
+msgstr "Saisissez le nom d'un clavier ou d'une langue à rechercher%1$s"
 
 # Search box link for popular keyboards
 msgid "Popular keyboards"
@@ -61,20 +61,20 @@ msgid "You can apply prefixes"
 msgstr "Vous pouvez appliquer des préfixes"
 
 # (keyboards)
-msgid "%skeyboards%s"
-msgstr "%sclaviers%s"
+msgid "%1$skeyboards%2$s"
+msgstr "%1$sclaviers%2$s"
 
 # (languages)
-msgid "%slanguages%s"
-msgstr "%slangues%s"
+msgid "%1$slanguages%2$s"
+msgstr "%1$slangues%2$s"
 
 # (scripts, writing systems) or...
-msgid "%sscripts, writing systems%s or"
-msgstr "%sscripts, systèmes d'écriture%s ou"
+msgid "%1$sscripts, writing systems%2$s or"
+msgstr "%1$sscripts, systèmes d'écriture%2$s ou"
 
 # (countries) to filter your search results...
-msgid "%scountries%s to filter your search results. For example"
-msgstr "%spays%s pour filtrer vos résultats de recherche. Par exemple"
+msgid "%1$scountries%2$s to filter your search results. For example"
+msgstr "%1$spays%2$s pour filtrer vos résultats de recherche. Par exemple"
 
 # Search box hint: example of country search
 msgid "searches for keyboards for languages used in Thailand."
@@ -89,6 +89,6 @@ msgid "to search for a BCP 47 language tag, for example"
 msgstr "pour rechercher une balise de langue BCP 47, par exemple"
 
 # Search box hint: BCP 47 language example
-msgid "searches for Tigrigna %sEthiopia%s"
-msgstr "busca Tigrigna %sEtiopía%s"
+msgid "searches for Tigrigna %1$sEthiopia%2$s"
+msgstr "busca Tigrigna %1$sEtiopía%2$s"
 

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -24,10 +24,10 @@
     'Hints',
     'The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.',
     'You can apply prefixes',
-    '%1$skeyboards%2$s',
-    '%1$slanguages%2$s',
-    '%1$sscripts, writing systems%2$s or',
-    '%1$scountries%2$s to filter your search results. For example',
+    '(keyboards)',
+    '(languages)',
+    '(scripts, writing systems) or',
+    '(countries) to filter your search results. For example',
     'searches for keyboards for languages used in Thailand.',
     'Use prefix',
     'to search for a BCP 47 language tag, for example',
@@ -103,10 +103,10 @@
       </li>
       <li>
         <?= $keyboardIndexStrings['You can apply prefixes'] ?> 
-        <code>k:</code> <?= Locale::_s($keyboardIndexStrings['%1$skeyboards%2$s'], "(", "), ") ?>
-        <code>l:</code> <?= Locale::_s($keyboardIndexStrings['%1$slanguages%2$s'], "(", "), ") ?>
-        <code>s:</code> <?= Locale::_s($keyboardIndexStrings['%1$sscripts, writing systems%2$s or'], "(", ")") ?>
-        <code>c:</code> <?= Locale::_s($keyboardIndexStrings['%1$scountries%2$s to filter your search results. For example'], "(", ")") ?> 
+        <code>k:</code> <?= $keyboardIndexStrings['(keyboards)'] ?>
+        <code>l:</code> <?= $keyboardIndexStrings['(languages)'] ?>
+        <code>s:</code> <?= $keyboardIndexStrings['(scripts, writing systems) or'] ?>
+        <code>c:</code> <?= $keyboardIndexStrings['(countries) to filter your search results. For example'] ?> 
         <code>c:thailand</code> <?= $keyboardIndexStrings['searches for keyboards for languages used in Thailand.'] ?>
       </li>
       <li>

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -9,9 +9,52 @@
   use Keyman\Site\com\keyman\templates\Foot;
   use Keyman\Site\com\keyman\Locale;
 
+  // Of array of strings at top of file
+  // by msgid 
+  $keyboardIndexStrings = localize('keyboards', [
+    'Keyboard Search',
+    'Keyman Keyboard Search',
+    'Keyboard search%s',
+    'Enter language or keyboard',
+    'Search',
+    'New search',
+    'Enter the name of a keyboard or language to search for%s',
+    'Popular keyboards',
+    'All keyboards',
+    'Hints',
+    'The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.',
+    'You can apply prefixes',
+    '%skeyboards%s',
+    '%slanguages%s',
+    '%sscripts, writing systems%s or',
+    '%scountries%s to filter your search results. For example',
+    'searches for keyboards for languages used in Thailand.',
+    'Use prefix',
+    'to search for a BCP 47 language tag, for example',
+    'searches for Tigrigna %sEthiopia%s',    
+  ]);
+
+  function localize($domain, $strings) {
+    bindtextdomain("$domain-fr-FR", __DIR__ . "/../_includes/locale");
+    bindtextdomain("$domain-es-ES", __DIR__ . "/../_includes/locale");
+
+    $previousTextDomain = textdomain(NULL);
+    Locale::setTextDomain($domain);
+
+    $result = [];
+    foreach($strings as $s) {
+      $result[$s] = _($s);
+    }
+
+    // Restore textdomain
+    textdomain($previousTextDomain);
+    return $result;
+  }
+
   $head_options = [
-    'title' =>'Keyboard Search',
-    'description' => 'Keyman Keyboard Search',
+    'title' => $keyboardIndexStrings['Keyboard Search'],
+    'description' => $keyboardIndexStrings['Keyman Keyboard Search'],
+    'language' => Locale::currentLocale(),
     'css' => [Util::cdn('css/template.css'), Util::cdn('keyboard-search/search.css')],
     'js' => [Util::cdn('keyboard-search/jquery.mark.js'), Util::cdn('keyboard-search/dedicated-landing-pages.js'),
       Util::cdn('keyboard-search/search.js')]
@@ -47,14 +90,14 @@
 
 <div class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
 
-  <h2 class="red underline"><a href='/keyboards'>Keyboard Search</a></h2>
+  <h2 class="red underline"><a href='/keyboards'><?= $keyboardIndexStrings['Keyboard Search'] ?></a></h2>
 
   <div id='search-box'>
     <form method='get' action='/keyboards' name='f'>
-      <label for="search-q">Keyboard search:</label><input id="search-q" type="text" placeholder="Enter language or keyboard" name="q"
+      <label for="search-q"><?= Locale::_s($keyboardIndexStrings['Keyboard search%s'], ":") ?></label><input id="search-q" type="text" placeholder="<?= $keyboardIndexStrings['Enter language or keyboard'] ?>" name="q"
       <?php if($embed == 'none') echo 'autofocus'; ?>>
-      <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="Search" onclick="return do_search()">
-      <label id="search-new"><a href='/keyboards<?=$session_query_q?>'>New search</a></label>
+      <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="<?= $keyboardIndexStrings['Search'] ?>" onclick="return do_search()">
+      <label id="search-new"><a href='/keyboards<?=$session_query_q?>'><?= $keyboardIndexStrings['New search'] ?></a></label>
       <input id="search-obsolete" type="hidden" name="obsolete" value="0">
       <input id="search-page" type="hidden" name="page" value="1">
     </form>
@@ -63,14 +106,31 @@
   <div id='search-results-container' class=''>
   <div id='search-results'></div>
   <div id='search-results-empty'>
-    <p>Enter the name of a keyboard or language to search for. (<a href="?q=p:popular">Popular keyboards</a> | <a href="?q=p:alphabetical">All keyboards</a>)</p>
+    <p>
+      <?= Locale::_s($keyboardIndexStrings['Enter the name of a keyboard or language to search for%s'], ". (") ?>
+      <a href="?q=p:popular"><?= $keyboardIndexStrings['Popular keyboards'] ?></a> | 
+      <a href="?q=p:alphabetical"><?= $keyboardIndexStrings['All keyboards'] ?></a>)
+    </p>
     <br />
-    <p>Hints</p>
+    <p><?= $keyboardIndexStrings['Hints'] ?></p>
     <ul>
-      <li>The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.</li>
-      <li>You can apply prefixes <code>k:</code> (keyboards), <code>l:</code> (languages), <code>s:</code> (scripts, writing systems)
-      or <code>c:</code> (countries) to filter your search results. For example <code>c:thailand</code> searches for keyboards for languages used in Thailand.</li>
-      <li>Use prefix <code>l:id:</code> to search for a BCP 47 language tag, for example <code>l:id:ti-et</code> searches for Tigrigna (Ethiopia).</li>
+      <li>
+        <?= $keyboardIndexStrings['The search always returns a list of keyboards. ' .
+          'It searches for keyboard names and details, language names, country names and script names.'] ?>
+      </li>
+      <li>
+        <?= $keyboardIndexStrings['You can apply prefixes'] ?> 
+        <code>k:</code> <?= Locale::_s($keyboardIndexStrings['%skeyboards%s'], "(", "), ") ?>
+        <code>l:</code> <?= Locale::_s($keyboardIndexStrings['%slanguages%s'], "(", "), ") ?>
+        <code>s:</code> <?= Locale::_s($keyboardIndexStrings['%sscripts, writing systems%s or'], "(", ")") ?>
+        <code>c:</code> <?= Locale::_s($keyboardIndexStrings['%scountries%s to filter your search results. For example'], "(", ")") ?> 
+        <code>c:thailand</code> <?= $keyboardIndexStrings['searches for keyboards for languages used in Thailand.'] ?>
+      </li>
+      <li>
+        <?= $keyboardIndexStrings['Use prefix'] ?> 
+        <code>l:id:</code> <?= $keyboardIndexStrings['to search for a BCP 47 language tag, for example'] ?> 
+        <code>l:id:ti-et</code> <?= Locale::_s($keyboardIndexStrings['searches for Tigrigna %sEthiopia%s'], "(", ").") ?>
+      </li>
     </ul>
   </div>
 </div>

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -14,24 +14,24 @@
   $keyboardIndexStrings = Locale::localize('keyboards', [
     'Keyboard Search',
     'Keyman Keyboard Search',
-    'Keyboard search%s',
+    'Keyboard search:',
     'Enter language or keyboard',
     'Search',
     'New search',
-    'Enter the name of a keyboard or language to search for%s',
+    'Enter the name of a keyboard or language to search for%1$s',
     'Popular keyboards',
     'All keyboards',
     'Hints',
     'The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.',
     'You can apply prefixes',
-    '%skeyboards%s',
-    '%slanguages%s',
-    '%sscripts, writing systems%s or',
-    '%scountries%s to filter your search results. For example',
+    '%1$skeyboards%2$s',
+    '%1$slanguages%2$s',
+    '%1$sscripts, writing systems%2$s or',
+    '%1$scountries%2$s to filter your search results. For example',
     'searches for keyboards for languages used in Thailand.',
     'Use prefix',
     'to search for a BCP 47 language tag, for example',
-    'searches for Tigrigna %sEthiopia%s',    
+    'searches for Tigrigna %1$sEthiopia%2$s',
   ]);
 
   $head_options = [
@@ -77,7 +77,7 @@
 
   <div id='search-box'>
     <form method='get' action='/keyboards' name='f'>
-      <label for="search-q"><?= Locale::_s($keyboardIndexStrings['Keyboard search%s'], ":") ?></label><input id="search-q" type="text" placeholder="<?= $keyboardIndexStrings['Enter language or keyboard'] ?>" name="q"
+      <label for="search-q"><?= $keyboardIndexStrings['Keyboard search:'] ?></label><input id="search-q" type="text" placeholder="<?= $keyboardIndexStrings['Enter language or keyboard'] ?>" name="q"
       <?php if($embed == 'none') echo 'autofocus'; ?>>
       <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="<?= $keyboardIndexStrings['Search'] ?>" onclick="return do_search()">
       <label id="search-new"><a href='/keyboards<?=$session_query_q?>'><?= $keyboardIndexStrings['New search'] ?></a></label>
@@ -90,7 +90,7 @@
   <div id='search-results'></div>
   <div id='search-results-empty'>
     <p>
-      <?= Locale::_s($keyboardIndexStrings['Enter the name of a keyboard or language to search for%s'], ". (") ?>
+      <?= Locale::_s($keyboardIndexStrings['Enter the name of a keyboard or language to search for%1$s'], ". (") ?>
       <a href="?q=p:popular"><?= $keyboardIndexStrings['Popular keyboards'] ?></a> | 
       <a href="?q=p:alphabetical"><?= $keyboardIndexStrings['All keyboards'] ?></a>)
     </p>
@@ -103,16 +103,16 @@
       </li>
       <li>
         <?= $keyboardIndexStrings['You can apply prefixes'] ?> 
-        <code>k:</code> <?= Locale::_s($keyboardIndexStrings['%skeyboards%s'], "(", "), ") ?>
-        <code>l:</code> <?= Locale::_s($keyboardIndexStrings['%slanguages%s'], "(", "), ") ?>
-        <code>s:</code> <?= Locale::_s($keyboardIndexStrings['%sscripts, writing systems%s or'], "(", ")") ?>
-        <code>c:</code> <?= Locale::_s($keyboardIndexStrings['%scountries%s to filter your search results. For example'], "(", ")") ?> 
+        <code>k:</code> <?= Locale::_s($keyboardIndexStrings['%1$skeyboards%2$s'], "(", "), ") ?>
+        <code>l:</code> <?= Locale::_s($keyboardIndexStrings['%1$slanguages%2$s'], "(", "), ") ?>
+        <code>s:</code> <?= Locale::_s($keyboardIndexStrings['%1$sscripts, writing systems%2$s or'], "(", ")") ?>
+        <code>c:</code> <?= Locale::_s($keyboardIndexStrings['%1$scountries%2$s to filter your search results. For example'], "(", ")") ?> 
         <code>c:thailand</code> <?= $keyboardIndexStrings['searches for keyboards for languages used in Thailand.'] ?>
       </li>
       <li>
         <?= $keyboardIndexStrings['Use prefix'] ?> 
         <code>l:id:</code> <?= $keyboardIndexStrings['to search for a BCP 47 language tag, for example'] ?> 
-        <code>l:id:ti-et</code> <?= Locale::_s($keyboardIndexStrings['searches for Tigrigna %sEthiopia%s'], "(", ").") ?>
+        <code>l:id:ti-et</code> <?= Locale::_s($keyboardIndexStrings['searches for Tigrigna %1$sEthiopia%2$s'], "(", ").") ?>
       </li>
     </ul>
   </div>

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -31,7 +31,7 @@
     'searches for keyboards for languages used in Thailand.',
     'Use prefix',
     'to search for a BCP 47 language tag, for example',
-    'searches for Tigrigna %1$sEthiopia%2$s',
+    'searches for Tigrigna (Ethiopia)',
   ]);
 
   $head_options = [
@@ -112,7 +112,7 @@
       <li>
         <?= $keyboardIndexStrings['Use prefix'] ?> 
         <code>l:id:</code> <?= $keyboardIndexStrings['to search for a BCP 47 language tag, for example'] ?> 
-        <code>l:id:ti-et</code> <?= Locale::_s($keyboardIndexStrings['searches for Tigrigna %1$sEthiopia%2$s'], "(", ").") ?>
+        <code>l:id:ti-et</code> <?= $keyboardIndexStrings['searches for Tigrigna (Ethiopia)'] ?>
       </li>
     </ul>
   </div>

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -11,7 +11,7 @@
 
   // Of array of strings at top of file
   // by msgid 
-  $keyboardIndexStrings = localize('keyboards', [
+  $keyboardIndexStrings = Locale::localize('keyboards', [
     'Keyboard Search',
     'Keyman Keyboard Search',
     'Keyboard search%s',
@@ -33,23 +33,6 @@
     'to search for a BCP 47 language tag, for example',
     'searches for Tigrigna %sEthiopia%s',    
   ]);
-
-  function localize($domain, $strings) {
-    bindtextdomain("$domain-fr-FR", __DIR__ . "/../_includes/locale");
-    bindtextdomain("$domain-es-ES", __DIR__ . "/../_includes/locale");
-
-    $previousTextDomain = textdomain(NULL);
-    Locale::setTextDomain($domain);
-
-    $result = [];
-    foreach($strings as $s) {
-      $result[$s] = _($s);
-    }
-
-    // Restore textdomain
-    textdomain($previousTextDomain);
-    return $result;
-  }
 
   $head_options = [
     'title' => $keyboardIndexStrings['Keyboard Search'],

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -9,34 +9,11 @@
   use Keyman\Site\com\keyman\templates\Foot;
   use Keyman\Site\com\keyman\Locale;
 
-  // Of array of strings at top of file
-  // by msgid 
-  $keyboardIndexStrings = Locale::localize('keyboards', [
-    'Keyboard Search',
-    'Keyman Keyboard Search',
-    'Keyboard search:',
-    'Enter language or keyboard',
-    'Search',
-    'New search',
-    'Enter the name of a keyboard or language to search for%1$s',
-    'Popular keyboards',
-    'All keyboards',
-    'Hints',
-    'The search always returns a list of keyboards. It searches for keyboard names and details, language names, country names and script names.',
-    'You can apply prefixes',
-    '(keyboards)',
-    '(languages)',
-    '(scripts, writing systems) or',
-    '(countries) to filter your search results. For example',
-    'searches for keyboards for languages used in Thailand.',
-    'Use prefix',
-    'to search for a BCP 47 language tag, for example',
-    'searches for Tigrigna (Ethiopia)',
-  ]);
+  Locale::localize('keyboards');
 
   $head_options = [
-    'title' => $keyboardIndexStrings['Keyboard Search'],
-    'description' => $keyboardIndexStrings['Keyman Keyboard Search'],
+    'title' => _('Keyboard Search'),
+    'description' => _('Keyman Keyboard Search'),
     'language' => Locale::currentLocale(),
     'css' => [Util::cdn('css/template.css'), Util::cdn('keyboard-search/search.css')],
     'js' => [Util::cdn('keyboard-search/jquery.mark.js'), Util::cdn('keyboard-search/dedicated-landing-pages.js'),
@@ -73,14 +50,14 @@
 
 <div class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
 
-  <h2 class="red underline"><a href='/keyboards'><?= $keyboardIndexStrings['Keyboard Search'] ?></a></h2>
+  <h2 class="red underline"><a href='/keyboards'><?= _('Keyboard Search') ?></a></h2>
 
   <div id='search-box'>
     <form method='get' action='/keyboards' name='f'>
-      <label for="search-q"><?= $keyboardIndexStrings['Keyboard search:'] ?></label><input id="search-q" type="text" placeholder="<?= $keyboardIndexStrings['Enter language or keyboard'] ?>" name="q"
+      <label for="search-q"><?= _('Keyboard search:') ?></label><input id="search-q" type="text" placeholder="<?= _('Enter language or keyboard') ?>" name="q"
       <?php if($embed == 'none') echo 'autofocus'; ?>>
-      <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="<?= $keyboardIndexStrings['Search'] ?>" onclick="return do_search()">
-      <label id="search-new"><a href='/keyboards<?=$session_query_q?>'><?= $keyboardIndexStrings['New search'] ?></a></label>
+      <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="<?= _('Search') ?>" onclick="return do_search()">
+      <label id="search-new"><a href='/keyboards<?=$session_query_q?>'><?= _('New search') ?></a></label>
       <input id="search-obsolete" type="hidden" name="obsolete" value="0">
       <input id="search-page" type="hidden" name="page" value="1">
     </form>
@@ -90,29 +67,29 @@
   <div id='search-results'></div>
   <div id='search-results-empty'>
     <p>
-      <?= Locale::_s($keyboardIndexStrings['Enter the name of a keyboard or language to search for%1$s'], ". (") ?>
-      <a href="?q=p:popular"><?= $keyboardIndexStrings['Popular keyboards'] ?></a> | 
-      <a href="?q=p:alphabetical"><?= $keyboardIndexStrings['All keyboards'] ?></a>)
+      <?= _('Enter the name of a keyboard or language to search for') ?> (
+      <a href="?q=p:popular"><?= _('Popular keyboards') ?></a> | 
+      <a href="?q=p:alphabetical"><?= _('All keyboards') ?></a>)
     </p>
     <br />
-    <p><?= $keyboardIndexStrings['Hints'] ?></p>
+    <p><?= _('Hints') ?></p>
     <ul>
       <li>
-        <?= $keyboardIndexStrings['The search always returns a list of keyboards. ' .
-          'It searches for keyboard names and details, language names, country names and script names.'] ?>
+        <?= _('The search always returns a list of keyboards. ' .
+          'It searches for keyboard names and details, language names, country names and script names.') ?>
       </li>
       <li>
-        <?= $keyboardIndexStrings['You can apply prefixes'] ?> 
-        <code>k:</code> <?= $keyboardIndexStrings['(keyboards)'] ?>
-        <code>l:</code> <?= $keyboardIndexStrings['(languages)'] ?>
-        <code>s:</code> <?= $keyboardIndexStrings['(scripts, writing systems) or'] ?>
-        <code>c:</code> <?= $keyboardIndexStrings['(countries) to filter your search results. For example'] ?> 
-        <code>c:thailand</code> <?= $keyboardIndexStrings['searches for keyboards for languages used in Thailand.'] ?>
+        <?= _('You can apply prefixes') ?> 
+        <code>k:</code> <?= _('(keyboards)') ?>
+        <code>l:</code> <?= _('(languages)') ?>
+        <code>s:</code> <?= _('(scripts, writing systems) or') ?>
+        <code>c:</code> <?= _('(countries) to filter your search results. For example') ?> 
+        <code>c:thailand</code> <?= _('searches for keyboards for languages used in Thailand.') ?>
       </li>
       <li>
-        <?= $keyboardIndexStrings['Use prefix'] ?> 
-        <code>l:id:</code> <?= $keyboardIndexStrings['to search for a BCP 47 language tag, for example'] ?> 
-        <code>l:id:ti-et</code> <?= $keyboardIndexStrings['searches for Tigrigna (Ethiopia)'] ?>
+        <?= _('Use prefix') ?> 
+        <code>l:id:</code> <?= _('to search for a BCP 47 language tag, for example') ?> 
+        <code>l:id:ti-et</code> <?= _('searches for Tigrigna (Ethiopia)') ?>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Re-implements #500 for #384

This updates Locale.php for localizing the keyboards/ index page

## Changes

### Locale.php
* Validate the new locale before overriding the current locale
* `setTextDomain()` to manage the localization files
* Add `_s()` wrapper


### keyboards/index.php
* Use the pattern described in #384 of storing the localized strings into an array


## Screenshots

Note: the "Search" button image asset contains English text.
 
**French**

http://keyman.com.localhost/keyboards/?lang=fr-FR

![image](https://github.com/user-attachments/assets/36e067d7-d68b-4aac-971c-f51883120092)


**Spanish**

http://keyman.com.localhost/keyboards/?lang=es-ES

![image](https://github.com/user-attachments/assets/73944611-d263-411f-9f4f-b973bd37d76a)


 