### PR TITLE
fix: properly handle paths in init-container.sh

### DIFF
--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+
 if [[ ! $1 =~ "debug" ]]; then
   echo "---- Generating CDN ---"
-  rm -rf cdn/deploy
-  cd cdn
+  rm -rf "$THIS_SCRIPT_PATH/../cdn/deploy"
+  cd "$THIS_SCRIPT_PATH/../cdn"
   php -d include_path=/var/www/html/_includes:. cdnrefresh.php
   cd ..
 else
   echo "Skip Generating CDN and clean CDN cache"
-  rm -rf cdn/deploy
+  rm -rf "$THIS_SCRIPT_PATH/../cdn/deploy"
 fi


### PR DESCRIPTION
Ports fix from keymanapp/keymanweb.com/pull/136 to make the pathing in init-container.sh robust.