### PR TITLE
feat: Localize strings on keyboards details 📡

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -4,16 +4,71 @@
   require_once('includes/template.php');
   require_once('includes/playstore.php');
   require_once('includes/appstore.php');
+  require_once __DIR__ . '/../../../keyboards/session.php';
 
   use \DateTime;
   use \Keyman\Site\com\keyman\KeymanWebHost;
   use \Keyman\Site\Common\KeymanHosts;
+  use Keyman\Site\com\keyman\Locale;
+
+  // Of array of strings at top of file
+  // by msgid 
+  KeyboardDetails::$strings = Locale::localize('keyboards-details', [
+    "New keyboard search",
+    "Search",
+    "Install keyboard",
+    "Installs %s for %s on this device",
+    "Try this keyboard",
+    "Use keyboard online",
+    "Full online editor",
+    "Use %s in your web browser. No need to install anything.",
+    "Scan this code to load this keyboard on another device",
+    "Keyboard Details",
+    "Keyboard ID",
+    "Supported Platforms",
+    "Author",
+    "License",
+    "Documentation",
+    "Keyboard help",
+    "Help not available.",
+    "Source",
+    "Source not available.",
+    "Keyboard Version",
+    "Last Updated",
+    "Package Download",
+    "Monthly Downloads",
+    "Total Downloads",
+    "Downloads since %s",
+    "Encoding",
+    "Unicode",
+    "Legacy (ANSI)",
+    "Minimum %s Version",
+    "Related Keyboards",
+    "This keyboard is not available on %s",
+    "(deprecated)",
+    "(new version)",
+    "Supported Languages",
+    "Expand %s more %s",
+    "%s Collapse",
+    "Permanent link to this keyboard:",
+    "Important note:",
+    "This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called",
+    ", instead.",
+    "View details for obsolete version instead",
+    "Failed to load keyboard %s",
+    "Error returned from %s: %s",
+    "Keyboard %s not found.",
+    "New search",
+    "Sorry, this keyboard requires Keyman %s or higher."
+  ]);
 
   define('GITHUB_ROOT', 'https://github.com/keymanapp/keyboards/tree/master/');
   define('DOCUMENTATION_ROOT', KeymanHosts::Instance()->help_keyman_com . '/keyboard/');
 
   class KeyboardDetails
   {
+    static $strings;
+
     const platformTitles = [
       'windows' => 'Windows',
       'macos' => 'macOS',
@@ -107,10 +162,13 @@
         $h_filename = htmlspecialchars($filename);
         $platformTitle = self::platformTitles[$platform];
 
+        // Get the localized strings to pass to heredoc syntax
+        $install_keyboard = KeyboardDetails::$strings['Install keyboard'];
+        $install_keyboard_description = Locale::_s(KeyboardDetails::$strings['Installs %s for %s on this device'], $h_filename, $platformTitle);
         return <<<END
 <div class="download download-$platform">
-  <a class='download-link binary-download' href='$installLink'><span>Install keyboard</span></a>
-  <div class="download-description">Installs {$h_filename} for $platformTitle on this device</div>
+  <a class='download-link binary-download' href='$installLink'><span>$install_keyboard</span></a>
+  <div class="download-description">$install_keyboard_description</div>
 </div>
 END;
       } else {
@@ -146,11 +204,13 @@ END;
         $url = "{$KeymanHosts->keymanweb_com}/#$lang,Keyboard_" . self::$keyboard->id;
         if($useDescription) {
           $description = htmlentities(self::$keyboard->name);
-          $description = "<div class=\"download-description\">Use $description in your web browser. No need to install anything.</div>";
-          $linktext = 'Use keyboard online';
+          $useKeyboardDescription = Locale::_s(KeyboardDetails::$strings['Use %s in your web browser. No need to install anything.'], $description);
+          $description = "<div class=\"download-description\">
+            $useKeyboardDescription</div>";
+          $linktext = KeyboardDetails::$strings['Use keyboard online'];
         } else {
           $description = '';
-          $linktext = 'Full online editor';
+          $linktext = KeyboardDetails::$strings['Full online editor'];
         }
         return <<<END
           <div class="download download-web">
@@ -170,7 +230,7 @@ END;
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";
-        self::$title = 'Failed to load keyboard ' . self::$id;
+        self::$title = Locale::_s(KeyboardDetails::$strings['Failed to load keyboard %s'], self::$id);
         header('HTTP/1.0 404 Keyboard not found');
       } else {
         $s = json_decode($s);
@@ -183,19 +243,19 @@ END;
           self::$minVersion = isset(self::$keyboard->minKeymanVersion) ? self::$keyboard->minKeymanVersion : $stable_version;
           self::$license = self::map_license(isset(self::$keyboard->license) ? self::$keyboard->license : 'Unknown');
         } else {
-          self::$error .= "Error returned from {$KeymanHosts->api_keyman_com}: $s\n";
-          self::$title = 'Failed to load keyboard ' . self::$id;
+          self::$error .= Locale::_s(KeyboardDetails::$strings['Error returned from %s: %s'], $KeymanHosts->api_keyman_com, "$s\n");
+          self::$title = Locale::_s(KeyboardDetails::$strings['Failed to load keyboard %s'], self::$id);
           header('HTTP/1.0 500 Internal Server Error');
         }
       }
 
       if(!empty(self::$keyboard)) {
         if (in_array('unicode', self::$keyboard->encodings) && in_array('ansi', self::$keyboard->encodings))
-          self::$keyboardEncoding = 'Unicode, Legacy (ANSI)';
+          self::$keyboardEncoding = KeyboardDetails::$strings['Unicode, Legacy (ANSI)'];
         else if (in_array('unicode', self::$keyboard->encodings))
-          self::$keyboardEncoding = 'Unicode';
+          self::$keyboardEncoding = KeyboardDetails::$strings['Unicode'];
         else // ansi
-          self::$keyboardEncoding = 'Legacy (ANSI)';
+          self::$keyboardEncoding = KeyboardDetails::$strings['Legacy (ANSI)'];
 
         $date = new DateTime(self::$keyboard->lastModifiedDate);
         self::$keyboardLastModifiedDate = $date->format('Y-m-d H:i');
@@ -300,7 +360,7 @@ END;
         // If parameters are missing ...
         ?>
           <h1 class='red underline'><?= self::$id ?></h1>
-          <p>Keyboard <?= self::$id ?> not found.</p>
+          <p><?= Locale::_s(KeyboardDetails::$strings['Keyboard %s not found.'], self::$id) ?></p>
         <?php
         // DEBUG: Only display errors on local sites
         global $KeymanHosts;
@@ -314,7 +374,7 @@ END;
         ?>
 
         <div id='search-box'>
-          <label id='search-new'><a href='/keyboards<?= $session_query_q ?>'>New search</a></label>
+          <label id='search-new'><a href='/keyboards<?= $session_query_q ?>'><?= KeyboardDetails::$strings['New search'] ?></a></label>
           <h1 class='red'><?= self::$title ?></h1>
         </div>
 
@@ -324,9 +384,9 @@ END;
 
         <div id='search-box'>
           <form method='get' action='/keyboards' name='f'>
-            <input id="search-q" type="text" placeholder="New keyboard search" name="q">
+            <input id="search-q" type="text" placeholder="<?= KeyboardDetails::$strings['New keyboard search'] ?>" name="q">
             <input id='search-page' type='hidden' name='page'>
-            <input id="search-f" type="image" src="<?= cdn('img/search-button.png') ?>" value="Search">
+            <input id="search-f" type="image" src="<?= cdn('img/search-button.png') ?>" value="<?= KeyboardDetails::$strings['Search'] ?>">
           </form>
         </div>
 <?php
@@ -343,11 +403,14 @@ END;
         $id = self::$id;
         echo "
           <div>
-            <a href='/keyboards/$dep$session_query_q' class='deprecated'><span>Important note:</span>
-            This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called <span>$dep</span>, instead.</a>
+            <a href='/keyboards/$dep$session_query_q' class='deprecated'>
+            <span> " . KeyboardDetails::$strings['Important note:'] . " </span>" .
+            KeyboardDetails::$strings['This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called'] . 
+            " <span>$dep</span>" . KeyboardDetails::$strings[', instead.'] . "</a>
           </div>
           <div>
-            <p class='deprecated-link'><a href='javascript:toggleDeprecatedVersionDetails()'>View details for obsolete version instead</a></p>
+            <p class='deprecated-link'><a href='javascript:toggleDeprecatedVersionDetails()'>" . 
+            KeyboardDetails::$strings['View details for obsolete version instead'] . "</a></p>
             <div id='deprecated-old'>
 
         ";
@@ -372,7 +435,7 @@ END;
 
       if ($embed_win && isset(self::$keyboard->minKeymanVersion) && version_compare(self::$keyboard->minKeymanVersion, $embed_version) > 0) {
 ?>
-        <p>Sorry, this keyboard requires Keyman <?= self::$keyboard->minKeymanVersion ?> or higher.</p>
+        <p><?= Locale::_s(KeyboardDetails::$strings["Sorry, this keyboard requires Keyman %s or higher."], self::$keyboard->minKeymanVersion) ?> </p>
 <?php
       } else {
         echo $text;
@@ -427,7 +490,7 @@ END;
       $webtext = self::WriteWebBoxes(false);
       $cdnUrlBase = KeymanWebHost::getKeymanWebUrlBase();
       ?>
-        <h2 id='try-header' class='red underline'>Try this keyboard</h2>
+        <h2 id='try-header' class='red underline'><?= KeyboardDetails::$strings['Try this keyboard'] ?></h2>
         <div id='try-box'>
           <input type='text' id='try-keyboard'>
           <div id='osk-host'></div>
@@ -467,45 +530,46 @@ END;
 
       // this is html, trusted in database
       ?>
-      <h2 class='red underline'>Keyboard Details</h2>
+      <h2 class='red underline'><?= KeyboardDetails::$strings["Keyboard Details"] ?></h2>
       <div class='cols' id='keyboard-details-col'>
         <div class='col'>
 
           <table id='keyboard-details'>
             <tbody>
             <tr>
-              <th>Keyboard ID</th>
+              <th><?= KeyboardDetails::$strings["Keyboard ID"] ?></th>
               <td><?= htmlentities(self::$id) ?></td>
             </tr>
             <tr>
-              <th>Supported Platforms</th>
+              <th><?= KeyboardDetails::$strings["Supported Platforms"] ?></th>
               <td><?= self::$keyboardPlatforms ?></td>
             </tr>
             <tr>
-              <th>Author</th>
+              <th><?= KeyboardDetails::$strings["Author"] ?></th>
               <td><?= htmlentities(self::$authorName) ?></td>
             </tr>
             <tr>
-              <th>License</th>
+              <th><?= KeyboardDetails::$strings["License"] ?></th>
               <td><?= self::$license ?></td>
             </tr>
             <tr>
-              <th>Documentation</th>
+              <th><?= KeyboardDetails::$strings["Documentation"] ?></th>
               <td>
 <?php
-              if (isset(self::$keyboard->helpLink)) {
+              if (isset(self::$keyboard->helpLink2)) {
 ?>
                 <a <?= $embed_target ?>
-                  href='<?= self::$keyboard->helpLink ?>'>Keyboard help</a>
+                  href='<?= self::$keyboard->helpLink ?>'><?= KeyboardDetails::$strings["Keyboard help"] ?></a>
 <?php
               } else {
-                echo "Help not available.";
+                $helpNotAvailable = KeyboardDetails::$strings['Help not available.'];
+                echo KeyboardDetails::$strings['Help not available.'];
               }
 ?>
               </td>
             </tr>
             <tr>
-              <th>Source</th>
+              <th><?= KeyboardDetails::$strings["Source"] ?></th>
               <td>
 <?php
                 if (isset(self::$keyboard->sourcePath) && preg_match('/^(release|experimental)\//', self::$keyboard->sourcePath)) {
@@ -514,15 +578,15 @@ END;
                     href='<?= GITHUB_ROOT . htmlentities(self::$keyboard->sourcePath) ?>'><?= htmlentities(self::$keyboard->sourcePath) ?></a>
 <?php
                 } else {
-                  echo "Source not available.";
+                  echo KeyboardDetails::$strings["Source not available."];
                 } ?>
               </td>
             <tr>
-              <th>Keyboard Version</th>
+              <th><?= KeyboardDetails::$strings["Keyboard Version"] ?></th>
               <td><?= htmlentities(self::$keyboard->version) ?></td>
             </tr>
             <tr>
-              <th>Last Updated</th>
+              <th><?= KeyboardDetails::$strings["Last Updated"] ?></th>
               <td><?= self::$keyboardLastModifiedDate ?></td>
             </tr>
             </tbody>
@@ -537,31 +601,31 @@ END;
               if(isset(self::$keyboard->packageFilename)) {
 ?>
             <tr>
-              <th>Package Download</th>
+              <th><?= KeyboardDetails::$strings["Package Download"] ?></th>
               <td><a href="<?= self::$kmpDownloadUrl ?>" rel="nofollow"><?= self::$keyboard->id ?>.kmp</a></td>
             </tr>
 <?php
               }
 ?>
             <tr>
-              <th>Monthly Downloads</th>
+              <th><?= KeyboardDetails::$strings["Monthly Downloads"] ?></th>
               <td><?= number_format(self::$downloadCount) ?></td>
             </tr>
             <tr>
-              <th>Total Downloads</th>
-              <td title='Downloads since October 2019'><?= number_format(self::$totalDownloadCount) ?></td>
+              <th><?= KeyboardDetails::$strings["Total Downloads"] ?></th>
+              <td title='<?= Locale::_s(KeyboardDetails::$strings["Downloads since %s"], "October 2019") ?>'><?= number_format(self::$totalDownloadCount) ?></td>
             </tr>
             <tr>
-              <th>Encoding</th>
+              <th><?= KeyboardDetails::$strings["Encoding"] ?></th>
               <td><?= self::$keyboardEncoding ?></td>
             </tr>
             <tr>
-              <th>Minimum Keyman Version</th>
+              <th><?= Locale::_s(KeyboardDetails::$strings["Minimum %s Version"], "Keyman") ?></th>
               <td><?= self::$minVersion ?></td>
             </tr>
             <?php if (isset(self::$keyboard->related)) { ?>
               <tr>
-                <th>Related Keyboards</th>
+                <th><?= KeyboardDetails::$strings["Related Keyboards"] ?></th>
                 <td>
                   <?php
                   foreach (self::$keyboard->related as $name => $value) {
@@ -571,19 +635,25 @@ END;
                     // schema.
                     $s = @file_get_contents($KeymanHosts->api_keyman_com . '/keyboard/' . rawurlencode($name));
                     if ($s === FALSE) {
-                      echo "<span class='keyboard-unavailable' title='This keyboard is not available on {$KeymanHosts->keyman_com_host}'>$hname</span> ";
+                      echo "<span class='keyboard-unavailable' title='" .  
+                        Locale::_s(KeyboardDetails::$strings['This keyboard is not available on %s'], $KeymanHosts->keyman_com_host) . 
+                        "'>$hname</span> ";
                     } else {
                       echo "<a href='/keyboards/$hname$session_query_q'>$hname</a> ";
                     }
-                    if (isset($value->deprecates) && $value->deprecates) echo " (deprecated) ";
-                    if (isset($value->deprecatedBy) && $value->deprecatedBy) echo " (new version) ";
+                    if (isset($value->deprecates) && $value->deprecates)  {
+                      echo KeyboardDetails::$strings['(deprecated)'];
+                    }
+                    if (isset($value->deprecatedBy) && $value->deprecatedBy) {
+                      echo KeyboardDetails::$strings['(new version)'];
+                    }
                   }
                   ?>
                 </td>
               </tr>
             <?php } ?>
             <tr>
-              <th>Supported Languages</th>
+              <th><?= KeyboardDetails::$strings["Supported Languages"] ?></th>
               <td class='supported-languages'>
                 <?php
                   (function() {
@@ -596,8 +666,10 @@ END;
 
                     foreach($langs as $bcp47 => $detail) {
                       if($n == 3) {
-                        echo " <a id='expand-languages' href='#expand-languages'>Expand $count more &gt;&gt;</a>";
-                        echo "<a id='collapse-languages' href='#collapse-languages'>&lt;&lt; Collapse</a> <span class='expand-languages'>";
+                        echo " <a id='expand-languages' href='#expand-languages'>" . 
+                          Locale::_s(KeyboardDetails::$strings['Expand %s more %s'], $count, ">>") . "</a>";
+                        echo "<a id='collapse-languages' href='#collapse-languages'>" . 
+                          Locale::_s(KeyboardDetails::$strings['%s Collapse'], "<<") . "</a> <span class='expand-languages'>";
                       }
                       if (property_exists($detail, 'languageName')) {
                         echo
@@ -623,7 +695,7 @@ END;
       </div>
 
       <p id='permalink'>
-        Permanent link to this keyboard:
+        <?= KeyboardDetails::$strings["Permanent link to this keyboard:"] ?>
         <a <?= $embed_target ?> href='<?= KeymanHosts::Instance()->keyman_com ?>/keyboards/<?= self::$keyboard->id ?>'>
           <?= KeymanHosts::Instance()->keyman_com ?>/keyboards/<?= self::$keyboard->id ?>
         </a>
@@ -635,7 +707,7 @@ END;
 ?>
     <div class='qrcode-host qrcode-<?=$context?>'>
       <div id="qrcode-<?=$context?>"></div>
-      <div class='qrcode-caption'>Scan this code to load this keyboard on another device</div>
+      <div class='qrcode-caption'><?= KeyboardDetails::$strings["Scan this code to load this keyboard on another device"] ?></div>
     </div>
     <script type="text/javascript">
       new QRCode(document.getElementById("qrcode-<?=$context?>"), {

--- a/_includes/locale/en/LC_MESSAGES/keyboards-details-en.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-details-en.po
@@ -1,0 +1,176 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+# Default English strings for keyboards/keyboard-details.php
+
+# Placeholder for new keyboard search
+msgid "New keyboard search"
+msgstr "New keyboard search"
+
+# Search Button Value
+msgid "Search"
+msgstr "Search"
+
+# "Install keyboard" button text
+msgid "Install keyboard"
+msgstr "Install keyboard"
+
+# "Install keyboard" button description
+msgid "Installs %s for %s on this device"
+msgstr "Installs %s for %s on this device"
+
+# Try this keyboard heading
+msgid "Try this keyboard"
+msgstr "Try this keyboard"
+
+# "Use keyboard online" button text
+msgid "Use keyboard online"
+msgstr "Use keyboard online"
+
+# "Full online editor" button text
+msgid "Full online editor"
+msgstr "Full online editor"
+
+# "Use keyboard online" button description
+msgid "Use %s in your web browser. No need to install anything."
+msgstr "Use %s in your web browser. No need to install anything."
+
+# Scan this QR code
+msgid "Scan this code to load this keyboard on another device"
+msgstr "Scan this code to load this keyboard on another device"
+
+# Headers in Keyboard Details section
+
+msgid "Keyboard Details"
+msgstr "Keyboard Details"
+
+msgid "Keyboard ID"
+msgstr "Keyboard ID"
+
+msgid "Supported Platforms"
+msgstr "Supported Platforms"
+
+msgid "Author"
+msgstr "Author"
+
+msgid "License"
+msgstr "License"
+
+msgid "Documentation"
+msgstr "Documentation"
+
+msgid "Keyboard help"
+msgstr "Keyboard help"
+
+msgid "Help not available."
+msgstr "Help not available."
+
+msgid "Source"
+msgstr "Source"
+
+msgid "Source not available."
+msgstr "Source not available."
+
+msgid "Keyboard Version"
+msgstr "Keyboard Version"
+
+msgid "Last Updated"
+msgstr "Last Updated"
+
+msgid "Package Download"
+msgstr "Package Download"
+
+msgid "Monthly Downloads"
+msgstr "Monthly Downloads"
+
+msgid "Total Downloads"
+msgstr "Total Downloads"
+
+# Total Downloads title - Downloads since [date]
+msgid "Downloads since %s"
+msgstr "Downloads since %s"
+
+msgid "Encoding"
+msgstr "Encoding"
+
+# Encoding list
+msgid "Unicode, Legacy (ANSI)"
+msgstr "Unicode, Legacy (ANSI)"
+
+# Unicode encoding
+msgid "Unicode"
+msgstr "Unicode"
+
+# Legacy (ANSI) encoding
+msgid "Legacy (ANSI)"
+msgstr "Legacy (ANSI)"
+
+# Minimum Keyman Version
+msgid "Minimum %s Version"
+msgstr "Minimum %s Version"
+
+msgid "Related Keyboards"
+msgstr "Related Keyboards"
+
+# This keyboard is not available on keyman.com
+msgid "This keyboard is not available on %s"
+msgstr "This keyboard is not available on %s"
+
+msgid "(deprecated)"
+msgstr "(deprecated)"
+
+msgid "(new version)"
+msgstr "(new version)"
+
+msgid "Supported Languages"
+msgstr "Supported Languages"
+
+# Expand {count} more >>
+msgid "Expand %s more %s"
+msgstr "Expand %s more %s"
+
+# << Collapse
+msgid "%s Collapse"
+msgstr "%s Collapse"
+
+msgid "Permanent link to this keyboard:"
+msgstr "Permanent link to this keyboard:"
+
+## Obsolete keyboard notes
+
+msgid "Important note:"
+msgstr "Important note:"
+
+msgid "This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called"
+msgstr "This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called"
+
+msgid ", instead."
+msgstr ", instead."
+
+msgid "View details for obsolete version instead"
+msgstr "View details for obsolete version instead"
+
+msgid "New search"
+msgstr "New search"
+
+## TODO: Previous/Next pagination handled in search.js
+
+
+## Errors
+
+# Failed to load keyboard [ID]
+msgid "Failed to load keyboard %s"
+msgstr "Failed to load keyboard %s"
+
+# Error returned from api.keyman.com: {error string}
+msgid "Error returned from %s: %s"
+msgstr "Error returned from %s: %s"
+
+# Keyboard [ID] not found
+msgid "Keyboard %s not found."
+msgstr "Keyboard %s not found."
+
+# Sorry, this keyboard requires Keyman {minimum version} or higher.
+msgid "Sorry, this keyboard requires Keyman %s or higher."
+msgstr "Sorry, this keyboard requires Keyman %s or higher."

--- a/_includes/locale/en/LC_MESSAGES/keyboards-details-es-ES.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-details-es-ES.po
@@ -1,0 +1,176 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: keymancom\n"
+"X-Crowdin-Project-ID: 740839\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /master/keyboards/keyboards-details-en.po\n"
+"X-Crowdin-File-ID: 626\n"
+"Project-Id-Version: keymancom\n"
+"Language-Team: Spanish\n"
+"Language: es_ES\n"
+"PO-Revision-Date: 2024-12-17 06:13\n"
+
+# Placeholder for new keyboard search
+msgid "New keyboard search"
+msgstr "Nueva búsqueda de teclado"
+
+# Search Button Value
+msgid "Search"
+msgstr "Buscar"
+
+# "Install keyboard" button text
+msgid "Install keyboard"
+msgstr "Instalar teclado"
+
+# "Install keyboard" button description
+msgid "Installs %s for %s on this device"
+msgstr "Instalaciones %s para %s en este dispositivo"
+
+# Try this keyboard heading
+msgid "Try this keyboard"
+msgstr "Prueba este teclado"
+
+# "Use keyboard online" button text
+msgid "Use keyboard online"
+msgstr "Utilizar el teclado en línea"
+
+# "Full online editor" button text
+msgid "Full online editor"
+msgstr "Editor en línea completo"
+
+# "Use keyboard online" button description
+msgid "Use %s in your web browser. No need to install anything."
+msgstr "Usar %s en tu navegador web. No es necesario instalar nada."
+
+# Scan this QR code
+msgid "Scan this code to load this keyboard on another device"
+msgstr "Escanee este código para cargar este teclado en otro dispositivo"
+
+msgid "Keyboard Details"
+msgstr "Detalles del teclado"
+
+msgid "Keyboard ID"
+msgstr "Identificación del teclado"
+
+msgid "Supported Platforms"
+msgstr "Plataformas compatibles"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Licencia"
+
+msgid "Documentation"
+msgstr "Documentación"
+
+msgid "Keyboard help"
+msgstr "Ayuda con el teclado"
+
+msgid "Help not available."
+msgstr "Ayuda no disponible."
+
+msgid "Source"
+msgstr "Fuente"
+
+msgid "Source not available."
+msgstr "Fuente no disponible."
+
+msgid "Keyboard Version"
+msgstr "Versión de teclado"
+
+msgid "Last Updated"
+msgstr "Última actualización"
+
+msgid "Package Download"
+msgstr "Descarga del paquete"
+
+msgid "Monthly Downloads"
+msgstr "Descargas mensuales"
+
+msgid "Total Downloads"
+msgstr "Descargas totales"
+
+# Total Downloads title - Downloads since [date]
+msgid "Downloads since %s"
+msgstr "Descargas desde %s"
+
+msgid "Encoding"
+msgstr "Codificación"
+
+# Encoding list
+msgid "Unicode, Legacy (ANSI)"
+msgstr "Unicode, Legado (ANSI)"
+
+# Unicode encoding
+msgid "Unicode"
+msgstr ""
+
+# Legacy (ANSI) encoding
+msgid "Legacy (ANSI)"
+msgstr "Legado (ANSI)"
+
+# Minimum Keyman Version
+msgid "Minimum %s Version"
+msgstr "Versión mínima de %s"
+
+msgid "Related Keyboards"
+msgstr "Teclados relacionados"
+
+# This keyboard is not available on keyman.com
+msgid "This keyboard is not available on %s"
+msgstr "Este teclado no está disponible en %s"
+
+msgid "(deprecated)"
+msgstr "(obsoleta)"
+
+msgid "(new version)"
+msgstr "(nueva versión)"
+
+msgid "Supported Languages"
+msgstr "Idiomas compatibles"
+
+# Expand {count} more >>
+msgid "Expand %s more %s"
+msgstr "Expandir %s más %s"
+
+# << Collapse
+msgid "%s Collapse"
+msgstr "%s Colapsar"
+
+msgid "Permanent link to this keyboard:"
+msgstr "Enlace permanente a este teclado:"
+
+msgid "Important note:"
+msgstr "Nota importante:"
+
+msgid "This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called"
+msgstr "Esta es una versión obsoleta de este teclado. A menos que tenga una buena razón, haga clic aquí para instalar la nueva versión, llamada"
+
+msgid ", instead."
+msgstr ", en cambio."
+
+msgid "View details for obsolete version instead"
+msgstr "Ver detalles de la versión obsoleta en su lugar"
+
+msgid "New search"
+msgstr "Nueva búsqueda"
+
+# Failed to load keyboard [ID]
+msgid "Failed to load keyboard %s"
+msgstr "No se pudo cargar el teclado %s"
+
+# Error returned from api.keyman.com: {error string}
+msgid "Error returned from %s: %s"
+msgstr "Error devuelto desde %s: %s"
+
+# Keyboard [ID] not found
+msgid "Keyboard %s not found."
+msgstr "Teclado %s extraviado."
+
+# Sorry, this keyboard requires Keyman {minimum version} or higher.
+msgid "Sorry, this keyboard requires Keyman %s or higher."
+msgstr "Lo sentimos, este teclado requiere Keyman %s o superior."
+

--- a/_includes/locale/en/LC_MESSAGES/keyboards-details-fr-FR.po
+++ b/_includes/locale/en/LC_MESSAGES/keyboards-details-fr-FR.po
@@ -1,0 +1,186 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Crowdin-Project: keymancom\n"
+"X-Crowdin-Project-ID: 740839\n"
+"X-Crowdin-Language: fr\n"
+"X-Crowdin-File: /master/keyboards/keyboards-details.po\n"
+"X-Crowdin-File-ID: 2\n"
+"Project-Id-Version: keymancom\n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"PO-Revision-Date: 2024-11-11 08:15\n"
+
+# French strings for keyboards/keyboard-details.php
+
+# Placeholder for new keyboard search
+msgid "New keyboard search"
+msgstr "Nouvelle recherche de clavier"
+
+# Search Button Value
+msgid "Search"
+msgstr "Recherche"
+
+# "Install keyboard" button text
+msgid "Install keyboard"
+msgstr "Installer le clavier"
+
+# "Install keyboard" button description
+msgid "Installs %s for %s on this device"
+msgstr "Installer %s pour %s sur cet appareil"
+
+# Try this keyboard heading
+msgid "Try this keyboard"
+msgstr "Essayez ce clavier"
+
+# "Use keyboard online" button text
+msgid "Use keyboard online"
+msgstr "Utiliser le clavier en ligne"
+
+# "Full online editor" button text
+msgid "Full online editor"
+msgstr "Éditeur en ligne complet"
+
+# "Use keyboard online" button description
+msgid "Use %s in your web browser. No need to install anything."
+msgstr "Utiliser %s dans votre navigateur Web. Aucune installation n'est nécessaire."
+
+# Scan this QR code
+msgid "Scan this code to load this keyboard on another device"
+msgstr "Scannez ce code pour charger ce clavier sur un autre appareil"
+
+# Headers in Keyboard Details section
+
+msgid "Keyboard Details"
+msgstr "Détails du clavier"
+
+msgid "Keyboard ID"
+msgstr "ID du clavier"
+
+msgid "Supported Platforms"
+msgstr "Plateformes prises en charge"
+
+msgid "Author"
+msgstr "Auteur"
+
+msgid "License"
+msgstr "Licence"
+
+msgid "Documentation"
+msgstr "Documentation"
+
+msgid "Keyboard help"
+msgstr "Aide au clavier"
+
+msgid "Help not available."
+msgstr "Aide non disponible."
+
+msgid "Source"
+msgstr "Source"
+
+msgid "Source not available."
+msgstr "Source non disponible."
+
+msgid "Keyboard Version"
+msgstr "Version clavier"
+
+msgid "Last Updated"
+msgstr "Dernière mise à jour"
+
+msgid "Package Download"
+msgstr "Téléchargement du package"
+
+msgid "Monthly Downloads"
+msgstr "Téléchargements mensuels"
+
+msgid "Total Downloads"
+msgstr "Téléchargements totaux"
+
+# Total Downloads title - Downloads since [date]
+msgid "Downloads since %s"
+msgstr "Téléchargements depuis %s"
+
+msgid "Encoding"
+msgstr "Codage"
+
+# Encoding list
+msgid "Unicode, Legacy (ANSI)"
+msgstr "Unicode, Héritage (ANSI)"
+
+# Unicode encoding
+msgid "Unicode"
+msgstr "Unicode"
+
+# Legacy (ANSI) encoding
+msgid "Legacy (ANSI)"
+msgstr "Héritage (ANSI)"
+
+# Minimum Keyman Version
+msgid "Minimum %s Version"
+msgstr "Version minimale de %s"
+
+msgid "Related Keyboards"
+msgstr "Claviers associés"
+
+# This keyboard is not available on keyman.com
+msgid "This keyboard is not available on %s"
+msgstr "Ce clavier n'est pas disponible sur %s"
+
+msgid "(deprecated)"
+msgstr "(obsolète)"
+
+msgid "(new version)"
+msgstr "(nouvelle version)"
+
+msgid "Supported Languages"
+msgstr "Langues prises en charge"
+
+# Expand {count} more >>
+msgid "Expand %s more %s"
+msgstr "Développer %s plus %s"
+
+# << Collapse
+msgid "%s Collapse"
+msgstr "%s Effondrement"
+
+msgid "Permanent link to this keyboard:"
+msgstr "Lien permanent vers ce clavier:"
+
+## Obsolete keyboard notes
+
+msgid "Important note:"
+msgstr "Remarque importante :"
+
+msgid "This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called"
+msgstr "Il s'agit d'une version obsolète de ce clavier. Sauf si vous avez une bonne raison, cliquez ici pour installer la nouvelle version, appelée"
+
+msgid ", instead."
+msgstr ", plutôt."
+
+msgid "View details for obsolete version instead"
+msgstr "Afficher les détails de la version obsolète à la place"
+
+msgid "New search"
+msgstr "Nouvelle recherche"
+
+## TODO: Previous/Next pagination handled in search.js
+
+
+## Errors
+
+# Failed to load keyboard [ID]
+msgid "Failed to load keyboard %s"
+msgstr "Impossible de charger le clavier %s"
+
+# Error returned from api.keyman.com: {error string}
+msgid "Error returned from %s: %s"
+msgstr "Erreur renvoyée par %s: %s"
+
+# Keyboard [ID] not found
+msgid "Keyboard %s not found."
+msgstr "Claviere %s non trouvé."
+
+# Sorry, this keyboard requires Keyman {minimum version} or higher.
+msgid "Sorry, this keyboard requires Keyman %s or higher."
+msgstr "Désolé, ce clavier nécessite Keyman %s ou supérieur."


### PR DESCRIPTION
Follows #521 for #384

This uses Locale.php to generate an array of localized strings for the keyboard details page.
The array of localized strings is managed at the top of details in `$strings`.

A few **notes**:
* The keyboard descriptions remain in English because the content comes from keyboard info in api.keyman.com
* The "Search" button image is in English

## Screenshots

### khmer_angkor (details in French)
http://keyman.com.localhost/keyboards/khmer_angkor?lang=fr-FR

![khmer_angkor-FR](https://github.com/user-attachments/assets/2bb6b400-3e87-4e39-9160-64b74f343b40)

----

### cs-pinyin (obsolete keyboard, details in Spanish)
http://keyman.com.localhost/keyboards/cs-pinyin?lang=es-ES

![cs-pinyin-ES](https://github.com/user-attachments/assets/05ae95a3-6e99-4483-bc54-5e0a19aa45b6)

----

### sil_ipa (details in English for reference)

http://keyman.com.localhost/keyboards/sil_ipa?lang=en


![sil_ipa-EN](https://github.com/user-attachments/assets/101762d1-864e-4bc4-87ac-3b931633c7b0)
