### PR TITLE
chore: khmer translation now uses busra font

### DIFF
--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -265,11 +265,7 @@ html {
 	unicode-range: U+1780-17FF, U+19E0-19FF;
 }
 
-/* Khmer */
-:lang(km) {
-	/* The browser will automatically use Busra for Khmer chars and Cabin or Sans-serif for others */
-	font-family: 'Busra','Cabin', sans-serif;
-}
+/* Alphabetically */
 
 /* Amharic */
 :lang(amh).lang-example {
@@ -289,6 +285,12 @@ html {
 /* Lao */
 :lang(lao).lang-example {
 	font-family: LaoWeb;
+}
+
+/* Khmer */
+:lang(km) {
+	/* The browser will automatically use Busra for Khmer chars and Cabin or Sans-serif for others */
+	font-family: Busra, Cabin, sans-serif;
 }
 
 /* Malayalam

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -257,6 +257,20 @@ html {
 	src: url('//s.keyman.com/font/deploy/LateefRegOT.ttf') format("truetype");
 }
 
+@font-face {
+	font-family: Busra;
+	font-style: normal;
+	font-weight: normal;
+	src: url('//s.keyman.com/font/deploy/Busra-Regular.ttf') format("truetype");
+	unicode-range: U+1780-17FF, U+19E0-19FF;
+}
+
+/* Khmer */
+:lang(km) {
+	/* The browser will automatically use Busra for Khmer chars and Cabin or Sans-serif for others */
+	font-family: 'Busra','Cabin', sans-serif;
+}
+
 /* Amharic */
 :lang(amh).lang-example {
 	font-family: GeezWeb;


### PR DESCRIPTION
This PR calls Busra font for Khmer translation (with Unicode range) on the website. Changing to this font allow easy skim reading, clearer and bolder characters, and readability. Please review.

Test-bot: skip

# User Interfaces

URL: http://keyman.com.localhost:8053/km/keyboards/
<img width="500" alt="Screenshot 2026-05-21 at 4 24 45 in the afternoon" src="https://github.com/user-attachments/assets/bd2d2872-6a47-4617-9232-ae61fdd2dadb" />

<img width="500" alt="Screenshot 2026-05-21 at 4 24 58 in the afternoon" src="https://github.com/user-attachments/assets/57de145b-1250-4247-9607-596f88c920d4" />

---

URL: http://keyman.com.localhost:8053/km/downloads/
<img width="500" alt="image" src="https://github.com/user-attachments/assets/727b713c-87b6-4f90-8c17-4ac886c188a7" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/833835fe-0fb9-46ef-803e-abc96cce9c5e" />

