### PR TITLE
chore: Update links about SIL Global

### DIFF
--- a/_includes/2020/templates/Foot.php
+++ b/_includes/2020/templates/Foot.php
@@ -60,8 +60,8 @@
         </div>
         <div class="footer-third sil-logo">
             <br>
-            <a href="/about/"><img id="sil-logo" src="<?php echo ImageRandomizer::randomizer(); ?>" width="50%" alt='SIL' /></a>
-            <p>Created by <a href="/about/">SIL Global</a></p>
+            <a href="https://global.sil.org/about/"><img id="sil-logo" src="<?php echo ImageRandomizer::randomizer(); ?>" width="50%" alt='SIL' /></a>
+            <p>Created by <a href="https://global.sil.org/about/">SIL Global</a></p>
         </div>
     </div>
 </div>

--- a/about/index.md
+++ b/about/index.md
@@ -61,6 +61,6 @@ SIL Global is a faith-based nonprofit organization committed to serving language
 worldwide as they build capacity for sustainable language development. SIL does this primarily
 through research, translation, training and materials development.
 
-You can learn more about SIL Global on the [SIL Global web site](https://www.sil.org/about).
+You can learn more about SIL Global on the [SIL Global web site](https://global.sil.org/about/).
 
-➡️ [About SIL Global](https://www.sil.org/about)
+➡️ [About SIL Global](https://global.sil.org/about/)

--- a/free/index.md
+++ b/free/index.md
@@ -24,5 +24,5 @@ are licensed under the MIT License. All lexical models in the
 are also licensed under the MIT License. Copyright for these keyboards and
 lexical models belongs to many different authors.
 
-* [About SIL Global](https://www.sil.org/about)
+* [About SIL Global](https://global.sil.org/about/)
 * [About Keyman](/about)

--- a/sil-acquisition/index.php
+++ b/sil-acquisition/index.php
@@ -29,7 +29,7 @@ Keyman for Android, Keyman for iPhone and iPad and KeymanWeb.</p>
 
 <p>If you have questions about the acquisition, and how it may affect you, please read our Frequently Asked Questions section below.</p>
 
-<p><a href='http://www.sil.org/about/news/sil-acquires-rights-keyman'>Read the SIL announcement</a></p>
+<p><a href='https://global.sil.org/stories-news/sil-acquires-rights-keyman/'>Read the SIL announcement</a></p>
 
 <p class='center'><img class='inline' src='<?= cdn('img/android-splash.png'); ?>' alt='Keyman running on Android devices'></p>
 <h4 class='caption'>Keyman running on Android devices</h4>


### PR DESCRIPTION
Updates links about SIL Global to address https://github.com/keymanapp/keyman.com/pull/704#discussion_r3049057072

> btw, why doesn't about SIL Global go to https://global.sil.org/about/ ?

These are distinct from the "About Keyman" links

Also updated the latest link to the SIL News on acquiring Keyman (from 2015)
https://global.sil.org/stories-news/sil-acquires-rights-keyman/

Test-bot: skip
