### PR TITLE
fix: allow two chars for keyboard search

### DIFF
--- a/cdn/dev/keyboard-search/search.js
+++ b/cdn/dev/keyboard-search/search.js
@@ -76,7 +76,7 @@ function wrapSearch(localCounter, updateHistory) {
   // Workaround for HTML form encoding spaces with "+", which breaks keyboard searches
   q = q.replace(/\+/g, ' ');
   document.f.q.value = q;
-  if((!updateHistory && q.trim().length < 3) || q.trim().length == 0) {
+  if((!updateHistory && q.trim().length < 2) || q.trim().length == 0) {
     var resultsElement = $('#search-results');
     resultsElement.empty();
     if(updateHistory)
@@ -84,7 +84,7 @@ function wrapSearch(localCounter, updateHistory) {
     $('#search-box').removeClass('searching');
     return false;
   }
-
+  
   var base = location.protocol+'//api.'+location.host; // this works on test sites as well as live, assuming we use the host pattern "keyman.com[.localhost]"
   var url = base+'/search/2.0?p='+page+'&q='+encodeURIComponent(stripCommonWords(q));
 


### PR DESCRIPTION
fixes: #590

I was only able to test and got this result since the search did not work for me.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/75b849ff-2393-45dd-a1e2-b1c3f16a0ebe" />

This PR is ready for reviews.