### PR TITLE
fix: Append query string for /keyboards/languages searches

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -108,7 +108,7 @@ RewriteRule "^keyboards/(?!index\.php|install|keyboard|session|share)([^/]+)$" "
 # RewriteRule "^keyboards$" "/keyboards/index.php" [L]
 
 # /keyboards/languages to /keyboards/index.php
-RewriteRule "^keyboards/languages/(.*)" "/keyboards/index.php?q=l:id:$1" [END]
+RewriteRule "^keyboards/languages/(.*)" "/keyboards/index.php?q=l:id:$1" [END,QSA]
 
 # /keyboards/download to /keyboards/download.php
 RewriteRule "^keyboards/download(.php)?" "/keyboards/download.php" [END,QSA]


### PR DESCRIPTION
I believe this addresses keymanapp/keyman#12797

In Keyman for Android, the language search for keyboards wasn't shown in an embedded search

https://keyman.com/keyboards/languages/en?embed=android&embed_version=18.0
![image](https://github.com/user-attachments/assets/ad9bfc5d-02f4-4595-b758-9ac446ce0205)


This updates .htaccess to preserve the [query string](https://httpd.apache.org/docs/current/rewrite/flags.html#flag_qsa)


http://keyman.com.localhost/keyboards/languages/en?embed=android&embed_version=18.0
![image](https://github.com/user-attachments/assets/63ffe63c-f981-4edc-ac26-4337414100d7)
