### PR TITLE
chore: tidy up language check in menu globe button 🌋

### DIFF
--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -45,15 +45,12 @@ END;
 
       $path = '';
       // Replace language if current language in path is valid BCP-47
-      // Note: Validate::validate_bcp47 differs from regex in .htaccess
       if (!empty($parts['path'])) {
         $path = explode("/", $parts['path']);
-        if ($path[1] != null ) {
-           /* TODO: add validation back && class_exists('\\Keyman\\Site\\com\\keyman\\Validation') &&
-            \Keyman\Site\com\keyman\Validation::validate_bcp47($path[1]) != null*/
+        if ($path[1] == Locale::pageLocale()) {
           $path[1] = $language;
         } else {
-          // original URL didn't have a valid BCP-47 so inert it
+          // original URL didn't have a valid BCP-47, so inert new langage
           array_splice($path, 1, 0, $language);
         }
       }

--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -34,7 +34,8 @@ END;
     }
 
     /**
-     * Modify link of the current URL for a given UI language
+     * Modify link of the current URL for a given UI language.
+     * Skip if current URL isn't localized (e.g. _legacy)
      * @param language - language tag to use
      * @return string - modified URL
      */
@@ -49,8 +50,9 @@ END;
         $path = explode("/", $parts['path']);
         if ($path[1] == Locale::pageLocale()) {
           $path[1] = $language;
-        } else {
-          // original URL didn't have a valid BCP-47, so inert new langage
+        } else if (preg_match('/^\/(_legacy)\/.*$/i', $path[1], $matches)) {
+          // original URL didn't have a valid BCP-47, so insert new langage
+          // Skip for certain paths like: _legacy
           array_splice($path, 1, 0, $language);
         }
       }


### PR DESCRIPTION
Follows #696

Since the site URL locale is validated in #725, we can clean up how the menu globe key constructs the language list.

Test-bot: skip
