### PR TITLE
chore: add a section to `about/developers`

### DIFF
--- a/about/developers/index.md
+++ b/about/developers/index.md
@@ -116,9 +116,9 @@ With degrees in Electronics and Information Technology from QUT, I have worked a
 
 During my 3rd year of acquiring a computer science degree at National Polytechnic Institute of Cambodia, I got the opportunity to be involved in the Keyman's work, and until the 4th year, I got a role in Keyman as a Technical Support Engineer. If you are interested in my study, I have the source code (Laravel) of my Thesis on [GitHub](https://github.com/Meng-Heng/bus_ticketing_web).
 
-I managed to obtain some experience through an internship in Web Development for a POS system company based in Toul Kork, Phnom Penh, Cambodia. Also, I worked on simplistic apps and websites before the deadlines and kept up with the various programming languages the school had.
+I managed to obtain some experience through an internship in Web Development for a POS system company based in Toul Kork, Phnom Penh, Cambodia. I also worked on simplistic app and website design and development to submit the classes' deadlines and kept up with the various programming languages the school had.
 
-After successfully defending my Thesis and graduating, I continue to have a passion for supporting Keyman's users. The responsibility of a technical support engineer is to provide and form sophisticated help instructions according to users' requirements, monitor Keyman's social platforms and blogs, write documents, report bugs to the product developers, and use programming skills to fix bugs, add features, and make updates to Keyman websites.
+After successfully defending my Thesis and graduating, I continue to have a passion for supporting Keyman's users. The responsibility of a technical support engineer is to provide and form sophisticated help instructions according to users' requirements, monitor Keyman's social platforms and blogs, write documents, report bugs to the product developers, and use programming skills to fix bugs, add features, and make updates to the Keyman websites.
 
 ## Previous Contributors
 

--- a/about/developers/index.md
+++ b/about/developers/index.md
@@ -108,6 +108,18 @@ My personal website can be found at [markcsinclair.co.uk](https://markcsinclair.
 <br/>
 With degrees in Electronics and Information Technology from QUT, I have worked across various roles in software and electronics engineering. This has given me experience in high-availability systems, microcontroller design, and software development. With Keyman, I contribute mostly to the Keyman for Windows product. I am based in Australia and outside of work, I enjoy spending time with my family, mountain biking and road cycling.
 
+----
+
+![](https://github.com/Meng-Heng.png?size=240)
+
+### MengHeng Hav
+
+During my 3rd year of acquiring a computer science degree at National Polytechnic Institute of Cambodia, I got the opportunity to be involved in the Keyman's work, and until the 4th year, I got a role in Keyman as a Technical Support Engineer. If you are interested in my study, I have the source code (Laravel) of my Thesis on [GitHub](https://github.com/Meng-Heng/bus_ticketing_web).
+
+I managed to obtain some experience through an internship in Web Development for a POS system company based in Toul Kork, Phnom Penh, Cambodia. Also, I worked on simplistic apps and websites before the deadlines and kept up with the various programming languages the school had.
+
+After successfully defending my Thesis and graduating, I continue to have a passion for supporting Keyman's users. The responsibility of a technical support engineer is to provide and form sophisticated help instructions according to users' requirements, monitor Keyman's social platforms and blogs, write documents, report bugs to the product developers, and use programming skills to fix bugs, add features, and make updates to Keyman websites.
+
 ## Previous Contributors
 
 More about [previous contributors](./previous)

--- a/about/developers/index.md
+++ b/about/developers/index.md
@@ -113,7 +113,7 @@ With degrees in Electronics and Information Technology from QUT, I have worked a
 ![](https://github.com/Meng-Heng.png?size=240)
 
 ### MengHeng Hav
-
+<br/>
 During my 3rd year of acquiring a computer science degree at National Polytechnic Institute of Cambodia, I got the opportunity to be involved in the Keyman's work, and until the 4th year, I got a role in Keyman as a Technical Support Engineer. If you are interested in my study, I have the source code (Laravel) of my Thesis on [GitHub](https://github.com/Meng-Heng/bus_ticketing_web).
 
 I managed to obtain some experience through an internship in Web Development for a POS system company based in Toul Kork, Phnom Penh, Cambodia. I also worked on simplistic app and website design and development to submit the classes' deadlines and kept up with the various programming languages the school had.


### PR DESCRIPTION
I remember @mcdurdin mentioned adding a section to the about/developer page so I waited until graduating. I could not find that message now but I hope this is the correct place to add.

![image](https://github.com/user-attachments/assets/bb4b2e48-85ba-4a95-9a45-c0636729d83a)

This PR is ready for review.

Thank you!