### PR TITLE
fix: Style globe key when keyboard search page is scrolled 🗺️

### DIFF
--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -89,6 +89,7 @@ END;
       }
 
       // Phone layout
+      $globeClass = '';
       if ($divID === "phone") {
 ?>
 <div class="phone-menu-item">
@@ -97,12 +98,16 @@ END;
         </div>
       <?php
         return;
+      } else if ($divID === "ui-language") {
+        $globeClass = 'menu-item';
+      } else if ($divID === "ui-language1") {
+        $globeClass = 'help1-globe menu-item';
       }
 
       // Desktop layout
 echo <<<END
           <p>
-            <div id='$divID' class="menu-item">
+            <div id='$divID' class='$globeClass'>
 END;
 ?>
               <img src="<?php echo Util::cdn("img/globe.png"); ?>" alt="UI globe dropdown" />
@@ -207,7 +212,7 @@ END;
           <p id="donate"><a href="/donate">Donate</a></p>
           <p><a href="<?= KeymanHosts::Instance()->help_keyman_com ?>" target="blank">Support<img src="<?php echo Util::cdn("img/helpIcon.png"); ?>" alt="help icon"></a></p>
           <?php
-            Menu::render_globe_dropdown();
+            Menu::render_globe_dropdown("ui-language");
 ?>
         </div>
     </div>
@@ -225,7 +230,7 @@ END;
           <a id='help1-donate' href="/donate">Donate</a>
           <a href="<?= KeymanHosts::Instance()->help_keyman_com ?>"><img id="top-menu-icon2" src="<?php echo Util::cdn("img/helpIcon.png"); ?>" alt="help icon" /></a>
 <?php
-            Menu::render_globe_dropdown(1);
+            Menu::render_globe_dropdown("ui-language1");
 ?>
         </div>
         <div class="wrapper">

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -731,6 +731,13 @@ input[type="search"] {
 	margin-top: -1px;
 }
 
+#help1 #ui-language1 {
+	width: 28px;
+	margin: 0px 0px 14px 8px;
+	vertical-align: top;
+	height: 22px;
+}
+
 /* hover menus */
 
 .menu-item {


### PR DESCRIPTION
Fixes #635 and follows #667

Cleans up globe-key styling for the desktop view of #384

This adds CSS styling when the keyboard search page is scrolled (should have used div ID `ui-language1` in #667)

Numbers subject to change

## Screenshots When Keyboard Search Page Scrolled

### Currently on keyman.com

<img width="377" height="275" alt="Screenshot_2026-03-06_10-37-50" src="https://github.com/user-attachments/assets/44ca3238-e61f-4159-a8c6-0f3c50eb7b00" />

-----

### With this Changes


<img width="219" height="48" alt="Screenshot_2026-03-06_10-30-43" src="https://github.com/user-attachments/assets/27e10f6f-5b54-4180-ad23-3807e249a0bf" />

hover off

<br>

<img width="231" height="230" alt="Screenshot_2026-03-06_10-30-55" src="https://github.com/user-attachments/assets/e9613a4b-6bb8-4c0e-8660-58a4a5bfc2ef" />

hover on

Test-bot: skip
