### PR TITLE
fix: handle redirects for paths and files with terminating slashes 🌋

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,16 +23,106 @@ RewriteBase /
 # Add mime type for apple-app-site-association
 AddType application/json apple-app-site-association
 
-# Deny crowdin.yml
-RewriteRule "^crowdin.yml$" = [F,L]
-
 # Custom error messages (need to pass the original request)
 ErrorDocument 404 /_includes/errors/404.php
 
 RewriteRule "^_includes/errors/404(.php)?$" "/_includes/errors/404.php" [END]
 
+# ##################################################################
+# Reject special and legacy top-level files without i18n
+# ##################################################################
+
+# Any existing file in _common/assets - must come first because it is overridden below otherwise
+RewriteCond "%{DOCUMENT_ROOT}/$1/$2" -f
+RewriteRule "^(_common/assets)/(.+)$" - [END]
+
+#
+# The following top-level files and folders are not directly visible through URLs:
+#
+#    _common/      (excl. _common/assets/)
+#    _content/
+#    _includes/
+#    _scripts/
+#    .github/
+#    resources/
+#    tests/
+#    .editorconfig
+#    .gitattributes
+#    .gitignore
+#    .htaccess      (this file, not listed explicitly)
+#    build.sh
+#    composer.json
+#    composer.lock
+#    crowdin.yml
+#    Dockerfile
+#    package-lock.json
+#    package.json
+#    phpunit.xml
+#    README.md
+#    TODO.md
+#
+RewriteRule "^(_common|_content|_includes|_scripts|.github|resources|tests)(/.*|$)" - [F,END]
+RewriteRule "^(.editorconfig|.gitattributes|.gitignore|build.sh|composer.json|composer.lock|crowdin.yml|Dockerfile|package-lock.json|package.json|phpunit.xml|README.md|TODO.md)$" - [F,END]
+
+#
+# The following paths are accessible but controlled by sub-folder .htaccess:
+#    _legacy/
+# Thus this rule currently has no effect but will come into play if the
+# _legacy/.htaccess file is removed.
+#
+RewriteRule "^(_legacy)(/.*|$)" - [F,END]
+
+# ##################################################################
+# Handle special and legacy top-level files without i18n
+# ##################################################################
+
+#
+# The following top-level files and folders do not have i18n redirection,
+# but have .php and .md rewrites. They do not have sub-folders.
+#    _common/assets/    (handled above because _common/ itself is excluded)
+#    _control/
+#    _ie_thunk/
+#    _test/
+#
+# The following top-level files and folders do not have .php or .md rewrites
+#    .well-known/
+#    cdn/
+#    go/
+#    robots.txt
+#    tier.txt
+#
+
 # apple-app-site-association
 RewriteRule "^.well-known/apple-app-site-association$" "/.well-known/apple-app-site-association.json" [L]
+
+# Add terminating slash on top-level folders by redirecting
+RewriteCond "$1" ^(_control|_ie_thunk|_test|.well-known|go|cdn)$
+RewriteRule "^([^/]+)$" "$1/" [R,L]
+
+# .php rewrite
+RewriteCond "$1" ^(_control|_ie_thunk|_test)$
+RewriteCond "%{DOCUMENT_ROOT}/$1/$2.php" -f
+RewriteRule "^([^/]+)/(.+)$" "/$1/$2.php" [END]
+
+# .md rewrite
+RewriteCond "$1" ^(_control|_ie_thunk|_test)$
+RewriteCond "%{DOCUMENT_ROOT}/$1/$2.md" -f
+RewriteRule "^([^/]+)/(.+)$" "/_includes/includes/md/mdhost.php?file=$1/$2.md" [END]
+
+# .md rewrite for folder; no .php rewrite for folder
+RewriteCond "$1" ^(_control|_ie_thunk|_test)$
+RewriteCond "%{DOCUMENT_ROOT}/$1/index.md" -f
+RewriteRule "^([^/]+)/$" "/_includes/includes/md/mdhost.php?file=$1/index.md" [END]
+
+# Any existing file in any of those folders or sub folders
+RewriteCond "$1" ^(_control|_ie_thunk|_test|.well-known|go|cdn)$
+RewriteCond "%{DOCUMENT_ROOT}/$1/$2" -f
+RewriteRule "^([^/]+)/(.+)$" - [END]
+
+# Top-level files
+RewriteCond "$1" ^(robots.txt|tier.txt)$
+RewriteCond "%{DOCUMENT_ROOT}/$1" -f
+RewriteRule "^([^/]+)$" - [END]
 
 # ##################################################################
 # Redirections - before rewriting
