### PR TITLE
test: automate determining non-en locales for broken-link-checker test to ignore 🌋

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         set +o pipefail
         readarray -t ignoresArray <<< $(find ./_includes/locale/strings/keyboards/ -maxdepth 1 -name '*.php' ! -name "en.php" \
           -execdir basename  {} .php ';')
-        local baseURL="http://localhost:8053"
-        local ignoreStr=("  --exclude ${baseURL}*/downloads/releases/*")
+        baseURL="http://localhost:8053"
+        ignoreStr=("  --exclude ${baseURL}*/downloads/releases/*")
         for locale in "${ignoresArray[@]}"; do
           ignoreStr+=" --exclude ${baseURL}/$locale/*"
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
       env:
         fail-fast: true
 
-    - name: Install node dependencies
-      shell: bash
-      run: |
-        npm install
-
     #
     # Finally, run the tests
     #
@@ -42,11 +37,18 @@ jobs:
     - name: Check broken links
       shell: bash
       continue-on-error: false
-      working-directory: ./_test
       run: |
         set +e
         set +o pipefail
-        node blc_test.mjs | tee ../blc.log
+        readarray -t ignoresArray <<< $(find ./_includes/locale/strings/keyboards/ -maxdepth 1 -name '*.php' ! -name "en.php" \
+          -execdir basename  {} .php ';')
+        local baseURL="http://localhost:8053"
+        local ignoreStr=("  --exclude ${baseURL}*/downloads/releases/*")
+        for locale in "${ignoresArray[@]}"; do
+          ignoreStr+=" --exclude ${baseURL}/$locale/*"
+        done
+        echo "ignoreStr: ${ignoreStr[@]}"
+        npx broken-link-checker ${baseURL}/_test --recursive --ordered ---host-requests 50 -e --filter-level 3 ${ignoreStr} | tee blc.log
         echo "BLC_RESULT=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
     - name: Report on broken links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         readarray -t ignoresArray <<< $(find ./_includes/locale/strings/keyboards/ -maxdepth 1 -name '*.php' ! -name "en.php" \
           -execdir basename  {} .php ';')
         baseURL="http://localhost:8053"
-        ignoreStr=("  --exclude ${baseURL}*/downloads/releases/*")
+        ignoreStr=("  --exclude */downloads/releases/*")
         for locale in "${ignoresArray[@]}"; do
           ignoreStr+=" --exclude ${baseURL}/$locale/*"
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
     - name: Check broken links
       shell: bash
       continue-on-error: false
-      # Exclude checking locales for each link 'lang=*'
+      working-directory: ./_test
       run: |
         set +e
         set +o pipefail
-        npx broken-link-checker http://localhost:8053/_test --recursive --ordered ---host-requests 50 -e --filter-level 3 --exclude '*/donate' --exclude '*lang=*' | tee blc.log
+        node blc_test.mjs | tee ../blc.log
         echo "BLC_RESULT=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
     - name: Report on broken links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       env:
         fail-fast: true
 
+    - name: Install node dependencies
+      shell: bash
+      run: |
+        npm install
+
     #
     # Finally, run the tests
     #

--- a/_test/blc_test.mjs
+++ b/_test/blc_test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Keyman is copyright (C) SIL Global. MIT License.
+ * 
+ * Setup options and run the broken-link-checker on the site
+ * @param excludeExternalLinks: boolean to skip external links. Default true
+ *
+ * package.json using bhttp 1.2.8 to resolve this exception
+ * Reference: https://github.com/stevenvachon/broken-link-checker/issues/184
+ */
+import * as fs from 'node:fs';
+import { argv } from 'node:process';
+import * as path from 'node:path';
+import blc from 'broken-link-checker';
+import humanizeDuration from 'humanize-duration';
+const { SiteChecker } = blc;
+
+const KEYMAN_COM_BASE_URL = 'http://localhost:8053';
+
+/**
+ * Searches through ../_includes/locale/strings/keyboards/ for the localized .php files.
+ * Generate list of excludedKeywords: non-en locales
+ * @returns string[]
+ */
+function generateExcludeList() {
+  // Determine list of "locales" to exclude
+  const excluded = fs.readdirSync('../_includes/locale/strings/keyboards/')
+    .filter(file => path.extname(file).toLowerCase() === '.php')
+    .filter(file => file !== 'en.php')
+    .map(file => `${KEYMAN_COM_BASE_URL}/${path.basename(file, '.php')}/`);
+
+  return excluded;
+}
+
+/**
+ * Run the broken link checker test. Prints results while running
+ * @param excludeExternalLinks {boolean} to skip external links
+ */
+async function runTest(excludeExternalLinks) {
+  const options = {
+    cacheResponses: true, // Check each unique URL once
+    excludedKeywords: generateExcludeList(),
+    excludeExternalLinks: excludeExternalLinks,
+    excludedSchemes: ['market'],
+    filterLevel: 3,
+    maintainLinkOrder: true,
+    maxSocketsPerHost: 50,
+    recursive: true
+  };
+  console.info(`options: ${JSON.stringify(options, null, 2)}`);
+
+  let startTime = Date.now();
+  console.info(`start time: ${new Date(startTime).toISOString()}`);
+
+  const siteChecker = new SiteChecker(options, {
+    html: (tree, robots, response, pageURL) => {
+      console.info(`\nGetting links from: ${pageURL}`);
+    },
+    link: (result) => {
+      //console.info(`${JSON.stringify(result)}`);
+      if (result.broken) {
+        const brokenUrl = (result.url.resolved) ? result.url.resolved : result.url.original;
+        console.error(`├─BROKEN─ ${brokenUrl} because ${result.brokenReason}`);
+      } else if (result.excluded) {
+        console.info(`├─EXCLUDED─ ${result.url.resolved} for ${link.excludedReason}`);
+      } else {
+        // For troubleshooting valid links
+        //console.info(`├───OK─── ${result.url.resolved}`);
+      }
+    },
+    end: () => {
+      // Summary
+      console.info(`\nLinks broken: TBD`);
+      console.info(`\nTime elapsed: ${humanizeDuration(Date.now() - startTime, {largest: 2, round:true})}\n`);
+    }
+  });
+
+  const firstPageUrl = `${KEYMAN_COM_BASE_URL}/_test`;
+  siteChecker.enqueue(firstPageUrl);
+}
+
+/*
+ * Setup options and run the broken-link-checker on the site
+ * @param excludeExternalLinks: boolean to skip external links. Default true
+ */
+const excludeExternalLinks = argv.length >= 3 ? argv[2].toLowerCase() === 'true' : true;
+await runTest(excludeExternalLinks);

