### PR TITLE
feat: Start localizing Keyman product downloads page 🦯

### DIFF
--- a/_includes/includes/ui/downloads.php
+++ b/_includes/includes/ui/downloads.php
@@ -29,7 +29,8 @@
   function downloadSection($product, $platform, $filepattern, $tiers = '', $target = '') {
     if($target == '') $target = $platform;
 
-    echo "<h2 id='$target' class='red underline'>$product</h2>\n\n";
+    echo sprintf("<h2 id='%s' class='red underline'>%s</h2>\n\n", 
+      $target, _m_Downloads($product));
     $tiers = explode(' ',$tiers);
     foreach($tiers as $tier) {
       echo downloadLinks($product, $platform, $tier, $filepattern);
@@ -38,9 +39,7 @@
 
   function downloadLinks($product, $platform, $tier, $filepatterns) {
     global $versions;
-    $tierTitle = ucFirst($tier);
-    echo "<h3>$tierTitle</h3>\n";
-    echo "<ul>\n";
+    echo sprintf("<h3>%s</h3>\n<ul>\n", ucFirst(_m_Downloads($tier)));
     if(!empty($versions->$platform->$tier)) {
       if(!is_array($filepatterns)) $filepatterns = array($filepatterns);
       foreach($filepatterns as $filepattern) {
@@ -50,12 +49,18 @@
         if(!empty($versions->$platform->$tier->files->$file)) {
           $fileData = $versions->$platform->$tier->files->$file;
           $fileSize = formatSizeUnits($fileData->size);
-          echo "<li><a href='" . KeymanHosts::Instance()->downloads_keyman_com . "/$platform/$tier/{$versions->$platform->$tier->version}/$file'>$file $tier</a> (released $fileData->date, $fileSize)</li>\n";
+          echo sprintf("<li><a href='%s/%s/%s/%s/%s'>%s %s</a> %s</li>\n",
+            KeymanHosts::Instance()->downloads_keyman_com ,
+            $platform, $tier,
+            $versions->$platform->$tier->version,
+            $file, $file, $tier,
+            _m_Downloads('released_date_size', $fileData->date, $fileSize));
         }
       }
     }
-    echo "<li><a href='" . KeymanHosts::Instance()->downloads_keyman_com . "/$platform/$tier/'>All $product $tier releases</a></li>\n";
-    echo "</ul><br/>\n";
+    echo sprintf("<li><a href='%s/%s/%s/'>%s</a></li>\n</ul><br/>\n",
+      KeymanHosts::Instance()->downloads_keyman_com, $platform, $tier,
+      _m_Downloads('all_product_releases', _m_Downloads($product), _m_Downloads($tier)));
   }
 
   function downloadLargeCTA($product, $platform, $tier, $filepattern) {

--- a/_includes/locale/strings/downloads/en.php
+++ b/_includes/locale/strings/downloads/en.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for downloads/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Downloads Page Title
+  "downloads_page_title" => "Keyman Downloads",
+
+  # Downloads_page_description
+  "downloads_page_description" => "Keyman stable downloads",
+
+  # Get the latest
+  "get_the_latest" => 
+    "Get the latest version of Keyman here. These are standalone downloads and do not contain keyboard layouts
+    for your language. See also the %1\$s and the %2\$s.",
+
+  # Downloads pre-release page
+  "downloads_pre_release_page" => "pre-release download page",
+
+  # Downloads old versions page
+  "downloads_old_versions_page" => "old versions download page",
+
+  # Keyman version history
+  "keyman_version_history_1" => "Keyman version history",
+
+  # Keyman version history (description)
+  "keyman_version_history_2" => "(all products)",
+
+  # Browse all versions
+  "browse_all_versions" => "Browse all versions (14.0 onwards)",
+
+  ### Product Downloads
+
+  # Keyman for Windows
+  "product_windows" => "Keyman for Windows",
+
+  # Keyman for macOS
+  "product_macos" => "Keyman for macOS",
+
+  # Keyman for Android
+  "product_android" => "Keyman for Android",
+
+  "available_on_play_store" => "Keyman for Android is also available on the Play Store.",
+
+  # Keyman for iPhone and iPad
+  "product_ios" => "Keyman for iPHone and iPad",
+
+  "available_on_app_store" => "Keyman for iPhone and iPad can be found on the App Store.",
+
+  # Keyman for Linux
+  "product_linux" => "Keyman for Linux",
+
+  "install_via_launchpad" => "Ubuntu, Wasta-Linux: Keyman for Linux can be installed via launchpad:",
+
+  # Products for Software Developers
+  "products_for_software_developers" => "Products for Software Developers",
+
+  # KeymanWeb
+  "product_keymanweb" => "KeymanWeb",
+
+  # Keyman Developer
+  "product_developer" => "Keyman Developer",
+
+  # Keyman Engine for Android
+  "product_engine_android" => "Keyman Engine for Android",
+
+  # Keyman Engine for iOS
+  "product_engine_ios" => "Keyman Engine for iOS",
+
+  ## Tiers
+  "alpha" => "alpha",
+
+  "beta" => "beta",
+
+  "stable" => "stable",
+
+  # (released {date}, {file size})
+  "released_date_size" => "(released %1\$s, %2\$s)",
+
+  # All {product} {tier} releases
+  "all_product_releases" => "All %1\$s %2\$s releases",
+
+  # No downloads found for {product}
+  "no_downloads_found" => "No downloads found for %1\$s."
+]
+;
+

--- a/_includes/locale/strings/downloads/es.php
+++ b/_includes/locale/strings/downloads/es.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for downloads/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Downloads Page Title
+  "downloads_page_title" => "Descargas de Keyman",
+
+  # Downloads_page_description
+  "downloads_page_description" => "Descargas estables de Keyman",
+
+  # Get the latest
+  "get_the_latest" => 
+    "Obtenga la última versión de Keyman aquí. Estas son descargas independientes y no contienen diseños de teclado
+    para su idioma. Ver también la %1\$s y la %2\$s.",
+
+  # Downloads pre-release page
+  "downloads_pre_release_page" => "página de descarga de la versión preliminar",
+
+  # Downloads old versions page
+  "downloads_old_versions_page" => "páginas de descarga de versiones antiguas",
+
+  # Keyman version history
+  "keyman_version_history_1" => "Historial de versiones de Keyman",
+
+  # Keyman version history (description)
+  "keyman_version_history_2" => "(todos los productos)",
+
+  # Browse all versions
+  "browse_all_versions" => "Ver todas las versiones (14.0 en adelante)",
+
+  ### Product Downloads
+
+  # Keyman for Windows
+  "product_windows" => "Teclado para Windows",
+
+  # Keyman for macOS
+  "product_macos" => "Teclado para macOS",
+
+  # Keyman for Android
+  "product_android" => "Teclado para Android",
+
+  "available_on_play_store" => "Keyman para Android también está disponible en Play Store.",
+
+  # Keyman for iPhone and iPad
+  "product_ios" => "Teclado para iPhone e iPad",
+
+  "available_on_app_store" => "Keyman para iPhone e iPad se puede encontrar en la App Store.",
+
+  # Keyman for Linux
+  "product_linux" => "Keyman para Linux",
+
+  "install_via_launchpad" => "Ubuntu, Wasta-Linux: Keyman para Linux puede instalarse a través de launchpad:",
+
+  # Products for Software Developers
+  "products_for_software_developers" => "Productos para desarrolladores de software",
+
+  # KeymanWeb
+  "product_keymanweb" => "KeymanWeb",
+
+  # Keyman Developer
+  "product_developer" => "Keyman Developer",
+
+  # Keyman Engine for Android
+  "product_engine_android" => "Motor Keyman para Android",
+
+  # Keyman Engine for iOS
+  "product_engine_ios" => "Motor Keyman para iOS",
+
+  ## Tiers
+  "alpha" => "alfa",
+
+  "beta" => "beta",
+
+  "stable" => "estable",
+
+  # (released {date}, {file size})
+  "released_date_size" => "(publicado el %1\$s, %2\$s)",
+
+  # All {product} {tier} releases
+  "all_product_releases" => "Todas las versiones %1\$s %2\$s",
+
+  # No downloads found for {product}
+  "no_downloads_found" => "No se encontraron descargas para %1\$s."
+]
+;
+

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -71,6 +71,19 @@ files:
         fr: fr
         km: km
 
+  # Product Download files
+  - source: /_includes/locale/strings/downloads/en.php
+    dest: /downloads/en.php
+    translation: /_includes/locale/strings/downloads/%locale%.php
+    languages_mapping:
+      locale:
+        # Canonical locales as needed
+        es-ES: es
+        de: de
+        fr: fr
+        km: km
+
+
   # crowdin parameters descriptions:
 
   #

--- a/downloads/_downloads.php
+++ b/downloads/_downloads.php
@@ -1,29 +1,29 @@
 <?php
-  downloadSection('Keyman for Windows',         'windows', 'keyman-$version.exe', 'stable');
-  downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', 'stable');
-  downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', 'stable');
+  downloadSection('product_windows',            'windows', 'keyman-$version.exe', 'stable');
+  downloadSection('product_macos',              'mac',     'keyman-$version.dmg', 'stable');
+  downloadSection('product_android',            'android', 'keyman-$version.apk', 'stable');
 ?>
 
-<p>Keyman for Android is also available on the Play Store.</p>
+<p><?= _m_Downloads('available_on_play_store') ?></p>
 <?= $playstoreTable ?>
 
-<h2 id="iOS" class='red underline'>Keyman for iPhone and iPad</h2>
-<p>Keyman for iPhone and iPad can be found on the App Store.</p>
+<h2 id="iOS" class='red underline'><?= _m_Downloads('product_ios') ?></h2>
+<p><?= _m_Downloads('available_on_app_store') ?></p>
 <?= $appstoreTable ?>
 
-<h2 id='linux' class='red underline'>Keyman for Linux</h2>
+<h2 id='linux' class='red underline'><?= _m_Downloads('product_linux') ?></h2>
 
-<li>Ubuntu, Wasta-Linux: Keyman for Linux can be installed via launchpad:</li>
+<ul><li><?= _m_Downloads('install_via_launchpad') ?></li></ul>
 <blockquote><pre class='language-bash code'><code>sudo add-apt-repository ppa:keymanapp/keyman
 sudo apt install keyman onboard-keyman</code></pre></blockquote>
 
-<h2 class='red underline large'>Products for Software Developers</h2>
+<h2 class='red underline large'><?= _m_Downloads('products_for_software_developers') ?></h2>
 
 <?php
-  downloadSection('KeymanWeb',                     'web',       'keymanweb-$version.zip',             'stable');
-  downloadSection('Keyman Developer',              'developer', 'keymandeveloper-$version.exe',       'stable');
-  downloadSection('Keyman Engine for Android',     'android',   'keyman-engine-android-$version.zip', 'stable', 'android-engine');
-  downloadSection('Keyman Engine for iOS',         'ios',       'keyman-engine-ios-$version.zip',     'stable', 'ios-engine');
+  downloadSection('product_keymanweb',             'web',       'keymanweb-$version.zip',             'stable');
+  downloadSection('product_developer',             'developer', 'keymandeveloper-$version.exe',       'stable');
+  downloadSection('product_engine_android',        'android',   'keyman-engine-android-$version.zip', 'stable', 'android-engine');
+  downloadSection('product_engine_ios',            'ios',       'keyman-engine-ios-$version.zip',     'stable', 'ios-engine');
 ?>
 
 <br/>

--- a/downloads/index.php
+++ b/downloads/index.php
@@ -3,29 +3,39 @@
   require_once('includes/ui/downloads.php');
   require_once('includes/appstore.php');
   require_once('includes/playstore.php');
+  require_once('../keyboards/session.php');
   use Keyman\Site\Common\KeymanHosts;
+  use Keyman\Site\com\keyman\Locale;
+
+  Locale::definePageLocale('LOCALE_DOWNLOADS', 'downloads');
+  $_m_Downloads = function($id, ...$args) { return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); };
+  function _m_Downloads($id, ...$args) {    return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); }
 
   // Required
   head([
-    'title' =>'Keyman Downloads',
-    'description' => 'Keyman stable downloads',
+    'title' => _m_Downloads('downloads_page_title'),
+    'description' => _m_Downloads('downloads_page_description'),
     'css' => ['template.css','index.css','app-store-links.css', 'prism.css'],
     'js' => ['prism.js'],
     'showMenu' => true
   ]);
 ?>
 
