### PR TITLE
feat: Localize blue keyboard search button 🗺️

### DIFF
--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -95,7 +95,14 @@ h2 a {
 #search-box #search-f {
   float: left;
   position: relative;
-  left: -1px;
+  top: 1px;
+  height: 30px;
+  color: white;
+  background-color: #A0C4F3;
+  outline-style: solid;
+  outline-width: 1px;
+  border: none;
+  outline-color: #4184DC;
 }
 
 #search-results {

--- a/keyboards/index.php
+++ b/keyboards/index.php
@@ -58,7 +58,7 @@
     <form method='get' action='/keyboards' name='f'>
       <label for="search-q"><?= _m('keyboard_search') ?></label><input id="search-q" type="text" placeholder="<?= _m('enter_language') ?>" name="q"
       <?php if($embed == 'none') echo 'autofocus'; ?>>
-      <input id="search-f" type="image" src="<?= cdn('img/search-button.png"') ?>" value="<?= _m('search') ?>" onclick="return do_search()">
+      <input id="search-f" type="button" value="<?= _m('search') ?>" onclick="return do_search()">
       <label id="search-new"><a href='/keyboards<?=$session_query_q?>'><?= _m('new_search')?></a></label>
       <input id="search-obsolete" type="hidden" name="obsolete" value="0">
       <input id="search-page" type="hidden" name="page" value="1">


### PR DESCRIPTION
For #384

This restyles the blue keyboard search button so the label can be localized.

## Screenshot of Khmer
<img width="592" height="255" alt="image" src="https://github.com/user-attachments/assets/89e051b2-5a7f-4faf-bb9d-1c594a279cd8" />

## Screenshot of current live site

<img width="535" height="123" alt="image" src="https://github.com/user-attachments/assets/5461362d-c98f-48eb-ab37-29f9c039a115" />



**Note:** - This only changes the keyboard search page. The other search pages on the site are still using the English search button image
e.g.

<img width="672" height="316" alt="image" src="https://github.com/user-attachments/assets/108b5338-fa95-4085-9749-d9057111789f" />

Test-bot: skip
