### PR TITLE
refactor fallback locale 🌋

### DIFF
--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -39,10 +39,7 @@ class Head {
       // Redirect to /en/... if not a supported locale; this needs to be emitted
       // as a HTTP header before first content byte.
       if(Locale::invalidLocale()) {
-        if(preg_match('/^\\/[^\/]+\\/(.+)$/', $_SERVER['REQUEST_URI'], $matches)) {
-          header("Location: /" . Locale::DEFAULT_LOCALE . "/" . $matches[1]);
-          return;
-        }
+        Locale::redirectLocale();
       }
 ?><!DOCTYPE html>
 <html lang='<?=$fields->pageLocale?>'>

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -63,21 +63,38 @@
     }
 
     /**
+     * Redirect page to specified locale. Default to 'en' if unspecified
+     * @param $newLocale
+     */
+    public static function redirectLocale($newLocale = Locale::DEFAULT_LOCALE) {
+      if(preg_match('/^\\/[^\/]+\\/(.+)$/', $_SERVER['REQUEST_URI'], $matches)) {
+        header("Location: /" . $newLocale . "/" . $matches[1]);
+        return;
+      }
+    }
+
+    /**
      * Set the current locale based on the first path component
      * /<locale>/rest/of/path for the current page URL
      */
     private static function setLocaleFromURL() {
       // First component of the URL is always the locale
-      if(preg_match('/^\\/(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)\\//', $_SERVER['REQUEST_URI'], $matches)) {
-        if(!isset(DISPLAY_NAMES[$matches[1]])) {
-          // Note: this is an unsupported locale, so we'll end up redirecting in head.php to /en/...
+      if(preg_match('/^\/(([a-z]{2,3})(-([A-Z][a-z]{3}))?(-([A-Z]{2}|[0-9]{3}))?)\//', $_SERVER['REQUEST_URI'], $matches)) {
+        $fallbackLocales = self::calculateFallbackLocales($matches[1]);
+        if (isset($fallbackLocales[0])) {
+          $pageLocale = $fallbackLocales[0];
+          if ($pageLocale != $matches[1]) {
+            // Redirect if using a fallback locale
+            Locale::redirectLocale($pageLocale);
+          }
+        } else {
+          // Note: this is an unsupported locale, so we'll end up redirect in head.php to /en/...
           $pageLocale = Locale::DEFAULT_LOCALE;
           self::$invalidLocale = true;
-        } else {
-          $pageLocale = $matches[1];
         }
       } else {
         $pageLocale = Locale::DEFAULT_LOCALE;
+        // Don't set invalidLocale so pages like /_test/ work
       }
       self::setLocale($pageLocale);
     }


### PR DESCRIPTION
Addresses review comment https://github.com/keymanapp/keyman.com/pull/733#issuecomment-4437784365 by taking a subset of those changes

> I think we want our URLs to redirect if a fallback is encountered, rather than accepting `es-Fooo-BA` as a substitute for `es`. And we don't want case insensitivity either; we don't want `es`, `eS`, `Es`, and `ES` all to return the same document, because URLs are case sensitive. So ... 

* Locale::setLocaleFromURL() changes
  * tweak the regex to be case-sensitive (capitalize script and region)
  * redirect to the fallback locale (if found)

This way, `es-Fooo-BA` and `es-ES` redirect to `es`.

Unspecified locale still redirects to `en`

Test-bot: skip
