### PR TITLE
Add crowdin.yml configuration file 🗺️

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -22,6 +22,9 @@ RewriteBase /
 # Add mime type for apple-app-site-association
 AddType application/json apple-app-site-association
 
+# Deny crowdin.yml
+RewriteRule ^crowdin.yml$ = [F,L]
+
 # Custom error messages
 # ErrorDocument 404 /_includes/errors/404.php
 

--- a/_includes/locale/strings/keyboards/details/en.php
+++ b/_includes/locale/strings/keyboards/details/en.php
@@ -4,6 +4,7 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  *
  * Default English strings for keyboards/keyboard-details.php
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);

--- a/_includes/locale/strings/keyboards/details/fr.php
+++ b/_includes/locale/strings/keyboards/details/fr.php
@@ -4,6 +4,7 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  *
  * French strings for keyboards/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);

--- a/_includes/locale/strings/keyboards/en.php
+++ b/_includes/locale/strings/keyboards/en.php
@@ -4,6 +4,7 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  *
  * Default English strings for keyboards/index.php
+ * Don't escape $s when uploading source to crowdin because exports will escape \$s to \\$s
  */
 
 declare(strict_types=1);

--- a/_includes/locale/strings/keyboards/install/en.php
+++ b/_includes/locale/strings/keyboards/install/en.php
@@ -4,7 +4,7 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  *
  * Default English strings for keyboards/keyboard-install.php
- * Use placeholders like %1\$s
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);

--- a/_includes/locale/strings/keyboards/share/en.php
+++ b/_includes/locale/strings/keyboards/share/en.php
@@ -4,7 +4,7 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  *
  * Default English strings for keyboards/keyboard-share.php