@@ -49,17 +139,66 @@ RewriteRule "^((.+)/)?index(\.md|\.php)?$" "$1" [R,L]
 RewriteRule "^(.+)\.php$" "$1" [R,L]
 RewriteRule "^(.+)\.md$" "$1" [R,L]
 
-# Redirect folder without / to include /
+# ------------------------------------------------------------------
+# For consistency:
+#  * remove trailing `/` for files if present
+#  * add trailing `/` for folders if not present
+# ------------------------------------------------------------------
+
+#
+# Note: we don't test the content of the lang path parameter (?:[^/]+)/
+# here; that is managed exclusively in the i18n section later.
+#
+
+# Redirect folder to folder/ for .php
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2" -d
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.php" -f
+RewriteRule "^([^/]+)/(.+[^/])$" "$1/$2/" [R,L]
+
+# Redirect folder to folder/ for .md
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2" -d
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.md" -f
+RewriteRule "^([^/]+)/(.+[^/])$" "$1/$2/" [R,L]
+
+# Redirect file/ to file (.md)
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2" !-d
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2.md" -f
+RewriteRule "^([^/]+)/(.+)/$" "$1/$2" [R,L]
+
+# Redirect file/ to file (.php)
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2" !-d
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2.php" -f
+RewriteRule "^([^/]+)/(.+)/$" "$1/$2" [R,L]
+
+#
+# top-level folders and files
+#
+
+# Redirect folder to folder/ for .php
 RewriteCond "%{DOCUMENT_ROOT}/$1" -d
-RewriteCond "%{DOCUMENT_ROOT}/$1.php" !-f
-RewriteCond "%{DOCUMENT_ROOT}/$1.md" !-f
-RewriteRule "^(.+[^/])$" "$1/" [R,END]
+RewriteCond "%{DOCUMENT_ROOT}/$1/index.php" -f
+RewriteRule "^(.+[^/])$" "$1/" [R,L]
+
+# Redirect folder to folder/ for .md
+RewriteCond "%{DOCUMENT_ROOT}/$1" -d
+RewriteCond "%{DOCUMENT_ROOT}/$1/index.md" -f
+RewriteRule "^(.+[^/])$" "$1/" [R,L]
+
+# Redirect file/ to file (.md)
+RewriteCond "%{DOCUMENT_ROOT}/$1" !-d
+RewriteCond "%{DOCUMENT_ROOT}/$1.md" -f
+RewriteRule "^(.+)/$" "$1" [R,L]
+
+# Redirect file/ to file (.php)
+RewriteCond "%{DOCUMENT_ROOT}/$1" !-d
+RewriteCond "%{DOCUMENT_ROOT}/$1.php" -f
+RewriteRule "^(.+)/$" "$1" [R,L]
 
 # ------------------------------------------------------------------
 # Known path redirections
 # ------------------------------------------------------------------
 
-# Redirect /archive/downloads.php"
+# Redirect /archive/downloads.php
 RewriteRule "^archive/downloads(.php)?$" "/downloads/archive/" [NC,R=301,END,QSA]
 
 # ios and iphone and ipad to iphone-and-ipad
@@ -184,30 +323,11 @@ RewriteRule "^(downloads/releases|keyboards)/(.+)$" "en/$1/$2" [R,L]
 # Rewriting
 # ##################################################################
 
