### PR TITLE
refactor: remove useless link

### DIFF
--- a/_content/developer/keymanweb/index.2.0.php
+++ b/_content/developer/keymanweb/index.2.0.php
@@ -1,2 +1,0 @@
-<?php
-  header('Location: ./');

--- a/_content/developer/keymanweb/index.php
+++ b/_content/developer/keymanweb/index.php
@@ -99,7 +99,6 @@ the on screen keyboard.</p>
 <ul>
   <li><a href='keyboards'>Keyman Cloud CDN Keyboard Catalogue</a></li>
   <li><a href='<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/cloud/version/2.0'>How to: retrieve the latest version of KeymanWeb from Keyman Cloud CDN</a></li>
-  <li><a href='index.2.0'>Using older versions of KeymanWeb</a></li>
 </ul>
 
 <br>


### PR DESCRIPTION
"Using older versions of KeymanWeb" gets redirected to the current page which doesn't talk about using older versions, which makes it fairly useless and more confusing than helpful. This change removes the link (and the empty linked file).

Test-bot: skip