- * Use placeholders like %1\$s
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,189 @@
+#
+# Shared Crowdin control for https://keyman.com
+#
+
+#
+# Your Crowdin credentials
+#
+project_id_env: "KEYMAN_COM_CROWDIN_PROJECT_ID"
+api_token_env: "CROWDIN_PERSONAL_TOKEN"
+base_path: "." # local base path
+base_url: "https://api.crowdin.com"
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+preserve_hierarchy: true
+
+#
+# Files configuration
+#
+files:
+  # source: local path of file that gets uploaded to crowdin
+  # dest: crowdin path in https://crowdin.com/project/keymancom
+  # translation: local path where downloaded translations from crowdin go
+
+
+  # Keyboard search files
+
+  - source: /_includes/locale/strings/keyboards/en.php
+    dest: /keyboards/keyboards/en.php
+    translation: /_includes/locale/strings/keyboards/%locale%.php
+    languages_mapping:
+      locale:
+        # Canonical locales as needed
+        es-ES: es
+        de: de
+        fr: fr
+        km: km
+
+  - source: /_includes/locale/strings/keyboards/details/en.php
+    dest: /keyboards/keyboards-details/en.php
+    translation: /_includes/locale/strings/keyboards/details/%locale%.php
+    languages_mapping:
+      locale:
+        # Canonical locales as needed
+        es-ES: es
+        de: de
+        fr: fr
+        km: km
+
+  - source: /_includes/locale/strings/keyboards/install/en.php
+    dest: /keyboards/keyboards-install/en.php
+    translation: /_includes/locale/strings/keyboards/install/%locale%.php
+    languages_mapping:
+      locale:
+        # Canonical locales as needed
+        es-ES: es
+        de: de
+        fr: fr
+        km: km
+
+  - source: /_includes/locale/strings/keyboards/share/en.php
+    dest: /keyboards/keyboards-share/en.php
+    translation: /_includes/locale/strings/keyboards/share/%locale%.php
+    languages_mapping:
+      locale:
+        # Canonical locales as needed
+        es-ES: es
+        de: de
+        fr: fr
+        km: km
+
+  # crowdin parameters descriptions:
+
+  #
+  # Source files filter
+  # e.g. "/resources/en/*.json"
+  #
+
+  #
+  # Where translations will be placed
+  # e.g. "/resources/%two_letters_code%/%original_file_name%"
+  #
+  #"translation" : "",
+
+  #
+  # Files or directories for ignore
+  # e.g. ["/**/?.txt", "/**/[0-9].txt", "/**/*\?*.txt"]
+  #
+  #"ignore" : [],
+
+  #
+  # The dest allows you to specify a file name in Crowdin
+  # e.g. "/messages.json"
+  #
+  #"dest" : "",
+
+  #
+  # File type
+  # e.g. "json"
+  #
+  #"type" : "",
+
+  #
+  # The parameter "update_option" is optional. If it is not set, after the files update the translations for changed strings will be removed. Use to fix typos and for minor changes in the source strings
+  # e.g. "update_as_unapproved" or "update_without_changes"
+  #
+  #"update_option" : "",
+
+  #
+  # Start block (for XML only)
+  #
+
+  #
+  # Defines whether to translate tags attributes.
+  # e.g. 0 or 1  (Default is 1)
+  #
+  # "translate_attributes" : 1,
+
+  #
+  # Defines whether to translate texts placed inside the tags.
+  # e.g. 0 or 1 (Default is 1)
+  #
+  # "translate_content" : 1,
+
+  #
+  # This is an array of strings, where each item is the XPaths to DOM element that should be imported
+  # e.g. ["/content/text", "/content/text[@value]"]
+  #
+  # "translatable_elements" : [],
+
+  #
+  # Defines whether to split long texts into smaller text segments
+  # e.g. 0 or 1 (Default is 1)
+  #
+  # "content_segmentation" : 1,
+
+  #
+  # End block (for XML only)
+  #
+
+  #
+  # Start .properties block
+  #
+
+  #
+  # Defines whether single quote should be escaped by another single quote or backslash in exported translations
+  # e.g. 0 or 1 or 2 or 3 (Default is 3)
+  # 0 - do not escape single quote;
+  # 1 - escape single quote by another single quote;
+  # 2 - escape single quote by backslash;
+  # 3 - escape single quote by another single quote only in strings containing variables ( {0} ).
+  #
+  # "escape_quotes" : 3,
+
+  #
+  # Defines whether any special characters (=, :, ! and #) should be escaped by backslash in exported translations.
+  # e.g. 0 or 1 (Default is 0)
+  # 0 - do not escape special characters
+  # 1 - escape special characters by a backslash
+  #
+  # "escape_special_characters": 0
+  #
+
+  #
+  # End .properties block
+  #
+
+  #
+  # Often software projects have custom names for the directories where translations are placed. crowdin-cli allows you to map your own languages to be understandable by Crowdin.
+  #
+  #"languages_mapping" : {
+  #  "two_letters_code" : {
+  #    "crowdin_language_code" : "local_name"
+  #   }
+  #},
+
+  #
+  # Does the first line contain header?
+  # e.g. true or false
+  #
+  #"first_line_contains_header" : true,
+
+  #
+  # for spreadsheets
+  # e.g. "identifier,source_phrase,context,uk,ru,fr"
+  #
+  # "scheme" : "",

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -13,3 +13,20 @@ else
   echo "Skip Generating CDN and clean CDN cache"
   rm -rf "$THIS_SCRIPT_PATH/../cdn/deploy"
 fi
+# PHP localization strings need to have '$' escaped like '%1\$s'.
+# But the download files from Crowdin get escaped again as '%1\\$s'. 
+# Reverts to escaping once.
+cd "$THIS_SCRIPT_PATH/../_includes/locale/strings"
+
+find . -type f -name "*.php" -print0 | while IFS= read -r -d '' file; do
+  # Not doing sed in-place to avoid permission errors
+  sed -r 's/([0-9])\\{2}\$/\1\\\$/g' "$file" > temp
+
+  if [ $? -ne 0 ]; then
+    echo "ERROR cleaning up files: $file"
+    exit 1
+  fi
+
+  mv temp "$file"
+
+done


### PR DESCRIPTION
For #384 

This adds a crowdin configuration file (supports Crowdin CLI 4.0+).
One limitation is when downloading translated strings, the escaped parameters (e.g. `%1\$`) get downloaded as `%1\\$` so there's an extra step added to init-container.sh to fix the escaping.

The `languages_mapping` section uses canonical locales so `de` files in Crowdin don't get downloaded to `de-DE.php`

```yml
  - source: /_includes/locale/strings/keyboards/en.php
    dest: /keyboards/keyboards/en.php
    translation: /_includes/locale/strings/keyboards/%locale%.php
    languages_mapping:
      locale:
        # Canonical locales as needed
        es-ES: es
        de: de
        fr: fr
        km: km
```

Test-bot: skip
