### PR TITLE
fix: Don't show package download on unsupported devices

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -499,7 +499,7 @@ END;
     }
 
     protected static function WriteKeyboardDetails() {
-      global $embed_target, $session_query_q;
+      global $embed_target, $embed, $session_query_q;
 
       // this is html, trusted in database
       ?>
@@ -570,7 +570,8 @@ END;
           <table id='keyboard-details'>
             <tbody>
 <?php
-              if(isset(self::$keyboard->packageFilename)) {
+              if(isset(self::$keyboard->packageFilename) &&
+                 isset(self::$keyboard->platformSupport->$embed) && self::$keyboard->platformSupport->$embed != 'none') {
 ?>
             <tr>
               <th>Package Download</th>


### PR DESCRIPTION
Addreses [KEYMAN-ANDROID-251](https://keyman.sentry.io/issues/3725705438)

Currently, when keyboard details are returned for a package not available for the host device, 
* There's intentionally a lack of install/download button
* There's verbage *This keyboard is not supported on this device. You may find other options below.*

The keyboard details still provide a package download link to the .kmp file, and apparently enough Keyman for Android users attempt this (~150+ users on the order of 3000+ events) and the keyboard install fails because the .kmp file doesn't contain a touch layout keyboard.

This PR changes the Package Download to appear only for compatible devices. We can always manually goto downloads.keyman for engineering purposes.