### PR TITLE
feat: use page URL path to find current locale 🌋

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -336,26 +336,26 @@ RewriteRule "^(downloads/releases|keyboards)/(.+)$" "en/$1/$2" [R,L]
 
 # /keyboards/install/[id] to /keyboards/install.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/install/([^/]+)$" "/_content/keyboards/install.php?id=$2&lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards/install/([^/]+)$" "/_content/keyboards/install.php?id=$2" [END,QSA]
 
 # /keyboards/download/[id] to /keyboards/keyboard.php
 # This formerly redirected to a download, but we no longer need it; keep it for
 # legacy links
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/download/([^/]+)$" "/_content/keyboards/keyboard.php?id=$2&lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards/download/([^/]+)$" "/_content/keyboards/keyboard.php?id=$2" [END,QSA]
 
 # /keyboards/share/[id] to /keyboards/share.php
 # if the keyboard exists in the repo, then share.php will redirect to /keyboards/<id>
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/share/([^/]+)$" "/_content/keyboards/share.php?id=$2&lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards/share/([^/]+)$" "/_content/keyboards/share.php?id=$2" [END,QSA]
 
 # /keyboards/{id}.json to /keyboards/keyboard.json.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/(?!keyboard.json)(.*)\.json$" "/_content/keyboards/keyboard.json.php?id=$2&lang=$1" [END]
+RewriteRule "^([^/]+)/keyboards/(?!keyboard.json)(.*)\.json$" "/_content/keyboards/keyboard.json.php?id=$2" [END]
 
 # /keyboards/{id} to /keyboards/keyboard.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/(?!index\.php|install|keyboard|session|share)([^/]+)$" "/_content/keyboards/keyboard.php?id=$2&lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards/(?!index\.php|install|keyboard|session|share)([^/]+)$" "/_content/keyboards/keyboard.php?id=$2" [END,QSA]
 
 #
 # keyboards search
@@ -363,23 +363,23 @@ RewriteRule "^([^/]+)/keyboards/(?!index\.php|install|keyboard|session|share)([^
 
 # /keyboards/languages to /keyboards/index.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/languages/(.*)" "/_content/keyboards/index.php?q=l:id:$2&lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards/languages/(.*)" "/_content/keyboards/index.php?q=l:id:$2" [END,QSA]
 
 # /keyboards/download to /keyboards/download.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/download(.php)?" "/_content/keyboards/download.php?lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards/download(.php)?" "/_content/keyboards/download.php" [END,QSA]
 
 # /keyboards/legacy to /keyboards/keyboard.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/legacy/(.*)" "/_content/keyboards/keyboard.php?legacy=$2&lang=$1" [END]
+RewriteRule "^([^/]+)/keyboards/legacy/(.*)" "/_content/keyboards/keyboard.php?legacy=$2" [END]
 
 # /keyboards/countries to /keyboards/index.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards/countries/(.*)" "/_content/keyboards/index.php?q=c:id:$2&lang=$1" [END]
+RewriteRule "^([^/]+)/keyboards/countries/(.*)" "/_content/keyboards/index.php?q=c:id:$2" [END]
 
 # Root keyboard search to pass embed query?
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/keyboards(/)?$" "/_content/keyboards/index.php?lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/keyboards(/)?$" "/_content/keyboards/index.php" [END,QSA]
 
 
 #
