### PR TITLE
chore: Add km Crowdin strings for downloads

### DIFF
--- a/_includes/locale/strings/downloads/en.php
+++ b/_includes/locale/strings/downloads/en.php
@@ -50,7 +50,7 @@ return [
   "available_on_play_store" => "Keyman for Android is also available on the Play Store.",
 
   # Keyman for iPhone and iPad
-  "product_ios" => "Keyman for iPHone and iPad",
+  "product_ios" => "Keyman for iPhone and iPad",
 
   "available_on_app_store" => "Keyman for iPhone and iPad can be found on the App Store.",
 

--- a/_includes/locale/strings/downloads/km.php
+++ b/_includes/locale/strings/downloads/km.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Khmer strings for downloads/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Downloads Page Title
+  "downloads_page_title" => "ការទាញយក Keyman",
+
+  # Downloads_page_description
+  "downloads_page_description" => "ការទាញយកជំនាន់ស្ថេរភាព​ Keyman",
+
+  # Get the latest
+  "get_the_latest" => 
+    "យកជំនាន់ចុងក្រោយរបស់ ​Keyman​ នៅទីនេះ។ ទាំងនេះគឺជាការទាញយកកម្មវិធីឈរតែឯង និងមិនផ្ទុកប្លង់ក្ដារចុច    សម្រាប់ភាសារបស់អ្នក។ មើលបន្ថែម %1\$s និង %2\$s។",
+
+  # Downloads pre-release page
+  "downloads_pre_release_page" => "ទំព័រទាញយកមុនការចេញផ្សាយ",
+
+  # Downloads old versions page
+  "downloads_old_versions_page" => "ទំព័រទាញយកជំនាន់ចាស់",
+
+  # Keyman version history
+  "keyman_version_history_1" => "ប្រវត្តិជំនាន់ Keyman",
+
+  # Keyman version history (description)
+  "keyman_version_history_2" => "(ផលិតផលទាំងអស់)",
+
+  # Browse all versions
+  "browse_all_versions" => "រុករកជំនាន់ទាំងអស់ (14.0 ឡើងទៅ)",
+
+  ### Product Downloads
+
+  # Keyman for Windows
+  "product_windows" => "Keyman សម្រាប់ Windows",
+
+  # Keyman for macOS
+  "product_macos" => "Keyman សម្រាប់ macOS",
+
+  # Keyman for Android
+  "product_android" => "Keyman សម្រាប់ Android",
+
+  "available_on_play_store" => "Keyman សម្រាប់ Android ក៏មាននៅក្នុងកម្មវិធីទាញយក។",
+
+  # Keyman for iPhone and iPad
+  "product_ios" => "Keyman សម្រាប់ iPHone and iPad",
+
+  "available_on_app_store" => "Keyman សម្រាប់ iPhone and iPad អាចរកបាននៅក្នុងកម្មវិធីទាញយក។",
+
+  # Keyman for Linux
+  "product_linux" => "Keyman សម្រាប់ Linux",
+
+  "install_via_launchpad" => "Ubuntu, Wasta-Linux៖ Keyman សម្រាប់ Linux អាចដំឡើងបានតាម launchpad៖",
+
+  # Products for Software Developers
+  "products_for_software_developers" => "ផលិតផលសម្រាប់អ្នកអភិវឌ្ឍន៍កម្មវិធី",
+
+  # KeymanWeb
+  "product_keymanweb" => "KeymanWeb",
+
+  # Keyman Developer
+  "product_developer" => "Keyman Developer",
+
+  # Keyman Engine for Android
+  "product_engine_android" => "ម៉ាស៊ីន​ Keyman for Android",
+
+  # Keyman Engine for iOS
+  "product_engine_ios" => "ម៉ាស៊ីន​ Keyman for iOS",
+
+  ## Tiers
+  "alpha" => "ជំនាន់បឋម",
+
+  "beta" => "ជំនាន់សាកល្បង",
+
+  "stable" => "ជំនាន់ស្ថេរភាព",
+
+  # (released {date}, {file size})
+  "released_date_size" => "(បានផ្សព្វផ្សាយ %1\$s, %2\$s)",
+
+  # All {product} {tier} releases
+  "all_product_releases" => "រាល់ការផ្សព្វផ្សាយ %1\$s %2\$s",
+
+  # No downloads found for {product}
+  "no_downloads_found" => "មិនឃើញការទាញយកសម្រាប់ %1\$s។"
+]
+;
+

--- a/_includes/locale/strings/downloads/km.php
+++ b/_includes/locale/strings/downloads/km.php
@@ -49,7 +49,7 @@ return [
   "available_on_play_store" => "Keyman សម្រាប់ Android ក៏មាននៅក្នុងកម្មវិធីទាញយក។",
 
   # Keyman for iPhone and iPad
-  "product_ios" => "Keyman សម្រាប់ iPHone and iPad",
+  "product_ios" => "Keyman សម្រាប់ iPhone and iPad",
 
   "available_on_app_store" => "Keyman សម្រាប់ iPhone and iPad អាចរកបាននៅក្នុងកម្មវិធីទាញយក។",
 


### PR DESCRIPTION
This adds the Khmer Crowdin strings for the /downloads page

```
crowdin download -b master -l km
```

Since Crowdin escapes slashes when it downloads strings (`%1\$s` downloads as `%1\\$s`), I first started the site (init-container.sh) to fix the slashes before checking in the file.


http://keyman.com.localhost/km/downloads/

<img width="974" height="645" alt="image" src="https://github.com/user-attachments/assets/8d62a323-61cc-4900-99f7-858f2536b9e5" />


Test-bot: skip