### PR TITLE
fix: remove languages without keyboard and reword placeholder in demo2

### DIFF
--- a/developer/keymanweb/sample2.php
+++ b/developer/keymanweb/sample2.php
@@ -147,22 +147,13 @@
         <label>Please Select Your Language Here</label>
         <select id="single" class="js-states form-control" autofocus>
           <option value="" disabled selected>Select your option here</option>
-          <option value='ab'>Abkhazian</option>
-          <option value='aa'>Afar</option>
           <option value='af'>Afrikaans</option>
-          <option value='ak'>Akan</option>
           <option value='sq'>Albanian</option>
           <option value='am'>Amharic</option>
-          <option value='ar'>Arabic</option>
           <option value='an'>Aragonese</option>
           <option value='hy'>Armenian</option>
           <option value='as'>Assamese</option>
-          <option value='av'>Avaric</option>
-          <option value='ae'>Avestan</option>
           <option value='ay'>Aymara</option>
-          <option value='az'>Azerbaijani</option>
-          <option value='bm'>Bambara</option>
-          <option value='ba'>Bashkir</option>
           <option value='eu'>Basque</option>
           <option value='be'>Belarusian</option>
           <option value='bn'>Bengali</option>
@@ -173,15 +164,8 @@
           <option value='my'>Burmese</option>
           <option value='ca'>Catalan, Valencian</option>
           <option value='km'>Central Khmer</option>
-          <option value='ch'>Chamorro</option>
-          <option value='ce'>Chechen</option>
-          <option value='ny'>Chichewa, Chewa, Nyanja</option>
-          <option value='zh'>Chinese</option>
-          <option value='cu'>Church Slavonic, Old Slavonic, Old Church Slavonic</option>
-          <option value='cv'>Chuvash</option>
           <option value='kw'>Cornish</option>
           <option value='co'>Corsican</option>
-          <option value='cr'>Cree</option>
           <option value='hr'>Croatian</option>
           <option value='cs'>Czech</option>
           <option value='da'>Danish</option>
@@ -199,7 +183,6 @@
           <option value='ff'>Fulah</option>
           <option value='gd'>Gaelic, Scottish Gaelic</option>
           <option value='gl'>Galician</option>
-          <option value='lg'>Ganda</option>
           <option value='ka'>Georgian</option>
           <option value='de'>German</option>
           <option value='el'>Greek, Modern (1453–)</option>
@@ -208,68 +191,39 @@
           <option value='ht'>Haitian, Haitian Creole</option>
           <option value='ha'>Hausa</option>
           <option value='he'>Hebrew</option>
-          <option value='hz'>Herero</option>
           <option value='hi'>Hindi</option>
-          <option value='ho'>Hiri Motu</option>
           <option value='hu'>Hungarian</option>
           <option value='is'>Icelandic</option>
-          <option value='io'>Ido</option>
           <option value='ig'>Igbo</option>
-          <option value='id'>Indonesian</option>
-          <option value='ia'>Interlingua (International Auxiliary Language Association)</option>
-          <option value='ie'>Interlingue, Occidental</option>
-          <option value='iu'>Inuktitut</option>
           <option value='ik'>Inupiaq</option>
           <option value='ga'>Irish</option>
           <option value='it'>Italian</option>
           <option value='ja'>Japanese</option>
-          <option value='jv'>Javanese</option>
           <option value='kl'>Kalaallisut, Greenlandic</option>
           <option value='kn'>Kannada</option>
           <option value='kr'>Kanuri</option>
           <option value='ks'>Kashmiri</option>
           <option value='kk'>Kazakh</option>
-          <option value='ki'>Kikuyu, Gikuyu</option>
-          <option value='rw'>Kinyarwanda</option>
           <option value='ky'>Kirghiz, Kyrgyz</option>
-          <option value='kv'>Komi</option>
-          <option value='kg'>Kongo</option>
-          <option value='ko'>Korean</option>
-          <option value='kj'>Kuanyama, Kwanyama</option>
-          <option value='ku'>Kurdish</option>
-          <option value='lo'>Lao</option>
           <option value='la'>Latin</option>
           <option value='lv'>Latvian</option>
           <option value='li'>Limburgan, Limburger, Limburgish</option>
-          <option value='ln'>Lingala</option>
           <option value='lt'>Lithuanian</option>
-          <option value='lu'>Luba-Katanga</option>
           <option value='lb'>Luxembourgish, Letzeburgesch</option>
           <option value='mk'>Macedonian</option>
-          <option value='mg'>Malagasy</option>
-          <option value='ms'>Malay</option>
           <option value='ml'>Malayalam</option>
           <option value='mt'>Maltese</option>
           <option value='gv'>Manx</option>
           <option value='mi'>Maori</option>
           <option value='mr'>Marathi</option>