-<h2 class="red underline large">Keyman Downloads</h2>
+<h2 class="red underline large"><?= _m_Downloads('downloads_page_title') ?></h2>
 
 <p>
-  Get the latest version of Keyman here. These are standalone downloads and do not contain keyboard layouts
-  for your language. See also the <a href='pre-release'>pre-release download page</a> and the <a href='archive'>old versions download page</a>.
+  <?= _m_Downloads('get_the_latest', 
+    sprintf('<a href=\'pre-release\'>%s</a>', _m_Downloads('downloads_pre_release_page')),
+    sprintf('<a href=\'archive\'>%s</a>', _m_Downloads('downloads_old_versions_page')) ) ?>
 </p>
 
-<p><a href='<?= KeymanHosts::Instance()->help_keyman_com?>/version-history'>Keyman version history</a> (all products)</p>
+<p>
+  <a href='<?= KeymanHosts::Instance()->help_keyman_com?>/version-history'><?= _m_Downloads('keyman_version_history_1') ?></a> 
+  <?= _m_Downloads('keyman_version_history_2') ?>
+</p>
 
 
-  <a class="button" href="all-versions">Browse all versions (14.0 onwards)</a>
+  <a class="button" href="all-versions"><?= _m_Downloads('browse_all_versions') ?></a>
 
 
 <?php


### PR DESCRIPTION
For #687

This starts localizing the main Keyman products download page

Notes:
* Intentionally not doing i18n on date / file size.
* Also not localizing the Play Store / App Store sections since they're also embedded in several (non-localized) pages
* atm, locacalized pages depend on keyboards/Session.php so wee may need to (separately) refactor that to a common folder


## Screenshot

Spanish strings provided by @philleckrone

<img width="1091" height="696" alt="image" src="https://github.com/user-attachments/assets/30bab9a5-b423-439f-9dde-a400ca0fc8e1" />

Test-bot: skip
