### PR TITLE
fix: Set heading line-heights to accommodate Khmer subscripts 🗺️

### DIFF
--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -1247,18 +1247,20 @@ input[type="search"] {
 #section2 h1 {
 	text-align: center;
 	font-size: 28pt;
+	line-height: 1.4;
 	padding: 40px 10px 10px 10px;
 }
 
 #section2 h2 {
 	font-size: 22pt;
-	line-height: 1.2em;
+	line-height: 1.4;
 	padding: 40px 10px 10px 10px;
 	clear: both;
 }
 
 #section2 h3 {
 	font-size: 14pt;
+	line-height: 1.4;
 	font-weight: 600;
 	padding: 0px 10px 10px 10px;
 }


### PR DESCRIPTION
Follows #679 for #384 

The red heading underlines currently collide with Khmer subscripts
This PR sets adequate heading `line-height` 

| Collision (live) | Adjusted line-height |
|---------------------|--------------------------------|
| <img width="323" height="311" alt="image" src="https://github.com/user-attachments/assets/b6ec62cf-449e-493b-a197-e40e6388217e" /> |<img width="323" height="311" alt="image" src="https://github.com/user-attachments/assets/bb1258f1-bb97-430a-a18b-57f0ddcaa44b" /> |




Adjusted line-height with Latin script:

<img width="383" height="358" alt="image" src="https://github.com/user-attachments/assets/98e423e7-de87-4be6-9cf9-52dc88749344" />


Test-bot: skip