@@ -388,10 +388,10 @@ RewriteRule "^([^/]+)/keyboards(/)?$" "/_content/keyboards/index.php?lang=$1" [E
 
 # /contact/exception to /contact/exception.php
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/contact/exception(.php)?$" "/_content/contact/exception.php?lang=$1" [END,QSA]
+RewriteRule "^([^/]+)/contact/exception(.php)?$" "/_content/contact/exception.php" [END,QSA]
 
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/contact/exception\?id=(.+)$" "/_content/contact/exception?id=$2&lang=$1" [END]
+RewriteRule "^([^/]+)/contact/exception\?id=(.+)$" "/_content/contact/exception?id=$2" [END]
 
 #
 # downloads/releases
@@ -400,15 +400,13 @@ RewriteRule "^([^/]+)/contact/exception\?id=(.+)$" "/_content/contact/exception?
 # releases-tier/download
 # note: the tier is currently ignored
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/downloads/releases/(alpha|beta|stable)/(.+)$" "/_content/downloads/releases/_version_downloads.php?tier=$2&version=$3&lang=$1" [END]
+RewriteRule "^([^/]+)/downloads/releases/(alpha|beta|stable)/(.+)$" "/_content/downloads/releases/_version_downloads.php?tier=$2&version=$3" [END]
 
 # releases-download
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/downloads/releases/(.+)$" "/_content/downloads/releases/_version_downloads.php?version=$2&lang=$1" [END]
+RewriteRule "^([^/]+)/downloads/releases/(.+)$" "/_content/downloads/releases/_version_downloads.php?version=$2" [END]
 
-#
-# Assets don't use lang param
-#
+# other file types
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2" -f
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
 RewriteRule "^([^/]+)/(.+)$" "/_content/$2" [END]
@@ -426,28 +424,28 @@ RewriteRule "^([^/]+)/(.+)$" "/_content/$2" [END]
 # Rewrite file to file.md
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2.md" -f
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/(.+)$" "/_includes/includes/md/mdhost.php?file=_content/$2.md&lang=$1" [END]
+RewriteRule "^([^/]+)/(.+)$" "/_includes/includes/md/mdhost.php?file=_content/$2.md" [END]
 
 # Rewrite file to file.php
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2.php" -f
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2.md" !-f
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/(.+)$" "/_content/$2.php?lang=$1" [END]
+RewriteRule "^([^/]+)/(.+)$" "/_content/$2.php" [END]
 
 # Rewrite folder/ to folder/index.md
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.md" -f
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/(.+)/$" "/_includes/includes/md/mdhost.php?file=_content/$2/index.md&lang=$1" [END]
+RewriteRule "^([^/]+)/(.+)/$" "/_includes/includes/md/mdhost.php?file=_content/$2/index.md" [END]
 
 # Rewrite folder/ to folder/index.php
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.php" -f
 RewriteCond "%{DOCUMENT_ROOT}/_content/$2/index.md" !-f
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/(.+)/$" "/_content/$2/index.php?lang=$1" [END]
+RewriteRule "^([^/]+)/(.+)/$" "/_content/$2/index.php" [END]
 
 # Root page
 RewriteCond "$1" ^([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?$ [NC]   # BCP 47 match
-RewriteRule "^([^/]+)/$" "/_content/index.php?lang=$1" [END]
+RewriteRule "^([^/]+)/$" "/_content/index.php" [END]
 
 # Finally, append the terminating slash for folders, given it is no longer
 # done automatically because we put DirectorySlash off, for the top-level paths only

--- a/_content/keyboards/index.php
+++ b/_content/keyboards/index.php
@@ -40,7 +40,7 @@
     Menu::render([]); // we'll be doing client-side os detection now
   Body::render();
 
-  $keyboardsPage = '/' . $head_options['language'] . '/keyboards/';
+  $keyboardsPage = '/' . Locale::pageLocale() . '/keyboards/';
 ?>
 
 <script>

--- a/_content/keyboards/index.php
+++ b/_content/keyboards/index.php
@@ -9,14 +9,13 @@
   use Keyman\Site\com\keyman\templates\Foot;
   use Keyman\Site\com\keyman\Locale;
 
-  Locale::definePageLocale('LOCALE_KEYBOARDS', 'keyboards');
+  Locale::definePageScope('LOCALE_KEYBOARDS', 'keyboards');
   $_m = function($id, ...$args) { return Locale::m(LOCALE_KEYBOARDS, $id, ...$args); };
   function _m($id, ...$args) {    return Locale::m(LOCALE_KEYBOARDS, $id, ...$args); }
 
   $head_options = [
     'title' => _m('page_title'),
     'description' => _m('page_description'),
-    'language' => isset($_SESSION['lang']) ? $_SESSION['lang'] : 'en',
     'css' => [Util::cdn('css/template.css'), Util::cdn('keyboard-search/search.css')],
     'js' => [
       Util::cdn('keyboard-search/jquery.mark.js'),
@@ -45,11 +44,10 @@
 ?>
 
 <script>
-  var embed='<?=$embed?>';
-  var embed_query='<?=$session_query?>';
-  var embed_lang='<?=$head_options['language']?>';
+  window.embed='<?=$embed?>';
+  window.embed_query='<?=$session_query?>';
 
-  if(embed != 'none') {
+  if(window.embed != 'none') {
     // For an iframe hosted in Download Keyboards dialog, we cannot use
     // autofocus because it is cross-origin. However, setting focus
     // programatically works here.

--- a/_content/keyboards/install.php
+++ b/_content/keyboards/install.php
@@ -18,7 +18,7 @@
   use Keyman\Site\com\keyman\Util;
   use Keyman\Site\com\keyman\Locale;
 
-  Locale::definePageLocale('LOCALE_KEYBOARDS_INSTALL', 'keyboards/install');
+  Locale::definePageScope('LOCALE_KEYBOARDS_INSTALL', 'keyboards/install');
   $_m = function($id, ...$args) {
     return Locale::m(LOCALE_KEYBOARDS_INSTALL, $id, ...$args);
   };

--- a/_content/keyboards/session.php
+++ b/_content/keyboards/session.php
@@ -32,20 +32,6 @@
   $embed_ios = $embed == 'ios';
   $embed_developer = $embed == 'developer';
 
-  if(isset($_REQUEST['lang'])) {
-    \Keyman\Site\com\keyman\Locale::setLocale($_REQUEST['lang']);
-  } else if (isset($_SESSION['lang'])) {
-    \Keyman\Site\com\keyman\Locale::setLocale($_SESSION['lang']);
-  } else {
-    // Fallback to English locale
-    \Keyman\Site\com\keyman\Locale::setLocale(
-      \Keyman\Site\com\keyman\Locale::DEFAULT_LOCALE);
-  }
-  $embed_locale = \Keyman\Site\com\keyman\Locale::currentLocales();
-  if (!empty($embed_locale) && $embed_locale != \Keyman\Site\com\keyman\Locale::DEFAULT_LOCALE) { 
-    $_SESSION['lang'] = $embed_locale[0];
-  }
-
   if($embed != 'none') {
     // Poor man's session control because IE embedded in downlevel Windows destroys cookie support by
     // default, including in existing versions of Keyman.

--- a/_content/keyboards/share.php
+++ b/_content/keyboards/share.php
@@ -6,7 +6,7 @@
   use Keyman\Site\Common\KeymanHosts;
   use Keyman\Site\com\keyman\Locale;
 
-  Locale::definePageLocale('LOCALE_KEYBOARDS_SHARE', 'keyboards/share');
+  Locale::definePageScope('LOCALE_KEYBOARDS_SHARE', 'keyboards/share');
   $_m = function($id, ...$args) {
     return Locale::m(LOCALE_KEYBOARDS_SHARE, $id, ...$args);
   };

--- a/_includes/2020/templates/Foot.php
+++ b/_includes/2020/templates/Foot.php
@@ -6,16 +6,14 @@
   use Keyman\Site\Common\ImageRandomizer;
   use Keyman\Site\Common\KeymanVersion;
   use Keyman\Site\Common\KeymanHosts;
+  use Keyman\Site\com\keyman\Locale;
 
   class Foot {
     static function render(array $fields = []) {
       $fields = (object)$fields;
       $fields->stable_version = KeymanVersion::stable_version;
       $fields->beta_version = KeymanVersion::beta_version;
-
-      // Fallback to 'en'
-      // TODO-I18N-URL-SCHEME: integrate with Locale.php
-      $fields->lang = isset($_REQUEST['lang']) ? $_REQUEST['lang'] : 'en';
+      $fields->pageLocale = Locale::pageLocale();
 ?>
 
       </div>
@@ -46,7 +44,7 @@
             <div id="privacy-policy"><a href="/privacy/">Privacy policy</a></div>
 
             <div id='footer-get-involved'>
-              <a href="/<?=$fields->lang?>/about/get-involved">Get involved</a>
+              <a href="/<?=$fields->pageLocale?>/about/get-involved">Get involved</a>
               <a href='/donate'>Donate</a>
             </div>
         </div>

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -6,6 +6,7 @@
 use Keyman\Site\com\keyman\Util;
 use Keyman\Site\com\keyman\KeymanComSentry;
 use Keyman\Site\Common\KeymanHosts;
+use Keyman\Site\com\keyman\Locale;
 
 // *Don't* use autoloader here because of potential side-effects in older pages
 require_once _KEYMANCOM_INCLUDES . '/2020/Util.php';
@@ -19,9 +20,6 @@ class Head {
       if(!isset($fields->title)) {
         $fields->title = 'Keyman | Type to the world in your language';
       }
-      // Fallback to 'en'
-      // TODO-I18N-URL-SCHEME: integrate with Locale.php
-      $fields->lang = isset($_REQUEST['lang']) ? $_REQUEST['lang'] : 'en';
 
       if(!isset($fields->favicon)) {
         $fields->favicon = Util::cdn("img/favicon.ico");
@@ -35,14 +33,19 @@ class Head {
       if(!isset($fields->js_i18n_domains)) {
         $fields->js_i18n_domains = [];
       }
+
+      $fields->pageLocale = Locale::pageLocale();
+
+      // Redirect to /en/... if not a supported locale; this needs to be emitted
+      // as a HTTP header before first content byte.
+      if(Locale::invalidLocale()) {
+        if(preg_match('/^\\/[^\/]+\\/(.+)$/', $_SERVER['REQUEST_URI'], $matches)) {
+          header("Location: /" . Locale::DEFAULT_LOCALE . "/" . $matches[1]);
+          return;
+        }
+      }
 ?><!DOCTYPE html>
-<?php
-  if (!empty($fields->lang)) {
-    echo "<html lang='$fields->lang'>";
-  } else {
-    echo "<html>";
-  }
-?>
+<html lang='<?=$fields->pageLocale?>'>
 <head>
   <meta charset="utf-8">
   <?php

--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -23,9 +23,7 @@
       $fields->stable_version = KeymanVersion::stable_version;
       $fields->beta_version = KeymanVersion::beta_version;
 
-      // Fallback to 'en'
-      // TODO-I18N-URL-SCHEME: integrate with Locale.php
-      $fields->lang = isset($_REQUEST['lang']) ? $_REQUEST['lang'] : 'en';
+      $fields->pageLocale = Locale::pageLocale();
 
       echo <<<END
 <body data-device="$fields->device">
@@ -135,7 +133,7 @@ END;
     <div id="phone-menu-inner">
         <div class="phone-menu-item">
             <h3>Keyboards</h3>
-            <form method="get" action="/<?=$fields->lang?>/keyboards" name="fsearch">
+            <form method="get" action="/<?=$fields->pageLocale?>/keyboards" name="fsearch">
                 <input id="language-search2" type="text" placeholder="Enter language" name="q">
                 <input id="search-submit2" type="image" src="<?php echo Util::cdn("img/search-button.png"); ?>" alt="search button" value="Search" onclick="if(document.getElementById('language-search2').value==''){return false;}">
             </form>
@@ -144,44 +142,44 @@ END;
   <div class="phone-menu-item">
             <h3>Products</h3>
             <ul>
-                <li><a href="/<?=$fields->lang?>/windows/">Keyman <?=$fields->stable_version?> for Windows</a></li>
-                <li><a href="/<?=$fields->lang?>/mac/">Keyman <?=$fields->stable_version?> for macOS</a></li>
-                <li><a href="/<?=$fields->lang?>/linux/">Keyman <?=$fields->stable_version?> for Linux</a></li>
-                <li><a href="/<?=$fields->lang?>/keymanweb/">KeymanWeb.com</a></li>
-                <li><a href="/<?=$fields->lang?>/iphone-and-ipad/">Keyman <?=$fields->stable_version?> for iPhone and iPad</a></li>
-                <li><a href="/<?=$fields->lang?>/android/">Keyman <?=$fields->stable_version?> for Android</a></li>
-                <li><a href="/<?=$fields->lang?>/bookmarklet/">Keyman Bookmarklet</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/windows/">Keyman <?=$fields->stable_version?> for Windows</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/mac/">Keyman <?=$fields->stable_version?> for macOS</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/linux/">Keyman <?=$fields->stable_version?> for Linux</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/keymanweb/">KeymanWeb.com</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/iphone-and-ipad/">Keyman <?=$fields->stable_version?> for iPhone and iPad</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/android/">Keyman <?=$fields->stable_version?> for Android</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/bookmarklet/">Keyman Bookmarklet</a></li>
             </ul>
             <h3>Downloads</h3>
             <ul>
-                <li><a href='/<?=$fields->lang?>/downloads/'>Current release versions</a></li>
-                <li><a href='/<?=$fields->lang?>/downloads/pre-release/'>Pre-release versions</a></li>
-                <li><a href="/<?=$fields->lang?>/downloads/archive/">Older versions</a></li>
+                <li><a href='/<?=$fields->pageLocale?>/downloads/'>Current release versions</a></li>
+                <li><a href='/<?=$fields->pageLocale?>/downloads/pre-release/'>Pre-release versions</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/downloads/archive/">Older versions</a></li>
             </ul>
         </div>
         <div class="phone-menu-item">
             <h3>Developer Tools</h3>
             <ul>
-                <li><a href="/<?=$fields->lang?>/developer/">Keyman Developer <?=$fields->stable_version?></a></li>
-                <li><a href="/<?=$fields->lang?>/engine/">Keyman Engine for Desktop</a></li>
-                <li><a href="/<?=$fields->lang?>/engine/">Keyman Engine for Web</a></li>
-                <li><a href="/<?=$fields->lang?>/engine/">Keyman Engine for iOS</a></li>
-                <li><a href="/<?=$fields->lang?>/engine/">Keyman Engine for Android</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/developer/">Keyman Developer <?=$fields->stable_version?></a></li>
+                <li><a href="/<?=$fields->pageLocale?>/engine/">Keyman Engine for Desktop</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/engine/">Keyman Engine for Web</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/engine/">Keyman Engine for iOS</a></li>
+                <li><a href="/<?=$fields->pageLocale?>/engine/">Keyman Engine for Android</a></li>
             </ul>
         </div>
         <div class="phone-menu-item">
             <h3>About</h3>
             <ul>
-              <li><a href="/<?=$fields->lang?>/about/">About Keyman</a></li>
-              <li><a href="/<?=$fields->lang?>/about/team">The team</a></li>
-              <li><a href="/<?=$fields->lang?>/about/get-involved">Get Involved</a></li>
-              <li><a href="/<?=$fields->lang?>/training">Training Events</a></li>
-              <li><a href="/<?=$fields->lang?>/free/">Free on all Platforms</a></li>
-              <li><a href="/<?=$fields->lang?>/ldml/">LDML Support</a></li>
-              <li><a href="/<?=$fields->lang?>/contact/">Contact Us</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/about/">About Keyman</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/about/team">The team</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/about/get-involved">Get Involved</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/training">Training Events</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/free/">Free on all Platforms</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/ldml/">LDML Support</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/contact/">Contact Us</a></li>
               <li><a href="<?= KeymanHosts::Instance()->blog_keyman_com ?>">Keyman Blog</a></li>
-              <li><a href="/<?=$fields->lang?>/testimonials/">Testimonials</a></li>
-              <li><a href="/<?=$fields->lang?>/search/">Search Site</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/testimonials/">Testimonials</a></li>
+              <li><a href="/<?=$fields->pageLocale?>/search/">Search Site</a></li>
            </ul>
         </div>
         <div class="phone-menu-item">
@@ -206,9 +204,9 @@ END;
         <img id="header-bottom" src="<?php echo Util::cdn("img/headerbar.png"); ?>" alt='Header bottom' />
         <div id="help">
 
-          <span id='free'>Keyman is <a href='/<?=$fields->lang?>/free'>free and open source</a></span>
+          <span id='free'>Keyman is <a href='/<?=$fields->pageLocale?>/free'>free and open source</a></span>
 
-          <form action="/<?=$fields->lang?>/search/" method="get" role="search">
+          <form action="/<?=$fields->pageLocale?>/search/" method="get" role="search">
             <div class="search-wrap">
               <label for="main-q" class="offscreen">Search</label>
               <input type="search" id="main-q" name="q" placeholder="Search" data-value="" value="" />
@@ -226,7 +224,7 @@ END;
     <div id="top-menu1">
         <a href="/"><img id="top-menu-icon" src="<?php echo Util::cdn("img/icon1.png"); ?>" alt="Keyman logo" /></a>
         <div id='help1'>
-          <form action="/<?=$fields->lang?>/search/" method="get" role="search">
+          <form action="/<?=$fields->pageLocale?>/search/" method="get" role="search">
             <div class="search-wrap">
               <label for="main-q" class="offscreen">Search</label>
               <input type="search" id="main-q" name="q" placeholder="Search" data-value="" value="" />
@@ -245,7 +243,7 @@ END;
                 <div class="menu-item-dropdown">
                     <div class="menu-dropdown-inner">
                         <h4>(2500+ languages)</h4>
-                        <form method="get" action="/<?=$fields->lang?>/keyboards" name="fsearch">
+                        <form method="get" action="/<?=$fields->pageLocale?>/keyboards" name="fsearch">
                             <input id="language-search" type="text" placeholder="Enter language" name="q">
                             <input id="search-submit" type="image" src="<?php echo Util::cdn('img/search-button.png'); ?>" value="Search" onclick="if(document.getElementById('language-search').value==''){return false;}">
                         </form>
@@ -274,19 +272,19 @@ END;
                     <div class="menu-dropdown-inner">
                         <h4>Core Products</h4>
                         <ul>
-                            <li><a href="/<?=$fields->lang?>/windows/">Keyman <?=$fields->stable_version?> for Windows</a></li>
-                            <li><a href="/<?=$fields->lang?>/mac/">Keyman <?=$fields->stable_version?> for macOS</a></li>
-                            <li><a href="/<?=$fields->lang?>/linux/">Keyman <?=$fields->stable_version?> for Linux</a></li>
-                            <li><a href="/<?=$fields->lang?>/iphone-and-ipad/">Keyman <?=$fields->stable_version?> for iPhone and iPad</a></li>
-                            <li><a href="/<?=$fields->lang?>/android/">Keyman <?=$fields->stable_version?> for Android</a></li>
-                            <li><a href="/<?=$fields->lang?>/keymanweb/">KeymanWeb.com</a></li>
-                            <li><a href="/<?=$fields->lang?>/bookmarklet/">Keyman Bookmarklet</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/windows/">Keyman <?=$fields->stable_version?> for Windows</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/mac/">Keyman <?=$fields->stable_version?> for macOS</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/linux/">Keyman <?=$fields->stable_version?> for Linux</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/iphone-and-ipad/">Keyman <?=$fields->stable_version?> for iPhone and iPad</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/android/">Keyman <?=$fields->stable_version?> for Android</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/keymanweb/">KeymanWeb.com</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/bookmarklet/">Keyman Bookmarklet</a></li>
                         </ul>
                         <h4>Downloads</h4>
                         <ul>
-                            <li><a href='/<?=$fields->lang?>/downloads/'>Current release versions</a></li>
-                            <li><a href='/<?=$fields->lang?>/downloads/pre-release/'>Pre-release versions</a></li>
-                            <li><a href="/<?=$fields->lang?>/downloads/archive/">Older versions</a></li>
+                            <li><a href='/<?=$fields->pageLocale?>/downloads/'>Current release versions</a></li>
+                            <li><a href='/<?=$fields->pageLocale?>/downloads/pre-release/'>Pre-release versions</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/downloads/archive/">Older versions</a></li>
                         </ul>
                     </div>
                 </div>
@@ -296,23 +294,23 @@ END;
                 <div class="menu-item-dropdown">
                     <div class="menu-dropdown-inner">
                         <ul>
-                            <li><a href="/<?=$fields->lang?>/about/">About Keyman</a></li>
-                            <li><a href="/<?=$fields->lang?>/about/team">The team</a></li>
-                            <li><a href="/<?=$fields->lang?>/about/get-involved">Get Involved</a></li>
-                            <li><a href="/<?=$fields->lang?>/training">Training Events</a></li>
-                            <li><a href="/<?=$fields->lang?>/free/">Free on all Platforms</a></li>
-                            <li><a href="/<?=$fields->lang?>/ldml/">LDML Support</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/about/">About Keyman</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/about/team">The team</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/about/get-involved">Get Involved</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/training">Training Events</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/free/">Free on all Platforms</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/ldml/">LDML Support</a></li>
                             <li><a href="<?= KeymanHosts::Instance()->help_keyman_com ?>">Help and Documentation</a></li>
-                            <li><a href="/<?=$fields->lang?>/contact/">Contact Us</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/contact/">Contact Us</a></li>
                             <li><a href="<?= KeymanHosts::Instance()->blog_keyman_com ?>">Keyman Blog</a></li>
-                            <li><a href="/<?=$fields->lang?>/testimonials/">Testimonials</a></li>
+                            <li><a href="/<?=$fields->pageLocale?>/testimonials/">Testimonials</a></li>
                         </ul>
                     </div>
                 </div>
             </div>
             <div class="menu-item" id="developer">
                 <div class="menu-item-sub" id="develop">
-                    <a href="/<?=$fields->lang?>/developer/">
+                    <a href="/<?=$fields->pageLocale?>/developer/">
                         <h3>Developer</h3>
                     </a>
                 </div>

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -12,7 +12,7 @@
   use \Keyman\Site\com\keyman\Locale;
   use \Keyman\Site\com\keyman;
 
-  Locale::definePageLocale('LOCALE_KEYBOARDS_DETAILS', 'keyboards/details');
+  Locale::definePageScope('LOCALE_KEYBOARDS_DETAILS', 'keyboards/details');
   $_m_KeyboardDetails = function($id, ...$args) {
     return Locale::m(LOCALE_KEYBOARDS_DETAILS, $id, ...$args);
   };

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -30,19 +30,57 @@
     // Each locale is an object? with loaded flag and array of strings
     private static $strings = [];
 
+    private static $invalidLocale = false;
+
     /**
      * Return the current locales. Fallback to 'en'
      * @return $currentLocales
      */
     public static function currentLocales() {
+      if(count(self::$currentLocales) == 0) {
+        // For pages with no locale set, or if called too early ...?
+        // var_dump(self::$currentLocales);
+        Locale::setLocaleFromURL();
+      }
       return self::$currentLocales;
+    }
+
+    /**
+     * Return the user-selected page locale, which is always embedded at the
+     * front of the URL path
+     */
+    public static function pageLocale() {
+      return self::currentLocales()[0];
+    }
+
+    public static function invalidLocale() {
+      return self::$invalidLocale;
+    }
+
+    /**
+     *
+     */
+    private static function setLocaleFromURL() {
+      // First component of the URL is always the
+      if(preg_match('/^\\/(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)\\//', $_SERVER['REQUEST_URI'], $matches)) {
+        if(!isset(DISPLAY_NAMES[$matches[1]])) {
+          // Note: this is an unsupported locale, so we'll end up redirecting in head.php to /en/...
+          $pageLocale = Locale::DEFAULT_LOCALE;
+          self::$invalidLocale = true;
+        } else {
+          $pageLocale = $matches[1];
+        }
+      } else {
+        $pageLocale = Locale::DEFAULT_LOCALE;
+      }
+      self::setLocale($pageLocale);
     }
 
     /**
      * Set the current locales, with an array of fallbacks, ending in 'en'.
      * @param $locale - the new current locale (xx-YY as specified in crowdin %locale%)
      */
-    public static function setLocale($locale) {
+    private static function setLocale($locale) {
       // Clear current locales
       self::$currentLocales = [];
 
@@ -120,7 +158,7 @@
      * @param $define -
      * @param $id - folder containing locale strings, relative to /_includes/locale/strings
      */
-    public static function definePageLocale($define, $id) {
+    public static function definePageScope($define, $id) {
       global $page_is_using_locale;
       $page_is_using_locale = true;
       define($define, $id);

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -38,8 +38,6 @@
      */
     public static function currentLocales() {
       if(count(self::$currentLocales) == 0) {
-        // For pages with no locale set, or if called too early ...?
-        // var_dump(self::$currentLocales);
         Locale::setLocaleFromURL();
       }
       return self::$currentLocales;
@@ -53,15 +51,24 @@
       return self::currentLocales()[0];
     }
 
+    /**
+     * Returns true if the locale determined from the URL is not a known locale,
+     * based on the list in DISPLAY_NAMES. If we are loaded in a context outside
+     * localized content, and where the top-level folder name would be valid
+     * BCP47, e.g. /go/, Locale::invalidLocale() will return true. See root
+     * /.htaccess for list of all non-localized content where this may arise.
+     */
     public static function invalidLocale() {
+      self::currentLocales(); // ensure locale is set
       return self::$invalidLocale;
     }
 
     /**
-     *
+     * Set the current locale based on the first path component
+     * /<locale>/rest/of/path for the current page URL
      */
     private static function setLocaleFromURL() {
-      // First component of the URL is always the
+      // First component of the URL is always the locale
       if(preg_match('/^\\/(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)\\//', $_SERVER['REQUEST_URI'], $matches)) {
         if(!isset(DISPLAY_NAMES[$matches[1]])) {
           // Note: this is an unsupported locale, so we'll end up redirecting in head.php to /en/...

--- a/cdn/dev/js/i18n.mjs
+++ b/cdn/dev/js/i18n.mjs
@@ -23,6 +23,10 @@ export class I18n {
 
   static _pageLocale;
 
+  /**
+   * @returns the current page locale based on the URL. Note that the PHP
+   * Locale.php is responsible for parsing and avoiding invalid locales.
+   */
   static pageLocale() {
     if(!this._pageLocale) {
       let langMatch = location.pathname.match(/^\/([^/]+)/);

--- a/cdn/dev/js/i18n.mjs
+++ b/cdn/dev/js/i18n.mjs
@@ -21,6 +21,16 @@ export class I18n {
   //   ]
   static domains = [];
 
+  static _pageLocale;
+
+  static pageLocale() {
+    if(!this._pageLocale) {
+      let langMatch = location.pathname.match(/^\/([^/]+)/);
+      this._pageLocale = langMatch ? langMatch[1] : 'en';
+    }
+    return this._pageLocale;
+  }
+
   /**
    * Load the strings for the given domain
    * @param {string} domain

--- a/cdn/dev/keyboard-search/search.mjs
+++ b/cdn/dev/keyboard-search/search.mjs
@@ -19,16 +19,12 @@ if (!String.prototype.includes) {
 
 /////////////////////////////
 
-if(typeof embed_query == 'undefined') {
-  var embed_query = '';
+if(typeof window.embed_query == 'undefined') {
+  window.embed_query = '';
 }
 
-var embed_query_q = embed_query == '' ? '' : '?'+embed_query;
-var embed_query_x = embed_query == '' ? '' : '&'+embed_query;
-
-// TODO: Validate BCP-47 triplet?
-var langMatch = location.pathname.match(/(\/(.+))?\/keyboards\/(.*)$/);
-var embed_lang = (langMatch) ? langMatch[2] : 'en';
+var embed_query_q = window.embed_query == '' ? '' : '?'+window.embed_query;
+var embed_query_x = window.embed_query == '' ? '' : '&'+window.embed_query;
 
 var dynamic_search_timeout = 0;
 
@@ -44,14 +40,15 @@ function getCurrentPath(q, page, obsolete) {
   obsolete = obsolete ? '&obsolete=1' : '';
   page = page > 1 ? 'page='+page : '';
   var path = '';
+  const base = `/${I18n.pageLocale()}`;
   if(r && r[1].charAt(0) == 'c') {
-    path = '/' + embed_lang + '/keyboards/countries/';
+    path = `${base}/keyboards/countries/`;
   } else if(r && r[1].charAt(0) == 'l') {
-    path = '/' + embed_lang + '/keyboards/languages/'+r[3];
+    path = `${base}/keyboards/languages/${r[3]}`;
   } else if(q == '') {
-    path = '/' + embed_lang + '/keyboards/'
+    path = `${base}/keyboards/`
   } else {
-    path = '/' + embed_lang + '/keyboards/?q='+encodeURIComponent(q);
+    path = `${base}/keyboards/?q=${encodeURIComponent(q)}`;
   }
 
   if(page + obsolete == '') {
@@ -97,8 +94,8 @@ function wrapSearch(localCounter, updateHistory) {
   var base = location.protocol+'//api.'+location.host; // this works on test sites as well as live, assuming we use the host pattern "keyman.com[.localhost]"
   var url = base+'/search/2.0?p='+page+'&q='+encodeURIComponent(stripCommonWords(q));
 
-  if(embed) {
-    url += '&platform='+embed;
+  if(window.embed) {
+    url += '&platform='+window.embed;
   }
 
   if(obsolete) {
@@ -297,9 +294,9 @@ function process_response(q, obsolete, res) {
         "</div>");
 
       if(kbd.isDedicatedLandingPage) {
-        $('.title a', k).text(kbd.name).attr('href', `/${embed_lang}/keyboards/h/${kbd.id}${embed_query_q}`);
+        $('.title a', k).text(kbd.name).attr('href', `/${I18n.pageLocale()}/keyboards/h/${kbd.id}${embed_query_q}`);
       } else {
-        $('.title a', k).text(kbd.name).attr('href', '/' + embed_lang + '/keyboards/'+kbd.id+(kbd.match.tag ? '?bcp47='+kbd.match.tag+embed_query_x : embed_query_q));
+        $('.title a', k).text(kbd.name).attr('href', '/' + I18n.pageLocale() + '/keyboards/'+kbd.id+(kbd.match.tag ? '?bcp47='+kbd.match.tag+embed_query_x : embed_query_q));
       }
 
       if(kbd.isDedicatedLandingPage) {


### PR DESCRIPTION
* Use first component of URL path to determine current locale
* Add PHP `Locale::pageLocale()` to retrieve the current locale
* Add JS `I18n.pageLocale()` to retrieve the current locale
* Redirect to /en/... if an unsupported locale is found (in head.php)
* Remove `lang` parameter from embedded keyboard search
* Remove `lang` parameter from rewrite rules
* Rename `Locale::definePageLocale()` to `Locale::definePageScope()` to clarify purpose of the function
* Remove lang property from session; we may want to track lang in the future so we remember for top-level redirects
* And fix the embed access in search.mjs (#720)

TODO: Once this change lands, we'll need to rebuild the lang parameter into the `/go/<platform>/download-keyboards` rewrite rules and redirect to the correct locale that way.

Fixes: #720
Test-bot: skip