-          <option value='mh'>Marshallese</option>
-          <option value='mn'>Mongolian</option>
-          <option value='na'>Nauru</option>
-          <option value='nv'>Navajo, Navaho</option>
-          <option value='ng'>Ndonga</option>
-          <option value='ne'>Nepali</option>
           <option value='nd'>North Ndebele</option>
           <option value='se'>Northern Sami</option>
           <option value='no'>Norwegian</option>
           <option value='nb'>Norwegian Bokmål</option>
           <option value='nn'>Norwegian Nynorsk</option>
           <option value='oc'>Occitan</option>
-          <option value='oj'>Ojibwa</option>
           <option value='or'>Oriya</option>
           <option value='om'>Oromo</option>
-          <option value='os'>Ossetian, Ossetic</option>
-          <option value='pi'>Pali</option>
           <option value='ps'>Pashto, Pushto</option>
           <option value='fa'>Persian</option>
           <option value='pl'>Polish</option>
@@ -278,30 +232,23 @@
           <option value='qu'>Quechua</option>
           <option value='ro'>Romanian, Moldavian, Moldovan</option>
           <option value='rm'>Romansh</option>
-          <option value='rn'>Rundi</option>
           <option value='ru'>Russian</option>
           <option value='sm'>Samoan</option>
           <option value='sg'>Sango</option>
           <option value='sa'>Sanskrit</option>
           <option value='sc'>Sardinian</option>
           <option value='sr'>Serbian</option>
-          <option value='sn'>Shona</option>
-          <option value='ii'>Sichuan Yi, Nuosu</option>
           <option value='sd'>Sindhi</option>
           <option value='si'>Sinhala, Sinhalese</option>
           <option value='sk'>Slovak</option>
           <option value='sl'>Slovenian</option>
           <option value='so'>Somali</option>
-          <option value='nr'>South Ndebele</option>
-          <option value='st'>Southern Sotho</option>
           <option value='es'>Spanish, Castilian</option>
-          <option value='su'>Sundanese</option>
           <option value='sw'>Swahili</option>
           <option value='ss'>Swati</option>
           <option value='sv'>Swedish</option>
           <option value='tl'>Tagalog</option>
           <option value='ty'>Tahitian</option>
-          <option value='tg'>Tajik</option>
           <option value='ta'>Tamil</option>
           <option value='tt'>Tatar</option>
           <option value='te'>Telugu</option>
@@ -309,28 +256,19 @@
           <option value='bo'>Tibetan</option>
           <option value='ti'>Tigrinya</option>
           <option value='to'>Tonga (Tonga Islands)</option>
-          <option value='ts'>Tsonga</option>
-          <option value='tn'>Tswana</option>
           <option value='tr'>Turkish</option>
           <option value='tk'>Turkmen</option>
-          <option value='tw'>Twi</option>
-          <option value='ug'>Uighur, Uyghur</option>
           <option value='uk'>Ukrainian</option>
           <option value='ur'>Urdu</option>
-          <option value='uz'>Uzbek</option>
-          <option value='ve'>Venda</option>
           <option value='vi'>Vietnamese</option>
-          <option value='vo'>Volapük</option>
           <option value='wa'>Walloon</option>
           <option value='cy'>Welsh</option>
           <option value='fy'>Western Frisian</option>
           <option value='wo'>Wolof</option>
           <option value='xh'>Xhosa</option>
-          <option value='yi'>Yiddish</option>
           <option value='yo'>Yoruba</option>
           <option value='za'>Zhuang, Chuang</option>
           <option value='zu'>Zulu</option>
-
         </select>
       </div>
     </div>
@@ -341,12 +279,12 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/js/select2.min.js"></script>
   <script>
     $("#single").select2({
-      placeholder: "Please Select Your Language Here",
+      placeholder: "Please Select A Language Here",
       allowClear: true
     });
   </script>
 
-  <textarea id="kwtextarea" class="center_iv" cols="20" rows="5" style="width: 99%; height: 220px; margin-top: -10px; font-size: 18px" placeholder="Please select your language from the above dropdown list and type according to the keyboard below. Press Shift Key to See the Other Characters."></textarea>
+  <textarea id="kwtextarea" class="center_iv" cols="20" rows="5" style="width: 99%; height: 220px; margin-top: -10px; font-size: 18px" placeholder="Please select a language from the above dropdown list and type according to the keyboard below. Press Shift Key to See the Other Characters."></textarea>
 
   <!--
       In this example, we are loading KeymanWeb late.  If you focus on a control early (e.g. a search box),


### PR DESCRIPTION
This change modifies demo2 and removes languages from the list that don't provide a web keyboard. Also reword the placeholder text to make it clearer that it's only a selection of languages.

Fixes: #561