### PR TITLE
chore: update BOOTSTRAP_VERSION to v0.28

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.22
+readonly BOOTSTRAP_VERSION=v0.28
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -H "Cache-Control: no-cache" -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 


### PR DESCRIPTION
This PR updates the BOOTSTRAP_VERSION in build.sh to v0.28.