-# ------------------------------------------------------------------
-# top-level content without i18n - _control/, go/, _test/, cdn
-# ------------------------------------------------------------------
-
-# No i18n - won't go to _content
-
-RewriteCond "%{DOCUMENT_ROOT}/$1/$2.php" -f
-RewriteRule "^(_control|go|_test)/(.+)$" "/$1/$2.php" [END]
-
-RewriteCond "%{DOCUMENT_ROOT}/$1/$2.md" -f
-RewriteRule "^(_control|go|_test)/(.+)$" "/_includes/includes/md/mdhost.php?file=$1/$2.md" [END]
-
-RewriteCond "%{DOCUMENT_ROOT}/$1/index.md" -f
-RewriteRule "^(_control|go|_test)(/?)$" "/_includes/includes/md/mdhost.php?file=$1/index.md" [END]
-
-RewriteCond "%{DOCUMENT_ROOT}/cdn/$1$2" -f
-RewriteRule "^cdn/(.+\.)(gif|js|png|svg)$" "/cdn/$1$2" [END]
-
-
 #
 # Intentionally not using regex from Validation::validate_bcp47 because we only need lang-script-region triplet
 # ^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)
 # [NC] for case-insensitive
-# Long regex for "BCP-47" codes = $1, rest of URL $7 onward
+# Long regex for "BCP-47" codes = $1, rest of URL $2 onward
 #
 
 #
@@ -215,41 +335,51 @@ RewriteRule "^cdn/(.+\.)(gif|js|png|svg)$" "/cdn/$1$2" [END]
 #
 
 # /keyboards/install/[id] to /keyboards/install.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/install/([^/]+)$" "/_content/keyboards/install.php?id=$7&lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/install/([^/]+)$" "/_content/keyboards/install.php?id=$2&lang=$1" [END,QSA]
 
 # /keyboards/download/[id] to /keyboards/keyboard.php
 # This formerly redirected to a download, but we no longer need it; keep it for
 # legacy links
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/download/([^/]+)$" "/_content/keyboards/keyboard.php?id=$7&lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/download/([^/]+)$" "/_content/keyboards/keyboard.php?id=$2&lang=$1" [END,QSA]
 
 # /keyboards/share/[id] to /keyboards/share.php
 # if the keyboard exists in the repo, then share.php will redirect to /keyboards/<id>
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/share/([^/]+)$" "/_content/keyboards/share.php?id=$7&lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/share/([^/]+)$" "/_content/keyboards/share.php?id=$2&lang=$1" [END,QSA]
 
 # /keyboards/{id}.json to /keyboards/keyboard.json.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/(?!keyboard.json)(.*)\.json$" "/_content/keyboards/keyboard.json.php?id=$7&lang=$1" [NC,END]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/(?!keyboard.json)(.*)\.json$" "/_content/keyboards/keyboard.json.php?id=$2&lang=$1" [END]
 
 # /keyboards/{id} to /keyboards/keyboard.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/(?!index\.php|install|keyboard|session|share)([^/]+)$" "/_content/keyboards/keyboard.php?id=$7&lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/(?!index\.php|install|keyboard|session|share)([^/]+)$" "/_content/keyboards/keyboard.php?id=$2&lang=$1" [END,QSA]
 
 #
 # keyboards search
 #
 
 # /keyboards/languages to /keyboards/index.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/languages/(.*)" "/_content/keyboards/index.php?q=l:id:$7&lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/languages/(.*)" "/_content/keyboards/index.php?q=l:id:$2&lang=$1" [END,QSA]
 
 # /keyboards/download to /keyboards/download.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/download(.php)?" "/_content/keyboards/download.php?lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/download(.php)?" "/_content/keyboards/download.php?lang=$1" [END,QSA]
 
 # /keyboards/legacy to /keyboards/keyboard.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/legacy/(.*)" "/_content/keyboards/keyboard.php?legacy=$7&lang=$1" [NC,END]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/legacy/(.*)" "/_content/keyboards/keyboard.php?legacy=$2&lang=$1" [END]
 
 # /keyboards/countries to /keyboards/index.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards/countries/(.*)" "/_content/keyboards/index.php?q=c:id:$7&lang=$1" [NC,END]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards/countries/(.*)" "/_content/keyboards/index.php?q=c:id:$2&lang=$1" [END]
 
 # Root keyboard search to pass embed query?
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards(/)?$" "/_content/keyboards/index.php?lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/keyboards(/)?$" "/_content/keyboards/index.php?lang=$1" [END,QSA]
 
 
 #
