### PR TITLE
Limit globe button visibility to `/keyboards/` pages 🗺️

### DIFF
--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -54,14 +54,13 @@ END;
     /**
      * Render the globe dropdown for changing the UI language
      * As UI languages get added, we'll need to update this.
-     * Limitation: Currently only visible on /keyboards/ pages
+     * Limitation: Currently only visible on pages that use localized strings
      * @param number - Div number, default 0.
      */
     private static function render_globe_dropdown($number = 0): void {
-      // Parse the current URI to determine globe visiblity
-      $url = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '/';
-      $path = parse_url($url, PHP_URL_PATH);
-      if (!isset($path) || !preg_match("/^\/keyboards.*$/i", $path)) { 
+      global $page_is_using_locale;
+      if (!isset($page_is_using_locale) || !$page_is_using_locale) {
+        // only render on pages that use localized strings
         return;
       }
 

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -11,7 +11,7 @@
   use \Keyman\Site\com\keyman\Locale;
   use \Keyman\Site\com\keyman;
   
-  define('LOCALE_KEYBOARD_DETAILS', 'keyboards/details');
+  Locale::definePageLocale('LOCALE_KEYBOARD_DETAILS', 'keyboards/details');
   $_m_KeyboardDetails = function($id, ...$args) {
     return Locale::m(LOCALE_KEYBOARD_DETAILS, $id, ...$args);
   };

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -89,6 +89,18 @@
     }
 
     /**
+     * Defines a global variable for page locale strings and also
+     * tells locale system that current page uses locales
+     * @param $define - 
+     * @param $id - folder containing locale strings, relative to /_includes/locale/strings
+     */
+    public static function definePageLocale($define, $id) {
+      global $page_is_using_locale;
+      $page_is_using_locale = true;
+      define($define, $id);
+    }
+
+    /**
      * Given a locale, return an array of fallback locales
      * For example: es-ES --> [es, es-ES]
      * TODO: Use an existing fallback algorthim like

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -9,7 +9,7 @@
   use Keyman\Site\com\keyman\templates\Foot;
   use Keyman\Site\com\keyman\Locale;
 
-  define('LOCALE_KEYBOARDS', 'keyboards');
+  Locale::definePageLocale('LOCALE_KEYBOARDS', 'keyboards');
   $_m = function($id, ...$args) { return Locale::m(LOCALE_KEYBOARDS, $id, ...$args); };
   function _m($id, ...$args) {    return Locale::m(LOCALE_KEYBOARDS, $id, ...$args); }
 


### PR DESCRIPTION
Addresses this point of #384

> We should hide the icon on pages that don't have localization (to avoid disappointment for users)

Will limit visibility to `/keyboards/` pages

Test-bot: skip

