### PR TITLE
chore: Update shared-sites to v0.15

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.11
+readonly BOOTSTRAP_VERSION=v0.15
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 


### PR DESCRIPTION
Update shared-sites to v0.15 notably:
* Adds GFM-style alerts
* Fix BASH syntax in docker.inc.sh