@@ -257,14 +387,11 @@ RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/keyboards(/
 #
 
 # /contact/exception to /contact/exception.php
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/contact/exception(.php)?" "/_content/contact/exception.php?lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/contact/exception(.php)?$" "/_content/contact/exception.php?lang=$1" [END,QSA]
 
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/contact/exception?id=(.+)$" "/_content/contact/exception?id=$7&lang=$1" [NC,END]
-
-#
-# ios
-#
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(iphone|ipad)(/.*)?" "/_content/iphone-and-ipad/$8?lang=$1" [NC,END,QSA]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/contact/exception\?id=(.+)$" "/_content/contact/exception?id=$2&lang=$1" [END]
 
 #
 # downloads/releases
@@ -272,16 +399,19 @@ RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(iphone|ipa
 
 # releases-tier/download
 # note: the tier is currently ignored
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/downloads/releases/(alpha|beta|stable)/(.+)$" "/_content/downloads/releases/_version_downloads.php?tier=$7&version=$8&lang=$1" [NC,END]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/downloads/releases/(alpha|beta|stable)/(.+)$" "/_content/downloads/releases/_version_downloads.php?tier=$2&version=$3&lang=$1" [END]
 
 # releases-download
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/downloads/releases/(.+)$" "/_content/downloads/releases/_version_downloads.php?version=$7&lang=$1" [NC,END]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/downloads/releases/(.+)$" "/_content/downloads/releases/_version_downloads.php?version=$2&lang=$1" [END]
 
 #
 # Assets don't use lang param
 #
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7" -f
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(.+)$" "/_content/$7$8" [NC,END]
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2" -f
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/(.+)$" "/_content/$2" [END]
 
 # TODO: do we want en/lao --> en/keyboards/basic_kbdlao? as well as /lao --> ...
 
@@ -294,27 +424,33 @@ RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(.+)$" "/_c
 ##############################################
 
 # Rewrite file to file.md
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7.md" -f
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(.+)$" "/_includes/includes/md/mdhost.php?file=_content/$7.md&lang=$1" [NC,END]
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2.md" -f
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/(.+)$" "/_includes/includes/md/mdhost.php?file=_content/$2.md&lang=$1" [END]
 
 # Rewrite file to file.php
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7.php" -f
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7.md" !-f
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(.+)$" "/_content/$7.php?lang=$1" [NC,END]
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2.php" -f
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2.md" !-f
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/(.+)$" "/_content/$2.php?lang=$1" [END]
 
 # Rewrite folder/ to folder/index.md
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7/index.md" -f
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(.+)/$" "/_includes/includes/md/mdhost.php?file=_content/$7/index.md&lang=$1" [NC,END]
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.md" -f
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/(.+)/$" "/_includes/includes/md/mdhost.php?file=_content/$2/index.md&lang=$1" [END]
 
 # Rewrite folder/ to folder/index.php
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7/index.php" -f
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7/index.md" !-f
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/(.+)/$" "/_content/$7/index.php?lang=$1" [NC,END]
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.php" -f
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.md" !-f
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/(.+)/$" "/_content/$2/index.php?lang=$1" [END]
 
 # Root page
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)/$" "/_content/index.php?lang=$1" [NC,END]
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)/$" "/_content/index.php?lang=$1" [END]
 
 # Finally, append the terminating slash for folders, given it is no longer
-# done automatically because we put DirectorySlash off
-RewriteCond "%{DOCUMENT_ROOT}/_content/$7$8" -d
-RewriteRule "^(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)(.*)([^/])?$" "$1$7$8/" [NC,R,QSA]
+# done automatically because we put DirectorySlash off, for the top-level paths only
+RewriteCond "%{DOCUMENT_ROOT}/_content/$2$3" -d
+RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
+RewriteRule "^([^/]+)(.*)([^/])?$" "$1$2$3/" [R,QSA]

--- a/_content/keyboards/h/amharic/index.php
+++ b/_content/keyboards/h/amharic/index.php
@@ -96,13 +96,13 @@
   <h3 id="cta-other-downloads">Download an Amharic keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../iphone/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../ipad/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/sinhala/garp/index.php