--- a/build.sh
+++ b/build.sh
@@ -46,9 +46,10 @@ function test_docker_container() {
   docker exec $KEYMAN_CONTAINER_DESC sh -c "find . -name '*.php' | grep -v '/vendor/' | xargs -n 1 -d '\\n' php -l"
 
   # NOTE: link checker runs on host rather than in docker image
-  # Also exclude testing locales for each link: 'lang=*'
   builder_echo blue "---- Testing links"
-  npx broken-link-checker http://localhost:8053/_test --recursive --ordered ---host-requests 50 -e --filter-level 3 --exclude '*/donate' --exclude='/downloads/releases/*' --exclude '*lang=*' | tee blc.log
+  cd ./_test
+  node blc_test.mjs | tee ../blc.log
+  cd ../
   local BLC_RESULT=${PIPESTATUS[0]}
   echo ----------------------------------------------------------------------
   echo Link check summary

--- a/build.sh
+++ b/build.sh
@@ -47,9 +47,17 @@ function test_docker_container() {
 
   # NOTE: link checker runs on host rather than in docker image
   builder_echo blue "---- Testing links"
-  cd ./_test
-  node blc_test.mjs | tee ../blc.log
-  cd ../
+
+  # determine non-en locales to ignore along with /downloads/releases
+  readarray -t ignoresArray <<< $(find ./_includes/locale/strings/keyboards/ -maxdepth 1 -name '*.php' ! -name "en.php" \
+    -execdir basename  {} .php ';')
+  local baseURL="http://localhost:8053"
+  local ignoreStr=("  --exclude ${baseURL}*/downloads/releases/*")
+  for locale in "${ignoresArray[@]}"; do
+    ignoreStr+=" --exclude ${baseURL}/$locale/*"
+  done
+  echo "ignoreStr: ${ignoreStr[@]}"
+  npx broken-link-checker ${baseURL}/_test --recursive --ordered ---host-requests 50 -e --filter-level 3 ${ignoreStr} | tee blc.log
   local BLC_RESULT=${PIPESTATUS[0]}
   echo ----------------------------------------------------------------------
   echo Link check summary

--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ function test_docker_container() {
   readarray -t ignoresArray <<< $(find ./_includes/locale/strings/keyboards/ -maxdepth 1 -name '*.php' ! -name "en.php" \
     -execdir basename  {} .php ';')
   local baseURL="http://localhost:8053"
-  local ignoreStr=("  --exclude ${baseURL}*/downloads/releases/*")
+  local ignoreStr=("  --exclude */downloads/releases/*")
   for locale in "${ignoresArray[@]}"; do
     ignoreStr+=" --exclude ${baseURL}/$locale/*"
   done

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/keymanapp/keyman.com#readme",
   "devDependencies": {
-    "broken-link-checker": "^0.7.8",
-    "bhttp": "1.2.8"
+    "broken-link-checker": "^0.7.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/keymanapp/keyman.com#readme",
   "devDependencies": {
-    "broken-link-checker": "^0.7.8"
+    "broken-link-checker": "^0.7.8",
+    "bhttp": "1.2.8"
   }
 }


### PR DESCRIPTION
Addresses https://github.com/keymanapp/keyman.com/pull/712#discussion_r3154723856

> Excluding all locales except en will not scale well. I wonder if there is a better way -- can we build a scripted filter using the api published at [broken-link-checker](https://www.npmjs.com/package/broken-link-checker)?

I'm applying to the base branch master so we can compare the CI link checker to existing runs
This [passing run took 13m 23s](https://github.com/keymanapp/keyman.com/actions/runs/25424339340) after skipping /downloads/releases

The one for [#979 took 26m 49s](https://github.com/keymanapp/keyman.com/actions/runs/25269524878/job/74089491806)

This updates ci.yml and build.sh to determine the list of non-en locales to ignore (along with /downloads/releases) for the broken-link-checker CLI to run.

Test-bot: skip
