### PR TITLE
fix: allow broken-link-checker to run on staging site

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,7 @@
-# Disallow all bots since we don't need anything idexed on the staging site
+# Allow broken-link-checker to run
+User-agent: broken-link-checker
+Allow: /
+
+# Disallow all bots since we don't need anything indexed on the staging site
 User-agent: *
 Disallow: /


### PR DESCRIPTION
I noticed the broken-link-checker wasn't running on staging branches due to #577.

This updates robots.txt to allow the broken-link-checker user-agent

I don't think this needs to :cherries: pick to master

Test-bot: skip