+++ b/_content/keyboards/h/sinhala/garp/index.php
@@ -92,13 +92,13 @@
   <h3 id="cta-other-downloads">Download a Sinhala keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" alt="."/>
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" alt="."/>
       <p>iPad</p>
     </a>

--- a/_content/keyboards/h/sinhala/sipon/index.php
+++ b/_content/keyboards/h/sinhala/sipon/index.php
@@ -91,13 +91,13 @@
   <h3 id="cta-other-downloads">Download a Sinhala keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" alt="."/>
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" alt="."/>
       <p>iPad</p>
     </a>

--- a/_content/keyboards/h/tamil/anjal-paangu/index.php
+++ b/_content/keyboards/h/tamil/anjal-paangu/index.php
@@ -102,13 +102,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tamil/index.php
+++ b/_content/keyboards/h/tamil/index.php
@@ -102,13 +102,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../iphone/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../ipad/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tamil/isis/index.php
+++ b/_content/keyboards/h/tamil/isis/index.php
@@ -91,13 +91,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tamil/new-typewriter/index.php
+++ b/_content/keyboards/h/tamil/new-typewriter/index.php
@@ -102,13 +102,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tamil/suratha-bamuni/index.php
+++ b/_content/keyboards/h/tamil/suratha-bamuni/index.php
@@ -102,13 +102,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tamil/visual-media-modular/index.php
+++ b/_content/keyboards/h/tamil/visual-media-modular/index.php
@@ -102,13 +102,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tamil/visual-media-typewriter/index.php
+++ b/_content/keyboards/h/tamil/visual-media-typewriter/index.php
@@ -102,13 +102,13 @@
   <h3 id="cta-other-downloads">Download a Tamil keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../../iphone/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../../ipad/">
+    <a href="../../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tigrigna/eritrean.php
+++ b/_content/keyboards/h/tigrigna/eritrean.php
@@ -87,13 +87,13 @@
   <h3 id="cta-other-downloads">Download a Tigrigna keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../iphone/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../ipad/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/tigrigna/index.php
+++ b/_content/keyboards/h/tigrigna/index.php
@@ -87,13 +87,13 @@
   <h3 id="cta-other-downloads">Download a Tigrigna keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../iphone/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../ipad/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/h/urdu/index.php
+++ b/_content/keyboards/h/urdu/index.php
@@ -86,13 +86,13 @@
   <h3 id="cta-other-downloads">Download an Urdu keyboard on these devices:</h3>
 
   <div class="download-cta-small iPhone" id="cta-iPhone">
-    <a href="../../../iphone/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-iphone.png'); ?>" />
       <p>iPhone</p>
     </a>
   </div>
   <div class="download-cta-small iPad" id="cta-iPad">
-    <a href="../../../ipad/">
+    <a href="../../../iphone-and-ipad/">
       <img src="<?php echo cdn('img/cta-icons/icon-ipad.png'); ?>" />
       <p>iPad</p>
   </div>

--- a/_content/keyboards/index.php
+++ b/_content/keyboards/index.php
@@ -40,6 +40,8 @@
   if($embed == 'none')
     Menu::render([]); // we'll be doing client-side os detection now
   Body::render();
+
+  $keyboardsPage = '/' . $head_options['language'] . '/keyboards/';
 ?>
 
 <script>
@@ -59,14 +61,14 @@
 
 <div class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
 
-  <h2 class="red underline"><a href='/<?= $head_options['language']?>/keyboards'><?= _m('page_title') ?></a></h2>
+  <h2 class="red underline"><a href='<?=$keyboardsPage?>'><?= _m('page_title') ?></a></h2>
 
   <div id='search-box'>
-    <form method='get' action='/<?= $head_options['language']?>/keyboards' name='f'>
+    <form method='get' action='<?=$keyboardsPage?>' name='f'>
       <label for="search-q"><?= _m('keyboard_search') ?></label><input id="search-q" type="text" placeholder="<?= _m('enter_language') ?>" name="q"
       <?php if($embed == 'none') echo 'autofocus'; ?>>
       <input id="search-f" type="button" value="<?= _m('search') ?>">
