### PR TITLE
fix: allow #osk-host element to grow in keyboard details

### DIFF
--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -338,8 +338,8 @@ html[data-platform~='windows linux macos'] #try-box {
 }
 
 #osk-host {
-  width: 640px;
-  height: 300px;
+  min-width: 640px;
+  min-height: 300px;
 }
 
 #osk-host .kmw-key-square {


### PR DESCRIPTION
Some keyboards use `&KMWHelpFile` to present a HTML fragment instead of the normal KeymanWeb OSK. Those keyboards were not displaying correctly in this view, with the content overlapping the Keyboard Details area.

Allowing the `#osk-host` element to grow mitigates this, although there are still keyboards such as https://keyman.com/keyboards/sil_ipa that do not have an optimal presentation.

Fixes: #573