### PR TITLE
fix: download links for pre-release versions 🌋

### DIFF
--- a/_content/downloads/pre-release/index.php
+++ b/_content/downloads/pre-release/index.php
@@ -3,6 +3,12 @@
   require_once _KEYMANCOM_INCLUDES . '/includes/ui/downloads.php';
   use Keyman\Site\Common\KeymanHosts;
 
+  use Keyman\Site\com\keyman\Locale;
+
+  Locale::definePageScope('LOCALE_DOWNLOADS', 'downloads');
+  $_m_Downloads = function($id, ...$args) { return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); };
+  function _m_Downloads($id, ...$args) {    return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); }
+
   // Required
   head([
     'title' =>'Keyman Pre-release Versions',
@@ -42,8 +48,8 @@
 <p><a href='<?=KeymanHosts::Instance()->help_keyman_com?>/version-history'>Keyman version history</a> (all products)</p>
 
 <?php
-  downloadSection('Keyman for Windows',         'windows', 'keyman-$version.exe', 'beta alpha');
-  downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', 'beta alpha');
+  downloadSection('product_windows',         'windows', 'keyman-$version.exe', 'beta alpha');
+  downloadSection('product_macos',           'mac',     'keyman-$version.dmg', 'beta alpha');
 ?>
 
 <h2 id='linux' class='red underline'>Keyman for Linux</h2>
@@ -60,8 +66,8 @@ sudo add-apt-repository ppa:keymanapp/keyman-alpha
 sudo apt install keyman onboard-keyman</code></pre>
 
 <?php
-  downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', 'beta alpha');
-  //downloadSection('Keyman for iPhone and iPad',    'ios',     'keyman-ios-$version.ipa', 'beta alpha');
+  downloadSection('product_android',         'android', 'keyman-$version.apk', 'beta alpha');
+  //downloadSection('product_ios',    'ios',     'keyman-ios-$version.ipa', 'beta alpha');
 ?>
 
 <p>You can also <a href="https://play.google.com/apps/testing/com.tavultesoft.kmapro">sign up</a> to access pre-release versions through Google Play.</p>
@@ -73,7 +79,7 @@ through <a href="https://developer.apple.com/testflight/testers/">Apple's TestFl
 <?= iosTestFlightTable(); ?>
 
 <?php
-  downloadSection('KeymanWeb',                     'web',     'keymanweb-$version.zip', 'beta alpha');
+  downloadSection('product_keymanweb',                     'web',     'keymanweb-$version.zip', 'beta alpha');
 ?>
 
 <ul>
@@ -82,5 +88,5 @@ through <a href="https://developer.apple.com/testflight/testers/">Apple's TestFl
 </ul>
 
 <?php
-  downloadSection('Keyman Developer',              'developer', array('keymandeveloper-$version.exe', 'kmcomp-$version.zip'), 'beta alpha');
+  downloadSection('product_developer',              'developer', array('keymandeveloper-$version.exe', 'kmcomp-$version.zip'), 'beta alpha');
 ?>

--- a/_content/downloads/releases/_version_downloads.php
+++ b/_content/downloads/releases/_version_downloads.php
@@ -4,6 +4,11 @@
   require_once _KEYMANCOM_INCLUDES . '/includes/appstore.php';
   require_once _KEYMANCOM_INCLUDES . '/includes/playstore.php';
   use Keyman\Site\Common\KeymanHosts;
+  use Keyman\Site\com\keyman\Locale;
+
+  Locale::definePageScope('LOCALE_DOWNLOADS', 'downloads');
+  $_m_Downloads = function($id, ...$args) { return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); };
+  function _m_Downloads($id, ...$args) {    return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); }
 
   if(!isset($_REQUEST['version'])) {
     echo "version parameter is required.";
@@ -119,9 +124,9 @@
 </div>
 
 <?php
-  downloadSection('Keyman for Windows',         'windows',   ['keyman-$version.exe', 'keymandesktop-$version.exe'], $tier);
-  downloadSection('Keyman for macOS',           'mac',     'keyman-$version.dmg', $tier);
-  downloadSection('Keyman for Android',         'android', 'keyman-$version.apk', $tier);
+  downloadSection('product_windows',         'windows',   ['keyman-$version.exe', 'keymandesktop-$version.exe'], $tier);
+  downloadSection('product_macos',           'mac',     'keyman-$version.dmg', $tier);
+  downloadSection('product_android',         'android', 'keyman-$version.apk', $tier);
 ?>
 
 <p>Keyman for Android is also available on the Play Store.</p>
@@ -142,10 +147,10 @@ sudo apt-get install keyman ibus-keyman onboard</code></pre></blockquote>
 <h2 class='red underline large'>Products for Software Developers</h2>
 
 <?php
-  downloadSection('KeymanWeb',                     'web',       'keymanweb-$version.zip',             $tier);
-  downloadSection('Keyman Developer',              'developer', 'keymandeveloper-$version.exe',       $tier);
-  downloadSection('Keyman Engine for Android',     'android',   'keyman-engine-android-$version.zip', $tier, 'android-engine');
-  downloadSection('Keyman Engine for iOS',         'ios',       'keyman-engine-ios-$version.zip',     $tier, 'ios-engine');
+  downloadSection('product_keymanweb',          'web',       'keymanweb-$version.zip',             $tier);
+  downloadSection('product_developer',          'developer', 'keymandeveloper-$version.exe',       $tier);
+  downloadSection('product_engine_android',     'android',   'keyman-engine-android-$version.zip', $tier, 'android-engine');
+  downloadSection('product_engine_ios',         'ios',       'keyman-engine-ios-$version.zip',     $tier, 'ios-engine');
 ?>
 
 <br/>


### PR DESCRIPTION
Reported by @MattGyverLee 
> Hi all. It looks like https://keyman.com/en/downloads/pre-release/ is missing download links for alpha versions.

----

Turns out the i18n for the product download pages introduced in #749 rippled to other download pages.
This will restore the download links to pages like:

http://keyman.com.localhost/en/downloads/pre-release/


<img width="1078" height="696" alt="pre-release" src="https://github.com/user-attachments/assets/75f780b6-c327-4c01-8060-14f252370e9b" />

and

http://keyman.com.localhost/en/downloads/releases/alpha/19.0.222

<img width="1218" height="496" alt="version-download" src="https://github.com/user-attachments/assets/61998374-9d66-4b94-9a02-c4c215e17bcf" />

but I didn't get around to updating the download links for the old /10 to /15 pages

Test-bot: skip







