### PR TITLE
refactor: clean up KeymanHosts usage and make consistent

### DIFF
--- a/12/index.php
+++ b/12/index.php
@@ -3,6 +3,7 @@
   require_once('includes/ui/downloads.php');
   require_once('includes/appstore.php');
   require_once('includes/playstore.php');
+  use \Keyman\Site\Common\KeymanHosts;
 
   // Required
   head([
@@ -32,14 +33,14 @@
 <p>Keyman Developer includes all the functionality you need to create dictionaries for your language.
 Distribute dictionaries directly through Keyman or peer-to-peer in your community.</p>
 
-<p><a href='<?=$KeymanHosts->help_keyman_com?>/developer/12.0/guides/lexical-models/'>Learn more about creating dictionaries</a></p>
+<p><a href='<?=KeymanHosts::Instance()->help_keyman_com?>/developer/12.0/guides/lexical-models/'>Learn more about creating dictionaries</a></p>
 
 <p style='text-align: center'><img src='predictive-text-editor.png'></p>
 
 <h2>There's more!</h2>
 
 <p>We have made many other smaller changes and improvements to Keyman 12, such as a new Welcome screen in Keyman Developer,
-and improvements to the stability of Keyman for MacOS. Read about all the changes in our <a href='<?=$KeymanHosts->help_keyman_com?>/version-history'>release notes</a>.</p>
+and improvements to the stability of Keyman for MacOS. Read about all the changes in our <a href='<?=KeymanHosts::Instance()->help_keyman_com?>/version-history'>release notes</a>.</p>
 
 <h1 class='red underline large'>Get Involved</h1>
 

--- a/13/index.php
+++ b/13/index.php
@@ -3,6 +3,7 @@ require_once('includes/template.php');
 require_once('includes/ui/downloads.php');
 require_once('includes/appstore.php');
 require_once('includes/playstore.php');
+use \Keyman\Site\Common\KeymanHosts;
 
 // Required
 head([
@@ -32,7 +33,7 @@ head([
 <h2>There's more!</h2>
 <p>We have made many other smaller changes and improvements to Keyman 13, such as an improved Lexical Model editor in Keyman Developer,
 improvements to context handling in Keyman for macOS, and setting keyboard options in Keyman for Linux. Read about all the changes in our
-<a href='<?=$KeymanHosts->help_keyman_com?>/version-history'>release notes</a>.
+<a href='<?=KeymanHosts::Instance()->help_keyman_com?>/version-history'>release notes</a>.
 
 <h1 class='red underline large'>Get Involved</h1>
 

--- a/14/index.php
+++ b/14/index.php
@@ -45,7 +45,7 @@ head([
     Mobile apps download and install keyboard packages from keyman.com
   </li>
   <li>
-    Consolidated crash reporting to <a href="<?= KeymanHosts::Instance()->sentry_keyman_com ?>">sentry.keyman.com</a>
+    Consolidated crash reporting to sentry.keyman.com
   </li>
   <li>
     Many bug fixes and improvements (see the <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>/version-history">version history</a>)

--- a/_control/info.php
+++ b/_control/info.php
@@ -6,3 +6,35 @@
 
   echo "<p><a href='./alive'>Alive</a></p>";
   echo "<p><a href='./ready'>Ready</a></p>";
+
+?>
+<table border=1>
+  <thead><tr><th>Site</th><th>Backend URL</th><th>Frontend URL</th></thead>
+  <tbody>
+    <tr>
+      <td>api.keyman.com</td>
+      <td><?= KeymanHosts::Instance()->SERVER_api_keyman_com ?></td>
+      <td><?= KeymanHosts::Instance()->api_keyman_com ?></td>
+    </tr>
+    <tr>
+      <td>help.keyman.com</td>
+      <td><?= KeymanHosts::Instance()->SERVER_help_keyman_com ?></td>
+      <td><?= KeymanHosts::Instance()->help_keyman_com ?></td>
+    </tr>
+    <tr>
+      <td>keyman.com</td>
+      <td><?= KeymanHosts::Instance()->SERVER_keyman_com ?></td>
+      <td><?= KeymanHosts::Instance()->keyman_com ?></td>
+    </tr>
+    <tr>
+      <td>keymanweb.com</td>
+      <td><?= KeymanHosts::Instance()->SERVER_keymanweb_com ?></td>
+      <td><?= KeymanHosts::Instance()->keymanweb_com ?></td>
+    </tr>
+    <tr>
+      <td>s.keyman.com</td>
+      <td><?= KeymanHosts::Instance()->SERVER_s_keyman_com ?></td>
+      <td><?= KeymanHosts::Instance()->s_keyman_com ?></td>
+    </tr>
+  </tbody>
+</table>

--- a/_ie_thunk/search.php
+++ b/_ie_thunk/search.php
@@ -9,6 +9,8 @@
 
   require_once('includes/servervars.php');
 
+  use Keyman\Site\Common\KeymanHosts;
+
   $q = $_REQUEST['q'];
-  echo file_get_contents("{$KeymanHosts->api_keyman_com}/search?q=".urlencode($q));
+  echo file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com ."/search?q=".urlencode($q));
 ?>

--- a/_includes/2020/KeymanDownloadVersions.php
+++ b/_includes/2020/KeymanDownloadVersions.php
@@ -18,7 +18,7 @@
 
     static function getDownloadUrls() {
       if(empty(self::$versions))
-        self::$versions = @json_decode(file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . '/api/version/2.0'));
+        self::$versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/version/2.0'));
       return self::$versions;
     }
 

--- a/_includes/2020/KeymanWebHost.php
+++ b/_includes/2020/KeymanWebHost.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 namespace Keyman\Site\com\keyman;
+use Keyman\Site\Common\KeymanHosts;
 
 class KeymanWebHost {
   static function getKeymanWebUrlBase() {
-    global $KeymanHosts;
-    $json = @file_get_contents("{$KeymanHosts->api_keyman_com}/version/web");
+    $json = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com."/version/web");
     if($json) {
       $json = json_decode($json);
     }
@@ -18,6 +18,6 @@ class KeymanWebHost {
       $build = "17.0.332";
     }
 
-    return "{$KeymanHosts->s_keyman_com}/kmw/engine/$build";
+    return KeymanHosts::Instance()->s_keyman_com."/kmw/engine/$build";
   }
 }

--- a/_includes/includes/servervars.php
+++ b/_includes/includes/servervars.php
@@ -27,7 +27,6 @@
   require_once(__DIR__ . '/../2020/Util.php');
 
   use \Keyman\Site\Common\KeymanVersion;
-  use \Keyman\Site\Common\KeymanHosts;
   use \Keyman\Site\com\keyman\Util;
 
   // Major stable and beta versions
@@ -46,10 +45,6 @@
   function betaTier() {
     return KeymanVersion::IsBetaTier();
   }
-
-  // TODO refactor away global variable
-  global $KeymanHosts;
-  $KeymanHosts = KeymanHosts::Instance();
 
   // Alpha and Beta signup links
   global $playstore_signup_link, $testflight_alpha_link, $testflight_beta_link;

--- a/_includes/includes/ui/downloads.php
+++ b/_includes/includes/ui/downloads.php
@@ -3,7 +3,7 @@
   require_once __DIR__ . '/../../autoload.php';
   use Keyman\Site\Common\KeymanHosts;
 
-  $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . '/api/version/2.0'));
+  $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/version/2.0'));
   //if($versions === NULL || $versions === FALSE) {
   //  echo "<p class='error'>WARNING: unable to retrieve latest versions of Keyman from download server</p>";
   //}

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -138,7 +138,6 @@ END;
 
     protected static function WriteWebBoxes($useDescription) {
       global $embed_target;
-      global $KeymanHosts;
 
       // only show if the jsFilename property is present in the .keyboard_info
       if(empty(self::$keyboard->jsFilename)) {
@@ -166,7 +165,7 @@ END;
         $lang = self::$bcp47;
       }
       if (!isset($lang)) $lang = 'en';
-      $url = "{$KeymanHosts->keymanweb_com}/#$lang,Keyboard_" . self::GetWebKeyboardId();
+      $url = KeymanHosts::Instance()->keymanweb_com ."/#$lang,Keyboard_" . self::GetWebKeyboardId();
       if($useDescription) {
         $description = htmlentities(self::$keyboard->name);
         $description = "<div class=\"download-description\">Use $description in your web browser. No need to install anything.</div>";
@@ -184,10 +183,10 @@ END;
     }
 
     protected static function LoadData() {
-      global $KeymanHosts, $stable_version;
+      global $stable_version;
 
       self::$error = "";
-      $s = @file_get_contents($KeymanHosts->api_keyman_com . '/keyboard/' . rawurlencode(self::$id));
+      $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com. '/keyboard/' . rawurlencode(self::$id));
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";
@@ -204,7 +203,7 @@ END;
           self::$minVersion = isset(self::$keyboard->minKeymanVersion) ? self::$keyboard->minKeymanVersion : $stable_version;
           self::$license = self::map_license(isset(self::$keyboard->license) ? self::$keyboard->license : 'Unknown');
         } else {
-          self::$error .= "Error returned from {$KeymanHosts->api_keyman_com}: $s\n";
+          self::$error .= "Error returned from ".KeymanHosts::Instance()->api_keyman_com.": $s\n";
           self::$title = 'Failed to load keyboard package ' . self::$id;
           header('HTTP/1.0 500 Internal Server Error');
         }
@@ -249,7 +248,7 @@ END;
 
         self::$downloadCount = 0;
         self::$totalDownloadCount = 0;
-        $s = @file_get_contents($KeymanHosts->api_keyman_com . '/search/2.0?q=k:id:' . rawurlencode(self::$id));
+        $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/search/2.0?q=k:id:' . rawurlencode(self::$id));
         if ($s !== FALSE) {
           $s = json_decode($s);
           if(is_object($s) && is_array(($s->keyboards))) {
@@ -324,8 +323,7 @@ END;
           <p>Keyboard package <?= self::$id ?> not found.</p>
         <?php
         // DEBUG: Only display errors on local sites
-        global $KeymanHosts;
-        if($KeymanHosts->Tier() == KeymanHosts::TIER_DEVELOPMENT && (ini_get('display_errors') !== '0')) {
+        if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT && (ini_get('display_errors') !== '0')) {
           echo "<p>" . self::$error . "</p>";
         }
         exit;
@@ -501,7 +499,7 @@ END;
     }
 
     protected static function WriteKeyboardDetails() {
-      global $embed_target, $session_query_q, $KeymanHosts;
+      global $embed_target, $session_query_q;
 
       // this is html, trusted in database
       ?>
@@ -607,9 +605,10 @@ END;
                     // TODO(lowpri): we could return this information in the API to avoid multiple
                     // round trip queries but that requires more changes to the API, docs, and
                     // schema.
-                    $s = @file_get_contents($KeymanHosts->api_keyman_com . '/keyboard/' . rawurlencode($name));
+                    $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/keyboard/' . rawurlencode($name));
                     if ($s === FALSE) {
-                      echo "<span class='keyboard-unavailable' title='This keyboard is not available on {$KeymanHosts->keyman_com_host}'>$hname</span> ";
+                      echo "<span class='keyboard-unavailable' title='This keyboard is not available on ".
+                        KeymanHosts::Instance()->keyman_com_host."'>$hname</span> ";
                     } else {
                       echo "<a href='/keyboards/$hname$session_query_q'>$hname</a> ";
                     }

--- a/_includes/includes/ui/legacy-keyboard-details.php
+++ b/_includes/includes/ui/legacy-keyboard-details.php
@@ -191,7 +191,6 @@ END;
     }
 
     protected static function WriteWebBoxes() {
-      global $KeymanHosts;
       if (isset(self::$downloads->js)) {
         if (isset(self::$keyboard->platformSupport->desktopWeb) && self::$keyboard->platformSupport->desktopWeb != 'none') {
           if (isset(self::$keyboard->languages)) {
@@ -207,7 +206,7 @@ END;
             }
           }
           if (!isset($lang)) $lang = 'en';
-          $url = "{$KeymanHosts->keymanweb_com}/#$lang,Keyboard_" . self::$keyboard->id;
+          $url = KeymanHosts::Instance()->keymanweb_com. "/#$lang,Keyboard_" . self::$keyboard->id;
           return self::onlinelink_box(
             self::$id,
             $url,
@@ -269,10 +268,10 @@ END;
     }
 
     protected static function LoadData() {
-      global $KeymanHosts, $stable_version;
+      global $stable_version;
 
       self::$error = "";
-      $s = @file_get_contents($KeymanHosts->api_keyman_com . '/keyboard/' . rawurlencode(self::$id));
+      $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/keyboard/' . rawurlencode(self::$id));
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";
@@ -289,13 +288,13 @@ END;
           self::$minVersion = isset(self::$keyboard->minKeymanVersion) ? self::$keyboard->minKeymanVersion : $stable_version;
           self::$license = self::map_license(isset(self::$keyboard->license) ? self::$keyboard->license : 'Unknown');
         } else {
-          self::$error .= "Error returned from {$KeymanHosts->api_keyman_com}: $s\n";
+          self::$error .= "Error returned from ".KeymanHosts::Instance()->api_keyman_com.": $s\n";
           self::$title = 'Failed to load keyboard ' . self::$id;
           header('HTTP/1.0 500 Internal Server Error');
         }
       }
 
-      $s = @file_get_contents($KeymanHosts->downloads_keyman_com . '/api/keyboard/1.0/' . rawurlencode(self::$id) . '?tier=' . self::$tier);
+      $s = @file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/keyboard/1.0/' . rawurlencode(self::$id) . '?tier=' . self::$tier);
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";
@@ -372,8 +371,7 @@ END;
           <p>Keyboard <?= self::$id ?> not found.</p>
         <?php
         // DEBUG: Only display errors on local sites
-        global $KeymanHosts;
-        if($KeymanHosts->Tier() == KeymanHosts::TIER_DEVELOPMENT  && (ini_get('display_errors') !== '0')) {
+        if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT  && (ini_get('display_errors') !== '0')) {
           echo "<p>" . self::$error . "</p>";
         }
         exit;

--- a/_legacy/keyboards/download.php
+++ b/_legacy/keyboards/download.php
@@ -1,4 +1,5 @@
 <?php
+  use Keyman\Site\Common\KeymanHosts;
   define('DEBUG', false);
 
   // Redirects download to the appropriate file on downloads.keyman.com

--- a/_legacy/keyboards/download.php
+++ b/_legacy/keyboards/download.php
@@ -71,9 +71,7 @@
    * Get metadata on the downloadable files from the download server for the keyboard in question
    */
   function getKeyboardDownloadData($id) {
-    global $KeymanHosts;
-
-    $s = @file_get_contents($KeymanHosts->downloads_keyman_com . '/api/keyboard/1.0/' . rawurlencode($id));
+    $s = @file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/keyboard/1.0/' . rawurlencode($id));
     if($s === FALSE) {
       echo "Unable to find keyboard $id";
       exit;

--- a/_legacy/keyboards/keyboard.json.php
+++ b/_legacy/keyboards/keyboard.json.php
@@ -14,7 +14,7 @@
   header('Content-Type: application/json; charset=utf-8');
   header('Access-Control-Allow-Origin: *');
 
-  $kmw = @file_get_contents("{$KeymanHosts->api_keyman_com}/cloud/4.0/keyboards/$id?version=$version&languageidtype=bcp47");
+  $kmw = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com."/cloud/4.0/keyboards/$id?version=$version&languageidtype=bcp47");
   if($kmw === FALSE) {
     header('HTTP/1.0 404 Keyboard not found');
     exit;

--- a/_legacy/keyboards/keyboard.php
+++ b/_legacy/keyboards/keyboard.php
@@ -2,6 +2,7 @@
   require_once('includes/template.php');
   require_once('includes/ui/legacy-keyboard-details.php');
   require_once('./session.php');
+  use Keyman\Site\Common\KeymanHosts;
 
   if(isset($_REQUEST['legacy'])) {
     $id = find_id_by_legacy(clean_id($_REQUEST['legacy']));
@@ -23,8 +24,7 @@
   }
 
   function find_id_by_legacy($legacy) {
-    global $KeymanHosts;
-    $s = @file_get_contents($KeymanHosts->api_keyman_com.'/search/?q=k:legacy:'.rawurlencode($legacy));
+    $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/search/?q=k:legacy:'.rawurlencode($legacy));
     if($s === FALSE) {
       return null;
     }

--- a/_legacy/keyboards/share.php
+++ b/_legacy/keyboards/share.php
@@ -2,6 +2,7 @@
   require_once('includes/template.php');
   require_once('includes/ui/legacy-keyboard-details.php');
   require_once('./session.php');
+  use Keyman\Site\Common\KeymanHosts;
 
   if(!isset($_REQUEST['id'])) {
     header('Location: /keyboards');
@@ -15,8 +16,7 @@
   }
 
   function find_keyboard($id) {
-    global $KeymanHosts;
-    $s = @file_get_contents($KeymanHosts->api_keyman_com.'/keyboard/'.$id);
+    $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/keyboard/'.$id);
     if($s === FALSE) {
       return null;
     }

--- a/android/index.php
+++ b/android/index.php
@@ -108,13 +108,13 @@
       <li>Can now display up to 8 suggestions on screen</li>
       <li>Can drag the banner left and right to see more suggestions</li>
       <li>Shortens long suggestions to avoid long words overwhelming the available space.</li>
-    </ol>  
+    </ol>
   </li>
   <li>Improves scaling of key caps for some keyboards (#10506)</li>
   <li>Add localization for:
     <ol>
-      <li>Mon (Burmese script)</li>  
-    </ol>  
+      <li>Mon (Burmese script)</li>
+    </ol>
   </li>
 </ul>
 
@@ -292,7 +292,7 @@
 </ul>
 <br/>
 <p>
-  <a href="<?= $KeymanHosts->help_keyman_com ?>/products/android/version-history/">View all version history</a>
+  <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>/products/android/version-history/">View all version history</a>
 </p>
 
 <?= $playstoreTable ?>
@@ -307,7 +307,7 @@
   You can develop your own keyboard layouts for Keyman for Android with <a href="/developer/download.php">Keyman Developer</a>. If you have existing keyboards, they can be ported to Android with just a recompile. And of course, we include support for touch-oriented features such as touch-and-hold menus, dynamic keyboard layers and more!
 </p>
 <p>
-  <a href="<?= $KeymanHosts->help_keyman_com ?>/developer/engine/android/">Keyman Engine for Android Documentation</a>
+  <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/engine/android/">Keyman Engine for Android Documentation</a>
 </p>
 <p>
   <a href="/downloads/#android-engine">Download the latest Keyman Engine for Android</a>

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=fix/keyman-hosts-for-server # TODO: v0.17
+readonly BOOTSTRAP_VERSION=v0.17
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.16
+readonly BOOTSTRAP_VERSION=fix/keyman-hosts-for-server # TODO: v0.17
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/developer/keymanweb/keyboards.php
+++ b/developer/keymanweb/keyboards.php
@@ -110,7 +110,7 @@ relies on font source paths being configured in <a href='<?= KeymanHosts::Instan
   <tbody>
 
 <?php
-  $data = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . '/cloud/4.0/keyboards?languageidtype=bcp47&version='.$stable_version);
+  $data = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . '/cloud/4.0/keyboards?languageidtype=bcp47&version='.$stable_version);
   if($data === FALSE) {
     // fallback if API is down, bad news anyway.
     $data = file_get_contents('keyboards.txt');

--- a/developer/keymanweb/keymanweb-version.inc.php
+++ b/developer/keymanweb/keymanweb-version.inc.php
@@ -5,7 +5,7 @@ use Keyman\Site\Common\KeymanHosts;
 
 function getKeymanWebHref()
 {
-  $json = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . "/version/web");
+  $json = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . "/version/web");
   if ($json) {
     $json = json_decode($json);
   }

--- a/downloads/all-versions/index.php
+++ b/downloads/all-versions/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once('includes/template.php');
 require_once('includes/ui/downloads.php');
+use Keyman\Site\Common\KeymanHosts;
 
 // Required
 head([
@@ -13,7 +14,7 @@ head([
 <h2 class="red underline large">Keyman downloads - all versions</h2>
 
 <?php
-$data = json_decode(file_get_contents('https://downloads.keyman.com/api/version/all'));
+$data = json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/version/all'));
 
 if ($data === NULL) {
   die('Error decoding JSON data.');

--- a/downloads/index.php
+++ b/downloads/index.php
@@ -3,6 +3,7 @@
   require_once('includes/ui/downloads.php');
   require_once('includes/appstore.php');
   require_once('includes/playstore.php');
+  use Keyman\Site\Common\KeymanHosts;
 
   // Required
   head([
@@ -21,7 +22,7 @@
   for your language. See also the <a href='pre-release'>pre-release download page</a> and the <a href='archive'>old versions download page</a>.
 </p>
 
-<p><a href='<?=$KeymanHosts->help_keyman_com?>/version-history'>Keyman version history</a> (all products)</p>
+<p><a href='<?= KeymanHosts::Instance()->help_keyman_com?>/version-history'>Keyman version history</a> (all products)</p>
 
 
   <a class="button" href="all-versions">Browse all versions (14.0 onwards)</a>

--- a/downloads/pre-release/index.php
+++ b/downloads/pre-release/index.php
@@ -1,6 +1,7 @@
 <?php
   require_once('includes/template.php');
   require_once('includes/ui/downloads.php');
+  use Keyman\Site\Common\KeymanHosts;
 
   // Required
   head([
@@ -38,7 +39,7 @@
   If neither of these sound like what you wanted: <a href='/downloads/'>download a stable release version of Keyman</a>.
 </p>
 
-<p><a href='<?=$KeymanHosts->help_keyman_com?>/version-history'>Keyman version history</a> (all products)</p>
+<p><a href='<?=KeymanHosts::Instance()->help_keyman_com?>/version-history'>Keyman version history</a> (all products)</p>
 
 <?php
   downloadSection('Keyman for Windows',         'windows', 'keyman-$version.exe', 'beta alpha');

--- a/downloads/releases/_version_downloads.php
+++ b/downloads/releases/_version_downloads.php
@@ -3,6 +3,7 @@
   require_once('includes/ui/downloads.php');
   require_once('includes/appstore.php');
   require_once('includes/playstore.php');
+  use Keyman\Site\Common\KeymanHosts;
 
   if(!isset($_REQUEST['version'])) {
     echo "version parameter is required.";
@@ -28,7 +29,7 @@
 
   // note: we currently ignore the tier parameter
 
-  $versions = @json_decode(file_get_contents("https://downloads.keyman.com/api/version/2.0?targetVersion=$version")); // TODO: use KeymanHosts in the future
+  $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . "/api/version/2.0?targetVersion=$version")); // TODO: use KeymanHosts in the future
 
   if(empty($versions->android))
     $tier = 'unknown';
@@ -44,7 +45,7 @@
 
 
 
-  $versionsData = @json_decode(file_get_contents("https://downloads.keyman.com/api/version/all"));
+  $versionsData = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . "/api/version/all"));
   if (!$versionsData) {
     die("Failed to retrieve or parse the API data.");
   }
@@ -114,7 +115,7 @@
 ?>
 
 <div class="navigation-buttons">
-  <a class ="button" href='<?=$KeymanHosts->help_keyman_com?>/version-history/all-versions.php#<?=$versionNumber?>'>View version history for <?=$versionNumber?></a>
+  <a class ="button" href='<?=KeymanHosts::Instance()->help_keyman_com?>/version-history/all-versions.php#<?=$versionNumber?>'>View version history for <?=$versionNumber?></a>
 </div>
 
 <?php

--- a/downloads/releases/_version_downloads.php
+++ b/downloads/releases/_version_downloads.php
@@ -29,7 +29,7 @@
 
   // note: we currently ignore the tier parameter
 
-  $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . "/api/version/2.0?targetVersion=$version")); // TODO: use KeymanHosts in the future
+  $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . "/api/version/2.0?targetVersion=$version"));
 
   if(empty($versions->android))
     $tier = 'unknown';

--- a/go/download/_download.php
+++ b/go/download/_download.php
@@ -27,7 +27,7 @@
     $WINDOWS_VERSION = $_REQUEST['version'];
     $MAC_VERSION = $_REQUEST['version'];
   } else {
-    $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . '/api/version/2.0'));
+    $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/version/2.0'));
 
     $DEVELOPER_VERSION = $versions->developer->$TIER->version;
     $WINDOWS_VERSION = $versions->windows->$TIER->version;

--- a/go/package/download.php
+++ b/go/package/download.php
@@ -42,7 +42,7 @@
 
       if(empty($version)) {
         // If version isn't provided, we'll query the live api for the version
-        $json = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . "/$type/" . rawurlencode($id));
+        $json = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . "/$type/" . rawurlencode($id));
         if ($json !== FALSE) {
           $json = json_decode($json);
         }
@@ -93,7 +93,7 @@
 
     private static function report_download_event($id, $platform, $tier, $bcp47, $update) {
       global $env;
-      $url = KeymanHosts::Instance()->api_keyman_com . "/increment-download/".rawurlencode($id);
+      $url = KeymanHosts::Instance()->SERVER_api_keyman_com . "/increment-download/".rawurlencode($id);
 
       if(KeymanHosts::Instance()->Tier() !== KeymanHosts::TIER_TEST) {
         if(KeymanHosts::Instance()->Tier() === KeymanHosts::TIER_DEVELOPMENT)

--- a/iphone-and-ipad/index.php
+++ b/iphone-and-ipad/index.php
@@ -214,7 +214,7 @@
 <br/>
 
 <p>
-  <a href="<?= $KeymanHosts->help_keyman_com ?>/products/iphone-and-ipad/version-history/">View all version history</a>
+  <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>/products/iphone-and-ipad/version-history/">View all version history</a>
 </p>
 
 <?= $appstoreTable ?>

--- a/keyboards/install.php
+++ b/keyboards/install.php
@@ -353,7 +353,7 @@ END;
 
       // Get Keyboard Metadata
 
-      $s = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . '/keyboard/' . rawurlencode(self::$id));
+      $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . '/keyboard/' . rawurlencode(self::$id));
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";
@@ -374,7 +374,7 @@ END;
 
       // Get Program Download Versions and URLs
 
-      $s = @file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . '/api/version/1.0');
+      $s = @file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/version/1.0');
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";

--- a/keyboards/keyboard.json.php
+++ b/keyboards/keyboard.json.php
@@ -14,7 +14,7 @@
   header('Content-Type: application/json; charset=utf-8');
   header('Access-Control-Allow-Origin: *');
 
-  $kmw = @file_get_contents("{$KeymanHosts->api_keyman_com}/cloud/4.0/keyboards/$id?version=$version&languageidtype=bcp47");
+  $kmw = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . "/cloud/4.0/keyboards/$id?version=$version&languageidtype=bcp47");
   if($kmw === FALSE) {
     header('HTTP/1.0 404 Keyboard not found');
     exit;

--- a/keyboards/keyboard.php
+++ b/keyboards/keyboard.php
@@ -3,6 +3,7 @@
   require_once('includes/ui/keyboard-details.php');
   require_once('./session.php');
   require_once __DIR__ . '/../_includes/autoload.php';
+  use Keyman\Site\Common\KeymanHosts;
 
   if(isset($_REQUEST['legacy'])) {
     $id = find_id_by_legacy(clean_id($_REQUEST['legacy']));
@@ -26,8 +27,7 @@
   }
 
   function find_id_by_legacy($legacy) {
-    global $KeymanHosts;
-    $s = @file_get_contents($KeymanHosts->api_keyman_com.'/search/?q=k:legacy:'.rawurlencode($legacy));
+    $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/search/?q=k:legacy:'.rawurlencode($legacy));
     if($s === FALSE) {
       return null;
     }

--- a/keyboards/share.php
+++ b/keyboards/share.php
@@ -2,6 +2,8 @@
   require_once('includes/template.php');
   require_once('includes/ui/keyboard-details.php');
   require_once('./session.php');
+  require_once __DIR__ . '/../_includes/autoload.php';
+  use Keyman\Site\Common\KeymanHosts;
 
   if(!isset($_REQUEST['id'])) {
     header('Location: /keyboards');
@@ -19,8 +21,7 @@
   }
 
   function find_keyboard($id) {
-    global $KeymanHosts;
-    $s = @file_get_contents($KeymanHosts->api_keyman_com.'/keyboard/'.$id);
+    $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/keyboard/'.$id);
     if($s === FALSE) {
       return null;
     }


### PR DESCRIPTION
* Splits the server-side and client-side references to keyman sites so that docker-based PHP can reference host.docker.internal on development machines for cross-references.

* Removes all remaining usage of global `$KeymanHost` variable, instead using `KeymanHost::Instance()` for consistency.

* Removes some links to legacy sites such as sentry.keyman.com.

- [x] TODO: update to `BOOTSTRAP_VERSION=v0.17` in build.sh before merge.

Relates-to: keymanapp/shared-sites#53