-      <label id="search-new"><a href='/<?= $head_options['language']?>/keyboards<?=$session_query_q?>'><?= _m('new_search')?></a></label>
+      <label id="search-new"><a href='<?= $keyboardsPage . $session_query_q?>'><?= _m('new_search')?></a></label>
       <input id="search-obsolete" type="hidden" name="obsolete" value="0">
       <input id="search-page" type="hidden" name="page" value="1">
     </form>

--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -148,8 +148,7 @@ END;
                 <li><a href="/<?=$fields->lang?>/mac/">Keyman <?=$fields->stable_version?> for macOS</a></li>
                 <li><a href="/<?=$fields->lang?>/linux/">Keyman <?=$fields->stable_version?> for Linux</a></li>
                 <li><a href="/<?=$fields->lang?>/keymanweb/">KeymanWeb.com</a></li>
-                <li><a href="/<?=$fields->lang?>/iphone/">Keyman <?=$fields->stable_version?> for iPhone</a></li>
-                <li><a href="/<?=$fields->lang?>/ipad/">Keyman <?=$fields->stable_version?> for iPad</a></li>
+                <li><a href="/<?=$fields->lang?>/iphone-and-ipad/">Keyman <?=$fields->stable_version?> for iPhone and iPad</a></li>
                 <li><a href="/<?=$fields->lang?>/android/">Keyman <?=$fields->stable_version?> for Android</a></li>
                 <li><a href="/<?=$fields->lang?>/bookmarklet/">Keyman Bookmarklet</a></li>
             </ul>

--- a/cdn/dev/keyboard-search/search.mjs
+++ b/cdn/dev/keyboard-search/search.mjs
@@ -27,7 +27,7 @@ var embed_query_q = embed_query == '' ? '' : '?'+embed_query;
 var embed_query_x = embed_query == '' ? '' : '&'+embed_query;
 
 // TODO: Validate BCP-47 triplet?
-var langMatch = location.pathname.match(/(\/(.+))?\/keyboards(.*)$/);
+var langMatch = location.pathname.match(/(\/(.+))?\/keyboards\/(.*)$/);
 var embed_lang = (langMatch) ? langMatch[2] : 'en';
 
 var dynamic_search_timeout = 0;
@@ -49,9 +49,9 @@ function getCurrentPath(q, page, obsolete) {
   } else if(r && r[1].charAt(0) == 'l') {
     path = '/' + embed_lang + '/keyboards/languages/'+r[3];
   } else if(q == '') {
-    path = '/' + embed_lang + '/keyboards'
+    path = '/' + embed_lang + '/keyboards/'
   } else {
-    path = '/' + embed_lang + '/keyboards?q='+encodeURIComponent(q);
+    path = '/' + embed_lang + '/keyboards/?q='+encodeURIComponent(q);
   }
 
   if(page + obsolete == '') {

--- a/go/.htaccess
+++ b/go/.htaccess
@@ -11,7 +11,7 @@ RedirectMatch "/go/(([1-9][0-9])([.]?)([0-9]))/developer-help-(mobile|packages)(
 # Modified to match download-package below
 RewriteRule "^keyboard/([^/]+)/download/kmp$" "package/download.php?type=keyboard&id=$1" [END,QSA]
 
-#download-exe
+# download-exe
 RedirectMatch "/go/keyboard/([^/?]+)/download/exe$" "/keyboards/download?id=$1&platform=windows&mode=bundle"
 
 # download-js

--- a/resources/keyman-site.conf
+++ b/resources/keyman-site.conf
@@ -4,9 +4,14 @@
 
 DirectoryIndex index.md index.php index.html
 
-<Directory /var/www/html>                
+<Directory /var/www/html>
 	Options +Includes +FollowSymLinks -MultiViews
 	AllowOverride All
+
+	## enable the LogLevel line below to trace mod_rewrite in the Docker logs.
+	## Note: traceX where X can be anything from 1-8
+	# LogLevel alert rewrite:trace3
+
 </Directory>
 
 php_value include_path "/var/www/html/_includes:."


### PR DESCRIPTION
Remove the `/` from a path if it refers to a file, and add a `/` if the path refers to a folder (implicit index.md/index.php).

Clean up keyboard search which had some assumptions about not including the `/` but that doesn't make sense with this pattern.

Test-bot: skip