### PR TITLE
fix: Use CDN on staging site

### DIFF
--- a/_includes/2020/Util.php
+++ b/_includes/2020/Util.php
@@ -21,7 +21,9 @@
           $cdn = false;
         }
       }
-      $use_cdn = KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_PRODUCTION || (isset($_REQUEST['cdn']) && $_REQUEST['cdn'] == 'force');
+      $use_cdn = KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_PRODUCTION || 
+          KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_STAGING || 
+          (isset($_REQUEST['cdn']) && $_REQUEST['cdn'] == 'force');
       if($use_cdn) {
         if($cdn && isset($cdn['/'.$file])) {
           return "/cdn/deploy{$cdn['/'.$file]}";


### PR DESCRIPTION
While investigating some Sentry issues on keyman.com, I noticed keyman-staging was using `dev` instead of `deploy` on the CDN assets

https://keyman.sentry.io/issues/6400178766/?environment=staging&project=5983516

This will make it to `staging` branch at the end of the sprint-merge