### PR TITLE
fix: Add Keyman 18.0 features for Android and iOS

### DIFF
--- a/android/index.php
+++ b/android/index.php
@@ -99,6 +99,15 @@
 </table>
 
 <br/>
+<h3>New in Keyman for Android 18.0 (April 2025)</h3>
+<ul>
+  <li>ENTER key can now handle different actions such as: newline, Previous, Next, Submit, and Search. (#12125, #12315, #12473)</li>
+  <li>New menu to adjust the number of milliseconds (300 ms to 1500 ms) required to trigger a longpress gesture (#12170, #12185)</li>
+  <li>Navigation arrows for back / forward actions now show correctly in right-to-left (RTL) languages (#12227)</li>
+  <li>Predictive text and on screen keyboard startup performance improvements (#11784, #11264, #11265)</li>
+</ul>
+
+<br/>
 <h3>New in Keyman for Android 17.0 (May 2024)</h3>
 <ul>
   <li>Multitap and flick gestures are now supported for Android. (#7324)</li>

--- a/iphone-and-ipad/index.php
+++ b/iphone-and-ipad/index.php
@@ -83,6 +83,13 @@
   </tbody>
 </table>
 
+<h2>New in Keyman 18.0 (April 2025)</h2>
+<ul>
+  <li>Predictive text and on screen keyboard startup performance improvements (#11784, #11264, #11265)</li>
+  <li>Keyboard size can now be adjusted to your preference (#12571)</li>
+  <li>Update minimum iOS version to 13.0</li>
+</ul>
+
 <h2>New in Keyman 17.0 (May 2024)</h2>
 <ul>
   <li>Multitap and flick gestures are now supported for iOS (#7934)</li>


### PR DESCRIPTION
Fixes #596

Just some belated documentation of Keyman 18.0 features for the Android and iOS products.

The desktop products don't seem to get updated each release ever since we did away with version pages (/15 was the last)

Test-bot: skip
