### PR TITLE
fix: Check embed for "new search" and dedicated landing pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -104,6 +104,10 @@ RewriteCond "%{HTTP_COOKIE}"    embed_keyboards_no_locale_redirect [OR]
 RewriteCond "%{QUERY_STRING}"   embed
 RewriteRule "^keyboards(/)?$" "/_content/keyboards/index.php" [END,QSA]
 
+# Dedicated landing pages
+RewriteCond "%{HTTP_COOKIE}"    embed_keyboards_no_locale_redirect [OR]
+RewriteCond "%{QUERY_STRING}"   embed
+RewriteRule "^keyboards/h/(.*)$" "/_content/keyboards/h/$1/index.php" [END,QSA]
 
 
 

--- a/_content/keyboards/index.php
+++ b/_content/keyboards/index.php
@@ -40,7 +40,10 @@
     Menu::render([]); // we'll be doing client-side os detection now
   Body::render();
 
-  $keyboardsPage = '/' . Locale::pageLocale() . '/keyboards/';
+  // For embedded mode, use root-level /keyboards, for Keyman 14.0-18.0.
+  // See .htaccess for full discussion (line ~32)
+  $keyboardsPage = ($embed != 'none') ? '/keyboards' :
+    '/' . Locale::pageLocale() . '/keyboards/';
 ?>
 
 <script>


### PR DESCRIPTION
Follows the `page_root` pattern in #734 for the "New Search" link.
For Keyman 14.0-18.0 apps using the embedded view, we don't include the locale for "Near Search"

Also added a section in .htaccess so dedicated landing pages can check the `embed` session cookie.
Fortunately, all the landing pages are `index.php`.

Test-bot: skip


