### PR TITLE
chore: Add stable-17.0 links to downloads/archive

### DIFF
--- a/downloads/archive/index.php
+++ b/downloads/archive/index.php
@@ -14,6 +14,7 @@
   require_once('./static-keys.php');
   // These variables should be progressively added if we update older versions.
   // 14.0 onward uses 3 numbers instead of 4
+  $ver_windows_17 = "17.0.335";
   $ver_windows_16 = "16.0.147";
   $ver_windows_15 = "15.0.274";
   $ver_windows_14 = "14.0.294";
@@ -25,6 +26,7 @@
 <h2 class="red underline">Keyman Desktop Download Archive</h2>
 <ul>
     <!-- TODO: use downloads API to get the latest 15.0 version -->
+    <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_17 ?>/keyman-<?= $ver_windows_17 ?>.exe">Keyman for Windows <?= $ver_windows_17 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_16 ?>/keyman-<?= $ver_windows_16 ?>.exe">Keyman for Windows <?= $ver_windows_16 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_15 ?>/keyman-<?= $ver_windows_15 ?>.exe">Keyman for Windows <?= $ver_windows_15 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/windows/stable/<?= $ver_windows_14 ?>/keyman-<?= $ver_windows_14 ?>.exe">Keyman for Windows <?= $ver_windows_14 ?> Download</a> (No activation required)</li>
@@ -43,6 +45,7 @@
 <h2 class="red underline">Keyman Developer Download Archive</h2>
 <ul>
     <!-- TODO: use downloads API to get the latest 13.0 version -->
+    <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_17 ?>/keymandeveloper-<?= $ver_windows_17 ?>.exe">Keyman Developer <?= $ver_windows_17 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_16 ?>/keymandeveloper-<?= $ver_windows_16 ?>.exe">Keyman Developer <?= $ver_windows_16 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_15 ?>/keymandeveloper-<?= $ver_windows_15 ?>.exe">Keyman Developer <?= $ver_windows_15 ?> Download</a> (No activation required)</li>
     <li><a href="<?= KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_14 ?>/keymandeveloper-<?= $ver_windows_14 ?>.exe">Keyman Developer <?= $ver_windows_14 ?> Download</a> (No activation required)</li>
@@ -56,7 +59,7 @@
 
 <h2 class="red underline">Keyman Developer kmcomp Download Archive</h2>
 <ul>
-  <li><a href="<?=KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_16 ?>/kmcomp-<?= $ver_windows_16 ?>.zip">Keyman Developer kmcomp <?= $ver_windows_16 ?> zip Download</a></li>
+  <li><a href="<?=KeymanHosts::Instance()->downloads_keyman_com ?>/developer/stable/<?= $ver_windows_17 ?>/kmcomp-<?= $ver_windows_17 ?>.zip">Keyman Developer kmcomp <?= $ver_windows_17 ?> zip Download</a></li>
 </ul>
 
 <h2 class="red underline">Obsolete Keyboards</h2>


### PR DESCRIPTION
With the upcoming stable-18.0 release, this adds stable-17.0 links to the downloads/archive page.

re: kmcomp download archive

Do we need to keep 16.0 links, or just the latest stable?