### PR TITLE
fix: help links on installing keyboards

### DIFF
--- a/keyboards/install.php
+++ b/keyboards/install.php
@@ -215,7 +215,7 @@ END;
         "?platform=linux&amp;version={$hu['keyboardversion']}&amp;tier={$hu['tier']}" .
         (empty($hu['bcp47']) ? "" : "&amp;bcp47={$hu['bcp47']}");
 
-      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/linux/current-version/guide/installing-keyboard";
+      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/linux/current-version/start/installing-keyboard";
 
       $keyboardHomeUrl = "/keyboards/{$hu['id']}" .
         (empty($hu['bcp47']) ? "" : "?bcp47=" . $hu['bcp47']);
@@ -328,7 +328,7 @@ END;
         "?platform=ios&amp;version={$hu['keyboardversion']}&amp;tier={$hu['tier']}" .
         (empty($hu['bcp47']) ? "" : "&amp;bcp47={$hu['bcp47']}");
 
-      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/iphone-and-ipad/current-version/start/installing-keyboards";
+      $helpLink = KeymanHosts::Instance()->help_keyman_com . "/products/iphone-and-ipad/current-version/start/searching-for-keyboards";
 
       $keyboardHomeUrl = "/keyboards/{$hu['id']}" .
         (empty($hu['bcp47']) ? "" : "?bcp47=" . $hu['bcp47']);


### PR DESCRIPTION
Fixes #607

This fixes the iOS and Linux links for installing a keyboard. The links for other platforms are working.

## User Testing
* **TEST_LINKS**  - Verifies new links work
1. Append each of the new links on the PR to https://help.keyman.com/
2. Verify each link is valid
