### PR TITLE
feat: Add Crowdin GHA to update source 🗺️

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,37 @@
+name: Upload translation sources to Crowdin https://crowdin.com/project/keymancom
+
+on:
+  schedule:
+    # At 06:00 every day (eventually only on Monday). https://crontab.cronhub.io/
+    - cron: '0 6 * * *'
+
+jobs:
+  upload-sources-to-crowdin:
+    if: github.repository == 'keymanapp/keyman.com'
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: crowdin action
+      uses: crowdin/github-action@v2.14.0
+      with:
+        upload_sources: true
+
+        # This is the name of the top-level directory that Crowdin will use for files.
+        # Note that this is not a "branch" in the git sense, but more like a top-level directory in your Crowdin project.
+        # This branch does NOT need to be manually created. It will be created automatically by the action.
+        crowdin_branch_name: master
+        config: 'crowdin.yml'
+
+        # TODO if we want action to auto create PRs
+        #GITHUB_TOKEN: $
+
+        # See https://crowdin.com/project/keymancom/tools/api
+        project_id: ${{ secrets.KEYMAN_COM_CROWDIN_PROJECT_ID }}
+
+        # A personal access token
+        # See https://crowdin.com/settings#api-key to generate a token
+        token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
Relates to #384

Based on https://github.com/keymanapp/keyman/blob/master/.github/workflows/crowdin.yml

This adds a Crowdin GitHub action so the keyman.com English source strings are automatically synced to the [Crowdin project](https://crowdin.com/project/keymancom).
Initially this is set to 06:00 every day, but can adjust to 06:00 every MON once I see it working.

I've already set the corresponding secrets in this repo.

Test-bot: skip
