### PR TITLE
fix: links to Keyman engine content

### DIFF
--- a/iphone-and-ipad/index.php
+++ b/iphone-and-ipad/index.php
@@ -228,7 +228,7 @@
   You can develop your own keyboard layouts for Keyman for iPhone and iPad with <a href='/developer'>Keyman Developer</a>.  If you have existing keyboards, they can be ported to iOS with just a recompile.  And of course, we include support for touch-oriented features such as touch-and-hold menus, dynamic keyboard layers and more!
 </p>
 <p>
-  <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/iphone-and-ipad/<?php echo $stable_version?>'>Keyman Engine for iPhone and iPad Documentation</a>
+  <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/iphone-and-ipad/current-version'>Keyman Engine for iPhone and iPad Documentation</a>
 </p>
 <p>
   <a href="/downloads/#ios-engine">Download the latest Keyman Engine for iOS</a>

--- a/iphone-and-ipad/index.php
+++ b/iphone-and-ipad/index.php
@@ -228,7 +228,7 @@
   You can develop your own keyboard layouts for Keyman for iPhone and iPad with <a href='/developer'>Keyman Developer</a>.  If you have existing keyboards, they can be ported to iOS with just a recompile.  And of course, we include support for touch-oriented features such as touch-and-hold menus, dynamic keyboard layers and more!
 </p>
 <p>
-  <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/iphone-and-ipad/<?php echo $stable_version?>/'>Keyman Engine for iPhone and iPad Documentation</a>
+  <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/iphone-and-ipad/current-version/'>Keyman Engine for iPhone and iPad Documentation</a>
 </p>
 <p>
   <a href="/downloads/#ios-engine">Download the latest Keyman Engine for iOS</a>

--- a/iphone-and-ipad/index.php
+++ b/iphone-and-ipad/index.php
@@ -228,7 +228,7 @@
   You can develop your own keyboard layouts for Keyman for iPhone and iPad with <a href='/developer'>Keyman Developer</a>.  If you have existing keyboards, they can be ported to iOS with just a recompile.  And of course, we include support for touch-oriented features such as touch-and-hold menus, dynamic keyboard layers and more!
 </p>
 <p>
-  <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/iphone-and-ipad/current-version'>Keyman Engine for iPhone and iPad Documentation</a>
+  <a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/iphone-and-ipad/<?php echo $stable_version?>/'>Keyman Engine for iPhone and iPad Documentation</a>
 </p>
 <p>
   <a href="/downloads/#ios-engine">Download the latest Keyman Engine for iOS</a>


### PR DESCRIPTION
Part of: #415.

There is no documentation from the `$stable_version` so I am adding a `/` to ensure the dropdown of other available versions.

Before:
![image](https://github.com/user-attachments/assets/405a80e7-170a-47b6-a41c-712ae88a61b9)

After:
![image](https://github.com/user-attachments/assets/f4c27315-803b-46af-b7ba-3890305e33c5)

This PR is ready for review.