### PR TITLE
fix: update version landing pages with new i18n references

### DIFF
--- a/_content/10/index.php
+++ b/_content/10/index.php
@@ -49,7 +49,7 @@
 
 
 <?php
-  downloadSection('Keyman Desktop 10',    'windows', 'keymandesktop-$version.exe', 'stable');
+  downloadSection('product_windows',    'windows', 'keymandesktop-$version.exe', 'stable');
 ?>
 
 <h3>What's New in Keyman Desktop 10 for Windows?</h3>
@@ -58,7 +58,7 @@
     supports Unicode 11.0 and BCP 47 language identifiers. Desktop 10 also includes additional user interface for Turkish.</p>
 
 <?php
-  downloadSection('Keyman 10 for macOS',   'mac',     'keyman-$version.dmg', 'stable');
+  downloadSection('product_macos',   'mac',     'keyman-$version.dmg', 'stable');
 ?>
 
 <h3>What's New in Keyman 10 for macOS?</h3>
@@ -68,7 +68,7 @@
   and easily install keyboard packages by double-clicking the kmp file.</p>
 
 <?php
-  downloadSection('Keyman for Android 10',            'android', 'keyman-$version.apk', 'stable');
+  downloadSection('product_android',            'android', 'keyman-$version.apk', 'stable');
 ?>
 <p>Keyman for Android is also available on the Play Store.</p>
 <?= $playstoreTable ?>
@@ -92,7 +92,7 @@
   Swift 4.0 app.</p>
 
 <?php
-  downloadSection('KeymanWeb 10', 'web', 'keymanweb-$version.zip', 'stable');
+  downloadSection('product_keymanweb', 'web', 'keymanweb-$version.zip', 'stable');
 ?>
 
 <h3>What's New in KeymanWeb 10?</h3>
@@ -104,7 +104,7 @@
 <h1 class='red underline'>Developer Software</h1>
 
 <?php
-  downloadSection('Keyman Developer 10',    'developer', 'keymandeveloper-$version.exe', 'stable');
+  downloadSection('product_developer',    'developer', 'keymandeveloper-$version.exe', 'stable');
 ?>
 
 <p><a href="<?= KeymanHosts::Instance()->help_keyman_com ?>/developer/10.0/">Keyman Developer 10</a> allows you to create

--- a/_content/11/index.php
+++ b/_content/11/index.php
@@ -66,7 +66,7 @@
 </ul>
 
 <?php
-  downloadSection('Keyman 11 for macOS',   'mac',     'keyman-$version.dmg', 'stable');
+  downloadSection('product_macos',   'mac',     'keyman-$version.dmg', 'stable');
 ?>
 
 <h3>What's New in Keyman 11 for macOS?</h3>
@@ -92,7 +92,7 @@ sudo apt-get install keyman onboard</code></pre></blockquote>
 </ul>
 
 <?php
-  downloadSection('Keyman for Android 11', 'android', 'keyman-$version.apk', 'stable');
+  downloadSection('product_android', 'android', 'keyman-$version.apk', 'stable');
 ?>
 <li>Keyman for Android is available on the Play Store.</li>
 <?= $playstoreTable ?>
@@ -122,7 +122,7 @@ sudo apt-get install keyman onboard</code></pre></blockquote>
 </ul>
 
 <?php
-  downloadSection('KeymanWeb 11', 'web', 'keymanweb-$version.zip', 'stable');
+  downloadSection('product_keymanweb', 'web', 'keymanweb-$version.zip', 'stable');
 ?>
 
 <!--h3>What's New in KeymanWeb 11?</h3-->
@@ -131,7 +131,7 @@ sudo apt-get install keyman onboard</code></pre></blockquote>
 <h1 class='red underline'>Developer Software</h1>
 
 <?php
-  downloadSection('Keyman Developer 11',    'developer', 'keymandeveloper-$version.exe', 'stable');
+  downloadSection('product_developer',    'developer', 'keymandeveloper-$version.exe', 'stable');
 ?>
 
 <h3>What's new in Keyman Developer 11?</h3>

--- a/_content/14/index.php
+++ b/_content/14/index.php
@@ -72,7 +72,7 @@ head([
 <h1 class='red underline'>User Software</h1>
 
 <?php
-downloadSection('Keyman 14 for Windows',   'windows',     'keyman-$version.exe', 'stable');
+downloadSection('product_windows',   'windows',     'keyman-$version.exe', 'stable');
 ?>
 
 <h3>What's New in Keyman 14 for Windows?</h3>
@@ -98,7 +98,7 @@ downloadSection('Keyman 14 for Windows',   'windows',     'keyman-$version.exe',
 
 
 <?php
-downloadSection('Keyman 14 for macOS',   'mac',     'keyman-$version.dmg', 'stable');
+downloadSection('product_macos',   'mac',     'keyman-$version.dmg', 'stable');
 ?>
 
 <h3>What's New in Keyman 14 for macOS?</h3>
@@ -144,7 +144,7 @@ sudo apt install keyman onboard-keyman
 </ul>
 
 <?php
-downloadSection('Keyman 14 for Android', 'android', 'keyman-$version.apk', 'stable');
+downloadSection('product_android', 'android', 'keyman-$version.apk', 'stable');
 ?>
 
 <?= $playstoreTable ?>
@@ -188,7 +188,7 @@ downloadSection('Keyman 14 for Android', 'android', 'keyman-$version.apk', 'stab
 
 
 <?php
-downloadSection('KeymanWeb 14', 'web', 'keymanweb-$version.zip', 'stable');
+downloadSection('product_keymanweb', 'web', 'keymanweb-$version.zip', 'stable');
 ?>
 
 <h3>What's New in KeymanWeb 14?</h3>
@@ -208,7 +208,7 @@ downloadSection('KeymanWeb 14', 'web', 'keymanweb-$version.zip', 'stable');
 <h1 class='red underline'>Developer Software</h1>
 
 <?php
-downloadSection('Keyman Developer 14',    'developer', 'keymandeveloper-$version.exe', 'stable');
+downloadSection('product_developer',    'developer', 'keymandeveloper-$version.exe', 'stable');
 ?>
 
 <h3>What's new in Keyman Developer 14?</h3>

--- a/_content/15/index.php
+++ b/_content/15/index.php
@@ -99,7 +99,7 @@ and are highlighting just a few of them here.</p>
 <h1 class='red underline'>User Software</h1>
 
 <?php
-downloadSection('Keyman 15 for Windows',   'windows',     'keyman-$version.exe', 'stable');
+downloadSection('product_windows',   'windows',     'keyman-$version.exe', 'stable');
 ?>
 
 <h3>What's New in Keyman 15 for Windows?</h3>
@@ -111,7 +111,7 @@ downloadSection('Keyman 15 for Windows',   'windows',     'keyman-$version.exe',
 
 
 <?php
-downloadSection('Keyman 15 for macOS',   'mac',     'keyman-$version.dmg', 'stable');
+downloadSection('product_macos',   'mac',     'keyman-$version.dmg', 'stable');
 ?>
 
 <h3>What's New in Keyman 15 for macOS?</h3>
@@ -146,7 +146,7 @@ sudo apt install keyman</code></pre></blockquote>
 </ul>
 
 <?php
-downloadSection('Keyman 15 for Android', 'android', 'keyman-$version.apk', 'stable');
+downloadSection('product_android', 'android', 'keyman-$version.apk', 'stable');
 ?>
 
 <?= $playstoreTable ?>
@@ -184,7 +184,7 @@ downloadSection('Keyman 15 for Android', 'android', 'keyman-$version.apk', 'stab
 
 
 <?php
-downloadSection('KeymanWeb 15', 'web', 'keymanweb-$version.zip', 'stable');
+downloadSection('product_keymanweb', 'web', 'keymanweb-$version.zip', 'stable');
 ?>
 
 <h3>What's New in KeymanWeb 15?</h3>
@@ -201,7 +201,7 @@ downloadSection('KeymanWeb 15', 'web', 'keymanweb-$version.zip', 'stable');
 <h1 class='red underline'>Developer Software</h1>
 
 <?php
-downloadSection('Keyman Developer 15',    'developer', 'keymandeveloper-$version.exe', 'stable');
+downloadSection('product_developer',    'developer', 'keymandeveloper-$version.exe', 'stable');
 ?>
 
 <h3>What's new in Keyman Developer 15?</h3>

--- a/_content/downloads/index.php
+++ b/_content/downloads/index.php
@@ -7,8 +7,6 @@
   use Keyman\Site\com\keyman\Locale;
 
   Locale::definePageScope('LOCALE_DOWNLOADS', 'downloads');
-  $_m_Downloads = function($id, ...$args) { return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); };
-  function _m_Downloads($id, ...$args) {    return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); }
 
   // Required
   head([
@@ -23,13 +21,13 @@
 <h2 class="red underline large"><?= _m_Downloads('downloads_page_title') ?></h2>
 
 <p>
-  <?= _m_Downloads('get_the_latest', 
+  <?= _m_Downloads('get_the_latest',
     sprintf('<a href=\'pre-release\'>%s</a>', _m_Downloads('downloads_pre_release_page')),
     sprintf('<a href=\'archive\'>%s</a>', _m_Downloads('downloads_old_versions_page')) ) ?>
 </p>
 
 <p>
-  <a href='<?= KeymanHosts::Instance()->help_keyman_com?>/version-history'><?= _m_Downloads('keyman_version_history_1') ?></a> 
+  <a href='<?= KeymanHosts::Instance()->help_keyman_com?>/version-history'><?= _m_Downloads('keyman_version_history_1') ?></a>
   <?= _m_Downloads('keyman_version_history_2') ?>
 </p>
 

--- a/_content/downloads/pre-release/index.php
+++ b/_content/downloads/pre-release/index.php
@@ -6,8 +6,6 @@
   use Keyman\Site\com\keyman\Locale;
 
   Locale::definePageScope('LOCALE_DOWNLOADS', 'downloads');
-  $_m_Downloads = function($id, ...$args) { return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); };
-  function _m_Downloads($id, ...$args) {    return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); }
 
   // Required
   head([

--- a/_content/downloads/releases/_version_downloads.php
+++ b/_content/downloads/releases/_version_downloads.php
@@ -7,8 +7,6 @@
   use Keyman\Site\com\keyman\Locale;
 
   Locale::definePageScope('LOCALE_DOWNLOADS', 'downloads');
-  $_m_Downloads = function($id, ...$args) { return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); };
-  function _m_Downloads($id, ...$args) {    return Locale::m(LOCALE_DOWNLOADS, $id, ...$args); }
 
   if(!isset($_REQUEST['version'])) {
     echo "version parameter is required.";

--- a/_content/keyboards/index.php
+++ b/_content/keyboards/index.php
@@ -10,12 +10,10 @@
   use Keyman\Site\com\keyman\Locale;
 
   Locale::definePageScope('LOCALE_KEYBOARDS', 'keyboards');
-  $_m = function($id, ...$args) { return Locale::m(LOCALE_KEYBOARDS, $id, ...$args); };
-  function _m($id, ...$args) {    return Locale::m(LOCALE_KEYBOARDS, $id, ...$args); }
 
   $head_options = [
-    'title' => _m('page_title'),
-    'description' => _m('page_description'),
+    'title' => _m_Keyboards('page_title'),
+    'description' => _m_Keyboards('page_description'),
     'css' => [Util::cdn('css/template.css'), Util::cdn('keyboard-search/search.css')],
     'js' => [
       Util::cdn('keyboard-search/jquery.mark.js'),
@@ -62,14 +60,14 @@
 
 <div class='<?= $embed == 'none' ? '' : 'embed embed-'.$embed ?>'>
 
-  <h2 class="red underline"><a href='<?=$keyboardsPage?>'><?= _m('page_title') ?></a></h2>
+  <h2 class="red underline"><a href='<?=$keyboardsPage?>'><?= _m_Keyboards('page_title') ?></a></h2>
 
   <div id='search-box'>
     <form method='get' action='<?=$keyboardsPage?>' name='f'>
-      <label for="search-q"><?= _m('keyboard_search') ?></label><input id="search-q" type="text" placeholder="<?= _m('enter_language') ?>" name="q"
+      <label for="search-q"><?= _m_Keyboards('keyboard_search') ?></label><input id="search-q" type="text" placeholder="<?= _m_Keyboards('enter_language') ?>" name="q"
       <?php if($embed == 'none') echo 'autofocus'; ?>>
-      <input id="search-f" type="button" value="<?= _m('search') ?>">
-      <label id="search-new"><a href='<?= $keyboardsPage . $session_query_q?>'><?= _m('new_search')?></a></label>
+      <input id="search-f" type="button" value="<?= _m_Keyboards('search') ?>">
+      <label id="search-new"><a href='<?= $keyboardsPage . $session_query_q?>'><?= _m_Keyboards('new_search')?></a></label>
       <input id="search-obsolete" type="hidden" name="obsolete" value="0">
       <input id="search-page" type="hidden" name="page" value="1">
     </form>
@@ -84,13 +82,13 @@
   <div id='search-results-container' class=''>
   <div id='search-results'></div>
   <div id='search-results-empty'>
-    <p><?= _m('enter_name') ?> (<a href="?q=p:popular"><?= _m('popular_keyboards') ?></a> | <a href="?q=p:alphabetical"><?= _m('all_keyboards') ?></a>)</p>
+    <p><?= _m_Keyboards('enter_name') ?> (<a href="?q=p:popular"><?= _m_Keyboards('popular_keyboards') ?></a> | <a href="?q=p:alphabetical"><?= _m_Keyboards('all_keyboards') ?></a>)</p>
     <br />
-    <p><?= _m('hints') ?></p>
+    <p><?= _m_Keyboards('hints') ?></p>
     <ul>
-      <li><?= _m('searchbox_description') ?></li>
-      <li><?= _m('searchbox_hint_2', '<code>k:</code>', '<code>l:</code>', '<code>s:</code>', '<code>c:</code>', '<code>c:thailand</code>') ?></li>
-      <li><?= _m('searchbox_hint_3', '<code>l:id:</code>', '<code>l:id:ti-et</code>') ?></li>
+      <li><?= _m_Keyboards('searchbox_description') ?></li>
+      <li><?= _m_Keyboards('searchbox_hint_2', '<code>k:</code>', '<code>l:</code>', '<code>s:</code>', '<code>c:</code>', '<code>c:thailand</code>') ?></li>
+      <li><?= _m_Keyboards('searchbox_hint_3', '<code>l:id:</code>', '<code>l:id:ti-et</code>') ?></li>
     </ul>
   </div>
 </div>

--- a/_content/keyboards/install.php
+++ b/_content/keyboards/install.php
@@ -19,12 +19,6 @@
   use Keyman\Site\com\keyman\Locale;
 
   Locale::definePageScope('LOCALE_KEYBOARDS_INSTALL', 'keyboards/install');
-  $_m = function($id, ...$args) {
-    return Locale::m(LOCALE_KEYBOARDS_INSTALL, $id, ...$args);
-  };
-  function _m($id, ...$args) {
-    return Locale::m(LOCALE_KEYBOARDS_INSTALL, $id, ...$args);
-  }
 
   // Bundled downloads will make use of Keyman tier, which the site visitor
   // can override with tier=[alpha|beta|stable]. If no override has been
@@ -98,7 +92,7 @@
     }
 
     protected static function WriteWindowsBoxes() {
-      global $_m;
+      global $_m_Keyboards_Install;
 
       $keyboard = self::$keyboard;
       $tier = self::$tier;
@@ -136,15 +130,15 @@
 
       $result = <<<END
         <div class='download download-windows'>
-        <p> {$_m('download_start_shortly', $h['name'])} </p>
-        <div class='download download-windows'><a class='download-link binary-download' href='$downloadLink'><span>{$_m('download_keyboard')}</span></a></div>
+        <p> {$_m_Keyboards_Install('download_start_shortly', $h['name'])} </p>
+        <div class='download download-windows'><a class='download-link binary-download' href='$downloadLink'><span>{$_m_Keyboards_Install('download_keyboard')}</span></a></div>
         <script data-host="{$h['host']}" data-tier="{$h['tier']}" data-version="{$h['version']}"
             data-id="{$h['id']}" data-bcp47="{$h['bcp47']}">
           startAfterPageLoad_Windows(document.currentScript.dataset);
         </script>
         <ul>
-        <li><a href='$helpLink'>{$_m('help_on_installing_keyman')}</a></li>
-        <li><a href='$keyboardHomeUrl'>{$_m('download_keyboard')}</a></li>
+        <li><a href='$helpLink'>{$_m_Keyboards_Install('help_on_installing_keyman')}</a></li>
+        <li><a href='$keyboardHomeUrl'>{$_m_Keyboards_Install('download_keyboard')}</a></li>
         </ul>
         </div>
 END;
@@ -152,7 +146,7 @@ END;
     }
 
     protected static function WritemacOSBoxes() {
-      global $_m;
+      global $_m_Keyboards_Install;
 
       $keyboard = self::$keyboard;
       $tier = self::$tier;
@@ -187,17 +181,17 @@ END;
       $result = <<<END
         <div class='download download-macos'>
           <div>
-            <p>{$_m('platform_not_installed', 'Keyman for macOS')}</p>
+            <p>{$_m_Keyboards_Install('platform_not_installed', 'Keyman for macOS')}</p>
             <ol>
-              <li id='step1'><a href='$downloadKeymanUrl' title='{$_m('download_keyman_title')}'>{$_m('install_keyman', 'Keyman for macOS')}</a></li>
+              <li id='step1'><a href='$downloadKeymanUrl' title='{$_m_Keyboards_Install('download_keyman_title')}'>{$_m_Keyboards_Install('install_keyman', 'Keyman for macOS')}</a></li>
               <li id='step2'><a class='download-link binary-download' rel="nofollow" href='$downloadLink'>
-                <span>{$_m('install_keyboard')}</span></a>
-                <div class='download-description'>{$_m('downloads_keyboard_for_platform', $h['name'], 'macOS')}</div>
+                <span>{$_m_Keyboards_Install('install_keyboard')}</span></a>
+                <div class='download-description'>{$_m_Keyboards_Install('downloads_keyboard_for_platform', $h['name'], 'macOS')}</div>
               </li>
             </ol>
             <ul>
-              <li><a href='$helpLink'>{$_m('help_on_installing_keyboard')}</a></li>
-              <li><a href='$keyboardHomeUrl'>{$_m('keyboard_home', $h['name'])}</a></li>
+              <li><a href='$helpLink'>{$_m_Keyboards_Install('help_on_installing_keyboard')}</a></li>
+              <li><a href='$keyboardHomeUrl'>{$_m_Keyboards_Install('keyboard_home', $h['name'])}</a></li>
             </ul>
           </div>
         </div>
@@ -206,7 +200,7 @@ END;
     }
 
     protected static function WriteLinuxBoxes() {
-      global $_m;
+      global $_m_Keyboards_Install;
 
       $keyboard = self::$keyboard;
       $tier = self::$tier;
@@ -244,19 +238,19 @@ END;
             startAfterPageLoad_Linux(document.currentScript.dataset);
           </script>
           <div>
-            <p>{$_m('platform_not_installed', 'Keyman for Linux')}</p>
+            <p>{$_m_Keyboards_Install('platform_not_installed', 'Keyman for Linux')}</p>
             <ol>
-              <li id='step1'><a href='$downloadKeymanUrl' title='{$_m('download_keyman_title')}'>{$_m('install_keyman', 'Keyman for Linux')}</a></li>
+              <li id='step1'><a href='$downloadKeymanUrl' title='{$_m_Keyboards_Install('download_keyman_title')}'>{$_m_Keyboards_Install('install_keyman', 'Keyman for Linux')}</a></li>
               <li id='step2'><a class='download-link binary-download' rel="nofollow" href='$downloadLink'>
-                <span>{$_m('install_keyboard')}</span></a>
-                <div class='download-description'>{$_m('downloads_keyboard_for_platform', $h['name'], 'Linux')}</div>
+                <span>{$_m_Keyboards_Install('install_keyboard')}</span></a>
+                <div class='download-description'>{$_m_Keyboards_Install('downloads_keyboard_for_platform', $h['name'], 'Linux')}</div>
               </li>
             </ol>
 
             <br>
             <ul>
-              <li><a href='$helpLink'>{$_m('help_on_installing_keyboard')}</a></li>
-              <li><a href='$keyboardHomeUrl'>{$_m('keyboard_home', $h['name'])}</a></li>
+              <li><a href='$helpLink'>{$_m_Keyboards_Install('help_on_installing_keyboard')}</a></li>
+              <li><a href='$keyboardHomeUrl'>{$_m_Keyboards_Install('keyboard_home', $h['name'])}</a></li>
             </ul>
           </div>
         </div>
@@ -265,7 +259,7 @@ END;
     }
 
     protected static function WriteAndroidBoxes() {
-      global $_m;
+      global $_m_Keyboards_Install;
 
       $keyboard = self::$keyboard;
       $tier = self::$tier;
@@ -306,14 +300,14 @@ END;
         <div class='download download-android'>
           <p></p>
           <div>
-            <p>{$_m('with_play_store', $h['name'])}</p>
-            <a class='download-link binary-download' href='$downloadKeymanUrl' title='{$_m('download_keyman_title')}'><span>{$_m('install_from_play_store')}</span></a>
-            <div class='download-description'>{$_m('keyman_and_keyboard_for_platform', $h['name'], 'Android')}</div>
+            <p>{$_m_Keyboards_Install('with_play_store', $h['name'])}</p>
+            <a class='download-link binary-download' href='$downloadKeymanUrl' title='{$_m_Keyboards_Install('download_keyman_title')}'><span>{$_m_Keyboards_Install('install_from_play_store')}</span></a>
+            <div class='download-description'>{$_m_Keyboards_Install('keyman_and_keyboard_for_platform', $h['name'], 'Android')}</div>
             <br>
-            <p>{$_m('already_installed')} <a rel="nofollow" href='$downloadLink'>{$_m('download_just_keyboard')}</a> {$_m('and_then_install_in_the_app')}</p>
+            <p>{$_m_Keyboards_Install('already_installed')} <a rel="nofollow" href='$downloadLink'>{$_m_Keyboards_Install('download_just_keyboard')}</a> {$_m_Keyboards_Install('and_then_install_in_the_app')}</p>
             <ul>
-              <li><a href='$helpLink'>{$_m('help_on_installing_keyboard')}</a></li>
-              <li><a href='$keyboardHomeUrl'>{$_m('keyboard_home', $h['name'])}</a></li>
+              <li><a href='$helpLink'>{$_m_Keyboards_Install('help_on_installing_keyboard')}</a></li>
+              <li><a href='$keyboardHomeUrl'>{$_m_Keyboards_Install('keyboard_home', $h['name'])}</a></li>
             </ul>
           </div>
         </div>
@@ -322,7 +316,7 @@ END;
     }
 
     protected static function WriteiOSBoxes() {
-      global $_m;
+      global $_m_Keyboards_Install;
 
       $keyboard = self::$keyboard;
       $tier = self::$tier;
@@ -357,17 +351,17 @@ END;
       $result = <<<END
         <div class='download download-ios'>
           <div>
-            <p>{$_m('platform_not_installed', 'Keyman for iPhone and iPad')}</p>
+            <p>{$_m_Keyboards_Install('platform_not_installed', 'Keyman for iPhone and iPad')}</p>
             <ol>
-              <li id='step1'><a href='$downloadKeymanUrl' title='{$_m('download_keyman_title')}'>{$_m('install_keyman', 'Keyman for iPhone and iPad')}</a></li>
+              <li id='step1'><a href='$downloadKeymanUrl' title='{$_m_Keyboards_Install('download_keyman_title')}'>{$_m_Keyboards_Install('install_keyman', 'Keyman for iPhone and iPad')}</a></li>
               <li id='step2'><a class='download-link binary-download' rel="nofollow" href='$downloadLink'>
-                <span>{$_m('install_keyboard')}</span></a>
-                <div class='download-description'>{$_m('downloads_keyboard_for_platform', $h['name'], 'iPhone and iPad')}</div>
+                <span>{$_m_Keyboards_Install('install_keyboard')}</span></a>
+                <div class='download-description'>{$_m_Keyboards_Install('downloads_keyboard_for_platform', $h['name'], 'iPhone and iPad')}</div>
               </li>
             </ol>
             <ul>
-              <li><a href='$helpLink'>{$_m('help_on_installing_keyboard')}</a></li>
-              <li><a href='$keyboardHomeUrl'>{$_m('keyboard_home', $h['name'])}</a></li>
+              <li><a href='$helpLink'>{$_m_Keyboards_Install('help_on_installing_keyboard')}</a></li>
+              <li><a href='$keyboardHomeUrl'>{$_m_Keyboards_Install('keyboard_home', $h['name'])}</a></li>
             </ul>
           </div>
         </div>
@@ -377,7 +371,7 @@ END;
 
     protected static function LoadData() {
       self::$error = "";
-      global $_m;
+      global $_m_Keyboards_Install;
 
       // Get Keyboard Metadata
 
@@ -392,7 +386,7 @@ END;
         if(is_object($s)) {
           self::$keyboard = $s;
           self::$title = htmlentities(self::$keyboard->name);
-          if (!preg_match('/keyboard$/i', self::$title)) self::$title = $_m('install_page_title', self::$title);
+          if (!preg_match('/keyboard$/i', self::$title)) self::$title = $_m_Keyboards_Install('install_page_title', self::$title);
         } else {
           self::$error .= "Error returned from ".KeymanHosts::Instance()->api_keyman_com.": $s\n";
           self::$title = 'Failed to load keyboard ' . self::$id;
@@ -416,7 +410,7 @@ END;
     }
 
     protected static function WriteTitle() {
-      global $_m;
+      global $_m_Keyboards_Install;
       $head_options = [
         'title' => self::$title,
         'js' => [Util::cdn('keyboard-search/keyboard-details.js'), Util::cdn('keyboard-search/install.js')],
@@ -430,7 +424,7 @@ END;
         // If parameters are missing ...
 ?>
           <h1 class='red underline'><?= htmlentities(self::$id); ?></h1>
-          <p><?= $_m('keyboard_not_found', htmlentities(self::$id)) ?></p>
+          <p><?= $_m_Keyboards_Install('keyboard_not_found', htmlentities(self::$id)) ?></p>
 <?php
         // DEBUG: Only display errors on local sites
         if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT && (ini_get('display_errors') !== '0')) {

--- a/_content/keyboards/share.php
+++ b/_content/keyboards/share.php
@@ -7,12 +7,6 @@
   use Keyman\Site\com\keyman\Locale;
 
   Locale::definePageScope('LOCALE_KEYBOARDS_SHARE', 'keyboards/share');
-  $_m = function($id, ...$args) {
-    return Locale::m(LOCALE_KEYBOARDS_SHARE, $id, ...$args);
-  };
-  function _m($id, ...$args) {
-    return Locale::m(LOCALE_KEYBOARDS_SHARE, $id, ...$args);
-  }
 
   if(!isset($_REQUEST['id'])) {
     header('Location: /keyboards');
@@ -47,19 +41,19 @@
   // Keyboard not found, so let's explain.
 
   $head_options = [
-    'title' => $_m('head_title', $id)
+    'title' => $_m_Keyboards_Share('head_title', $id)
   ];
 
   head($head_options);
 ?>
 
-<h1><?= $_m('h1_sharing_keyboard', $id) ?></h1>
+<h1><?= $_m_Keyboards_Share('h1_sharing_keyboard', $id) ?></h1>
 
-<p><?= $_m('line1') ?> <?= $_m('line2') ?> <b class='red'><?=$id?></b>, <?= $_m('line3') ?></p>
+<p><?= $_m_Keyboards_Share('line1') ?> <?= $_m_Keyboards_Share('line2') ?> <b class='red'><?=$id?></b>, <?= $_m_Keyboards_Share('line3') ?></p>
 
-<h2><?= $_m('h2_how_to_get') ?></h2>
+<h2><?= $_m_Keyboards_Share('h2_how_to_get') ?></h2>
 
-<p><?= $_m('how_to_get_1') ?></p>
+<p><?= $_m_Keyboards_Share('how_to_get_1') ?></p>
 
-<p><?= $_m('how_to_get_2') ?> <a href='https://community.software.sil.org/c/keyman'>
-<?= $_m('keyman_forum') ?></a> <?= $_m('how_to_get_3') ?></p>
+<p><?= $_m_Keyboards_Share('how_to_get_2') ?> <a href='https://community.software.sil.org/c/keyman'>
+<?= $_m_Keyboards_Share('keyman_forum') ?></a> <?= $_m_Keyboards_Share('how_to_get_3') ?></p>

--- a/_includes/includes/ui/downloads.php
+++ b/_includes/includes/ui/downloads.php
@@ -2,6 +2,8 @@
 
   require_once _KEYMANCOM_INCLUDES . '/autoload.php';
   use Keyman\Site\Common\KeymanHosts;
+  use Keyman\Site\com\keyman\Locale;
+  Locale::definePageScope('LOCALE_DOWNLOADS', 'downloads');
 
   $versions = @json_decode(file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . '/api/version/2.0'));
   //if($versions === NULL || $versions === FALSE) {
@@ -29,7 +31,7 @@
   function downloadSection($product, $platform, $filepattern, $tiers = '', $target = '') {
     if($target == '') $target = $platform;
 
-    echo sprintf("<h2 id='%s' class='red underline'>%s</h2>\n\n", 
+    echo sprintf("<h2 id='%s' class='red underline'>%s</h2>\n\n",
       $target, _m_Downloads($product));
     $tiers = explode(' ',$tiers);
     foreach($tiers as $tier) {

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -13,12 +13,6 @@
   use \Keyman\Site\com\keyman;
 
   Locale::definePageScope('LOCALE_KEYBOARDS_DETAILS', 'keyboards/details');
-  $_m_KeyboardDetails = function($id, ...$args) {
-    return Locale::m(LOCALE_KEYBOARDS_DETAILS, $id, ...$args);
-  };
-  function _m_KeyboardDetails($id, ...$args) {
-    return Locale::m(LOCALE_KEYBOARDS_DETAILS, $id, ...$args);
-  }
 
   define('GITHUB_ROOT', 'https://github.com/keymanapp/keyboards/tree/master/');
   define('DOCUMENTATION_ROOT', KeymanHosts::Instance()->help_keyman_com . '/keyboard/');
@@ -109,21 +103,21 @@
     }
 
     protected static function WriteDeveloperCloneBox() {
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       $filename = self::$id . ".kpj";
       $installLink = 'keyman:keyboard/install/' . rawurlencode(self::$id);
       if(!empty(self::$bcp47)) $installLink .= "?bcp47=" . rawurlencode(self::$bcp47);
       return <<<END
 <div class="download download-developer">
-  <div class="download-description">{$_m_KeyboardDetails('new_project_details', htmlspecialchars($filename))}</div>
+  <div class="download-description">{$_m_Keyboards_Details('new_project_details', htmlspecialchars($filename))}</div>
 </div>
 END;
   // <script>location.href = '$installLink';</script>
     }
 
     protected static function download_box($platform) {
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       if(!empty(self::$deprecatedBy)) {
         return "";
@@ -133,14 +127,14 @@ END;
         if(!empty(self::$bcp47)) $installLink .= "?bcp47=" . rawurlencode(self::$bcp47);
         return <<<END
 <div class="download download-{$platform}">
-  <a class='download-link binary-download' href='$installLink'><span>{$_m_KeyboardDetails('install_keyboard')}</span></a>
-  <div class='download-description'>{$_m_KeyboardDetails('install_keyboard_button_description', htmlspecialchars($filename), self::platformTitles[$platform])}</div>
+  <a class='download-link binary-download' href='$installLink'><span>{$_m_Keyboards_Details('install_keyboard')}</span></a>
+  <div class='download-description'>{$_m_Keyboards_Details('install_keyboard_button_description', htmlspecialchars($filename), self::platformTitles[$platform])}</div>
 </div>
 END;
       } else {
         return <<<END
 <div class="download download-$platform">
-  <span>{$_m_KeyboardDetails('keyboard_not_supported')}</span>
+  <span>{$_m_Keyboards_Details('keyboard_not_supported')}</span>
 </div>
 END;
       }
@@ -148,7 +142,7 @@ END;
 
     protected static function WriteWebBoxes($useDescription) {
       global $embed_target;
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       // only show if the jsFilename property is present in the .keyboard_info
       if(empty(self::$keyboard->jsFilename)) {
@@ -179,11 +173,11 @@ END;
       $url = KeymanHosts::Instance()->keymanweb_com ."/#$lang,Keyboard_" . self::GetWebKeyboardId();
       if($useDescription) {
         $description = htmlentities(self::$keyboard->name);
-        $description = "<div class='download-description'>".$_m_KeyboardDetails("use_keyboard_button_description", $description)."</div>";
-        $linktext = $_m_KeyboardDetails("use_keyboard_online");
+        $description = "<div class='download-description'>".$_m_Keyboards_Details("use_keyboard_button_description", $description)."</div>";
+        $linktext = $_m_Keyboards_Details("use_keyboard_online");
       } else {
         $description = '';
-        $linktext = $_m_KeyboardDetails("full_online_editor");
+        $linktext = $_m_Keyboards_Details("full_online_editor");
       }
       return <<<END
         <div class="download download-web">
@@ -195,39 +189,39 @@ END;
 
     protected static function LoadData() {
       global $stable_version;
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       self::$error = "";
       $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com. '/keyboard/' . rawurlencode(self::$id));
       if ($s === FALSE) {
         // Will fail later in the script
         self::$error .= error_get_last()['message'] . "\n";
-        self::$title = $_m_KeyboardDetails("failed_to_load_keyboard_package", self::$id);
+        self::$title = $_m_Keyboards_Details("failed_to_load_keyboard_package", self::$id);
         header('HTTP/1.0 404 Keyboard not found');
       } else {
         $s = json_decode($s);
         if(is_object($s)) {
           self::$keyboard = $s;
           self::$title = htmlentities(self::$keyboard->name);
-          if (!preg_match('/keyboard$/i', self::$title)) self::$title = $_m_KeyboardDetails("details_page_title", self::$title);
+          if (!preg_match('/keyboard$/i', self::$title)) self::$title = $_m_Keyboards_Details("details_page_title", self::$title);
           self::$description = isset(self::$keyboard->description) ? self::$keyboard->description : '';
           self::$authorName = isset(self::$keyboard->authorName) ? self::$keyboard->authorName : '';
           self::$minVersion = isset(self::$keyboard->minKeymanVersion) ? self::$keyboard->minKeymanVersion : $stable_version;
           self::$license = self::map_license(isset(self::$keyboard->license) ? self::$keyboard->license : 'Unknown');
         } else {
-          self::$error .= $_m_KeyboardDetails("error_returned_from_api", KeymanHosts::Instance()->api_keyman_com, $s);
-          self::$title = $_m_KeyboardDetails("failed_to_load_keyboard_package", self::$id);
+          self::$error .= $_m_Keyboards_Details("error_returned_from_api", KeymanHosts::Instance()->api_keyman_com, $s);
+          self::$title = $_m_Keyboards_Details("failed_to_load_keyboard_package", self::$id);
           header('HTTP/1.0 500 Internal Server Error');
         }
       }
 
       if(!empty(self::$keyboard)) {
         if (in_array('unicode', self::$keyboard->encodings) && in_array('ansi', self::$keyboard->encodings))
-          self::$keyboardEncoding = $_m_KeyboardDetails("encoding_list");
+          self::$keyboardEncoding = $_m_Keyboards_Details("encoding_list");
         else if (in_array('unicode', self::$keyboard->encodings))
-          self::$keyboardEncoding = $_m_KeyboardDetails("unicode");
+          self::$keyboardEncoding = $_m_Keyboards_Details("unicode");
         else // ansi
-          self::$keyboardEncoding = $_m_KeyboardDetails("legacy_ansi");
+          self::$keyboardEncoding = $_m_Keyboards_Details("legacy_ansi");
 
         // TODO: i18n date format, but would require a lot more Dockerfile dependencies
         $date = new DateTime(self::$keyboard->lastModifiedDate);
@@ -294,7 +288,7 @@ END;
 
       global $embed, $session_query_q, $embed_win, $embed_version;
       global $embed_target;
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       if ($embed != 'none') {
         $head_options += [
@@ -335,7 +329,7 @@ END;
         // If parameters are missing ...
         ?>
           <h1 class='red underline'><?= self::$id ?></h1>
-          <p><?= $_m_KeyboardDetails("package_not_found", self::$id); ?></p>
+          <p><?= $_m_Keyboards_Details("package_not_found", self::$id); ?></p>
         <?php
         // DEBUG: Only display errors on local sites
         if(KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT && (ini_get('display_errors') !== '0')) {
@@ -348,7 +342,7 @@ END;
         ?>
 
         <div id='search-box'>
-          <label id='search-new'><a href='/keyboards<?= $session_query_q ?>'><?= $_m_KeyboardDetails("new_search") ?></a></label>
+          <label id='search-new'><a href='/keyboards<?= $session_query_q ?>'><?= $_m_Keyboards_Details("new_search") ?></a></label>
           <h1 class='red'><?= self::$title ?></h1>
         </div>
 
@@ -358,9 +352,9 @@ END;
 
         <div id='search-box'>
           <form method='get' action='/keyboards' name='f'>
-            <input id="search-q" type="text" placeholder="<?= $_m_KeyboardDetails("new_keyboard_search") ?>" name="q">
+            <input id="search-q" type="text" placeholder="<?= $_m_Keyboards_Details("new_keyboard_search") ?>" name="q">
             <input id='search-page' type='hidden' name='page'>
-            <input id="search-f" type="submit" value="<?= $_m_KeyboardDetails("search") ?>">
+            <input id="search-f" type="submit" value="<?= $_m_Keyboards_Details("search") ?>">
           </form>
         </div>
 <?php
@@ -377,13 +371,13 @@ END;
         echo "
           <div>
             <a href='/keyboards/$dep$session_query_q' class='deprecated'>
-              <span> " . $_m_KeyboardDetails("important_note") . " </span>" .
-              $_m_KeyboardDetails("obsolete_version") .
-              " <span>$dep</span>" . $_m_KeyboardDetails("instead") . "</a>
+              <span> " . $_m_Keyboards_Details("important_note") . " </span>" .
+              $_m_Keyboards_Details("obsolete_version") .
+              " <span>$dep</span>" . $_m_Keyboards_Details("instead") . "</a>
           </div>
           <div>
             <p class='deprecated-link'><a href='javascript:toggleDeprecatedVersionDetails()'>" .
-              $_m_KeyboardDetails("view_obsolete_details") . "</a></p>
+              $_m_Keyboards_Details("view_obsolete_details") . "</a></p>
             <div id='deprecated-old'>
 
         ";
@@ -393,7 +387,7 @@ END;
     protected static function WriteDownloadBoxes() {
       global $embed, $embed_win, $embed_version;
       global $embed_developer;
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       // We'll write all the different platforms here and then let Bowser determine
       // which box to show. This is true for both embedded and web-based viewing.
@@ -413,7 +407,7 @@ END;
 
         if ($embed_win && isset(self::$keyboard->minKeymanVersion) && version_compare(self::$keyboard->minKeymanVersion, $embed_version) > 0) {
 ?>
-        <p><?= $_m_KeyboardDetails("requires_keyman_minimum_version", self::$keyboard->minKeymanVersion) ?></p>
+        <p><?= $_m_Keyboards_Details("requires_keyman_minimum_version", self::$keyboard->minKeymanVersion) ?></p>
 <?php
         } else {
           echo $text;
@@ -454,7 +448,7 @@ END;
 
     protected static function WriteKeymanWebBox() {
       global $embed;
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       // don't show if we are embedded into a Keyman app
       if($embed != 'none') {
@@ -483,7 +477,7 @@ END;
       $webtext = self::WriteWebBoxes(false);
       $cdnUrlBase = KeymanWebHost::getKeymanWebUrlBase();
       ?>
-        <h2 id='try-header' class='red underline'><?= $_m_KeyboardDetails("try_this_keyboard") ?></h2>
+        <h2 id='try-header' class='red underline'><?= $_m_Keyboards_Details("try_this_keyboard") ?></h2>
         <div id='try-box'>
           <div id='try-content'>
             <input type='text' id='try-keyboard'>
@@ -528,49 +522,49 @@ END;
 
     protected static function WriteKeyboardDetails() {
       global $embed_target, $session_query_q;
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 
       // this is html, trusted in database
       ?>
-      <h2 class='red underline'><?= $_m_KeyboardDetails("keyboard_details") ?></h2>
+      <h2 class='red underline'><?= $_m_Keyboards_Details("keyboard_details") ?></h2>
       <div class='cols' id='keyboard-details-col'>
         <div class='col'>
 
           <table id='keyboard-details'>
             <tbody>
             <tr>
-              <th><?= $_m_KeyboardDetails("keyboard_ID") ?></th>
+              <th><?= $_m_Keyboards_Details("keyboard_ID") ?></th>
               <td><?= htmlentities(self::$id) ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("supported_platforms") ?></th>
+              <th><?= $_m_Keyboards_Details("supported_platforms") ?></th>
               <td><?= self::$keyboardPlatforms ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("author") ?></th>
+              <th><?= $_m_Keyboards_Details("author") ?></th>
               <td><?= htmlentities(self::$authorName) ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("license") ?></th>
+              <th><?= $_m_Keyboards_Details("license") ?></th>
               <td><?= self::$license ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("documentation") ?></th>
+              <th><?= $_m_Keyboards_Details("documentation") ?></th>
               <td>
 <?php
               if (isset(self::$keyboard->helpLink)) {
 ?>
                 <a <?= $embed_target ?>
-                  href='<?= self::$keyboard->helpLink ?>'><?= $_m_KeyboardDetails("keyboard_help") ?></a>
+                  href='<?= self::$keyboard->helpLink ?>'><?= $_m_Keyboards_Details("keyboard_help") ?></a>
 <?php
               } else {
-                echo $_m_KeyboardDetails("help_not_available");
+                echo $_m_Keyboards_Details("help_not_available");
               }
 ?>
               </td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("source") ?></th>
+              <th><?= $_m_Keyboards_Details("source") ?></th>
               <td>
 <?php
                 if (isset(self::$keyboard->sourcePath) && preg_match('/^(release|experimental)\//', self::$keyboard->sourcePath)) {
@@ -579,15 +573,15 @@ END;
                     href='<?= GITHUB_ROOT . htmlentities(self::$keyboard->sourcePath) ?>'><?= htmlentities(self::$keyboard->sourcePath) ?></a>
 <?php
                 } else {
-                  echo $_m_KeyboardDetails("source_not_available");
+                  echo $_m_Keyboards_Details("source_not_available");
                 } ?>
               </td>
             <tr>
-              <th><?= $_m_KeyboardDetails("keyboard_version") ?></th>
+              <th><?= $_m_Keyboards_Details("keyboard_version") ?></th>
               <td><?= htmlentities(self::$keyboard->version) ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("last_updated") ?></th>
+              <th><?= $_m_Keyboards_Details("last_updated") ?></th>
               <td><?= self::$keyboardLastModifiedDate ?></td>
             </tr>
             </tbody>
@@ -602,7 +596,7 @@ END;
               if(isset(self::$keyboard->packageFilename)) {
 ?>
             <tr>
-              <th><?= $_m_KeyboardDetails("package_download") ?></th>
+              <th><?= $_m_Keyboards_Details("package_download") ?></th>
               <td><a href="<?= self::$kmpDownloadUrl ?>" rel="nofollow"><?= self::$keyboard->id ?>.kmp</a></td>
             </tr>
 <?php
@@ -610,24 +604,24 @@ END;
 ?>
             <!-- TODO: i18n keyboard download counts -->
             <tr>
-              <th><?= $_m_KeyboardDetails("monthly_downloads") ?></th>
+              <th><?= $_m_Keyboards_Details("monthly_downloads") ?></th>
               <td><?= number_format(self::$downloadCount) ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("total_downloads") ?></th>
-              <td title='<?= $_m_KeyboardDetails("downloads_since", $_m_KeyboardDetails("date_counting")) ?>'><?= number_format(self::$totalDownloadCount) ?></td>
+              <th><?= $_m_Keyboards_Details("total_downloads") ?></th>
+              <td title='<?= $_m_Keyboards_Details("downloads_since", $_m_Keyboards_Details("date_counting")) ?>'><?= number_format(self::$totalDownloadCount) ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("encoding") ?></th>
+              <th><?= $_m_Keyboards_Details("encoding") ?></th>
               <td><?= self::$keyboardEncoding ?></td>
             </tr>
             <tr>
-              <th><?= $_m_KeyboardDetails("minimum_version", "Keyman") ?></th>
+              <th><?= $_m_Keyboards_Details("minimum_version", "Keyman") ?></th>
               <td><?= self::$minVersion ?></td>
             </tr>
             <?php if (isset(self::$keyboard->related)) { ?>
               <tr>
-                <th><?= $_m_KeyboardDetails("related_keyboards") ?></th>
+                <th><?= $_m_Keyboards_Details("related_keyboards") ?></th>
                 <td>
                   <?php
                   foreach (self::$keyboard->related as $name => $value) {
@@ -638,17 +632,17 @@ END;
                     $s = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com.'/keyboard/' . rawurlencode($name));
                     if ($s === FALSE) {
                       echo "<span class='keyboard-unavailable' title='" .
-                        $_m_KeyboardDetails("keyboard_not_available",
+                        $_m_Keyboards_Details("keyboard_not_available",
                         KeymanHosts::Instance()->keyman_com_host) .
                         "'>$hname</span> ";
                     } else {
                       echo "<a href='/keyboards/$hname$session_query_q'>$hname</a> ";
                     }
                     if (isset($value->deprecates) && $value->deprecates) {
-                      echo $_m_KeyboardDetails("deprecated");
+                      echo $_m_Keyboards_Details("deprecated");
                     }
                     if (isset($value->deprecatedBy) && $value->deprecatedBy) {
-                      echo $_m_KeyboardDetails("new_version");
+                      echo $_m_Keyboards_Details("new_version");
                     }
                   }
                   ?>
@@ -656,11 +650,11 @@ END;
               </tr>
             <?php } ?>
             <tr>
-              <th><?= $_m_KeyboardDetails("supported_languages") ?></th>
+              <th><?= $_m_Keyboards_Details("supported_languages") ?></th>
               <td class='supported-languages'>
                 <?php
                   (function() {
-                    global $_m_KeyboardDetails;
+                    global $_m_Keyboards_Details;
 
                     $n = 0;
                     $count = count(get_object_vars(self::$keyboard->languages)) - 3;
@@ -672,9 +666,9 @@ END;
                     foreach($langs as $bcp47 => $detail) {
                       if($n == 3) {
                         echo " <a id='expand-languages' href='#expand-languages'>" .
-                          $_m_KeyboardDetails("expand_more", $count) . "</a>";
+                          $_m_Keyboards_Details("expand_more", $count) . "</a>";
                         echo "<a id='collapse-languages' href='#collapse-languages'>" .
-                          $_m_KeyboardDetails("collapse") . "</a> <span class='expand-languages'>";
+                          $_m_Keyboards_Details("collapse") . "</a> <span class='expand-languages'>";
                       }
                       if (property_exists($detail, 'languageName')) {
                         echo
@@ -700,7 +694,7 @@ END;
       </div>
 
       <p id='permalink'>
-        <?= $_m_KeyboardDetails("permanent_link_to_this_keyboard") ?>
+        <?= $_m_Keyboards_Details("permanent_link_to_this_keyboard") ?>
         <a <?= $embed_target ?> href='<?= KeymanHosts::Instance()->keyman_com ?>/keyboards/<?= self::$keyboard->id ?>'>
           <?= KeymanHosts::Instance()->keyman_com ?>/keyboards/<?= self::$keyboard->id ?>
         </a>
@@ -709,11 +703,11 @@ END;
     }
 
     protected static function WriteQRCode($context) {
-      global $_m_KeyboardDetails;
+      global $_m_Keyboards_Details;
 ?>
     <div class='qrcode-host qrcode-<?=$context?>'>
       <div id="qrcode-<?=$context?>"></div>
-      <div class='qrcode-caption'><?= $_m_KeyboardDetails("scan_qr_code") ?></div>
+      <div class='qrcode-caption'><?= $_m_Keyboards_Details("scan_qr_code") ?></div>
     </div>
     <script type="text/javascript">
       new QRCode(document.getElementById("qrcode-<?=$context?>"), {

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -170,15 +170,44 @@
     }
 
     /**
-     * Defines a global variable for page locale strings and also
-     * tells locale system that current page uses locales
-     * @param $define -
-     * @param $id - folder containing locale strings, relative to /_includes/locale/strings
+     * Defines a global variable for page locale strings and also tells locale
+     * system that current page uses locales. Also defines a global function and
+     * variable for the page scope, so that we can use shorter function calls to
+     * get localized strings in the page code.
+     *
+     * @param $define - a string such as 'LOCALE_DOWNLOADS', which will be
+     *                  defined as a constant for the page scope
+     * @param $id - folder containing locale strings, relative to
+     *              /_includes/locale/strings, such as 'downloads'. This will be
+     *              used as the domain for the page scope, and also used to
+     *              define a global variable and function for the page scope,
+     *              e.g. $_m_Downloads and _m_Downloads()
+     *
+     * Note that subfolders are supported, and the global variable and function
+     * will be defined with underscores, e.g. for id 'keyboards/install', the
+     * global variable and function will be `$_m_Keyboards_Install` and
+     * `_m_Keyboards_Install()`.
      */
     public static function definePageScope($define, $id) {
       global $page_is_using_locale;
       $page_is_using_locale = true;
+      if(defined($define)) {
+        // It is valid to definePageScope repeatedly but the id must match
+        $previousId = constant($define);
+        if($previousId != $id) {
+          trigger_error("constant $define already defined as '$previousId', redefinition as '$id'", E_USER_ERROR);
+        }
+        return;
+      }
       define($define, $id);
+
+      $scope = ucwords(str_replace('/', '_', $id), " \t\r\n\f\v_");
+      $script = <<<EOT
+        global \$_m_$scope;
+        \$_m_$scope = function(\$id, ...\$args) { return \Keyman\Site\com\keyman\Locale::m($define, \$id, ...\$args); };
+        function _m_$scope(\$id, ...\$args) { return \Keyman\Site\com\keyman\Locale::m($define, \$id, ...\$args); }
+EOT;
+      eval($script);
     }
 
     /**

--- a/_test/index.md
+++ b/_test/index.md
@@ -36,3 +36,12 @@ showmenu: false
 ## Link to Main Page
 
 [Main Page](/)
+
+## Versioned landing pages
+
+[10](/10)
+[11](/11)
+[12](/12)
+[13](/13)
+[14](/14)
+[15](/15)


### PR DESCRIPTION
* Update the call to `downloadSection()` in version landing pages to match the new identifiers used in ui/downloads.php. Fixes the base issue for the versioned landing pages.

* Refactor `Locale::definePageScope` to declare standard `$_m_<domain>` variable and `_m_<domain>()` function, so that we can skip the Locale initialization boilerplate in more places. Also make it possible to declare multiple scopes (supporting includes in the future), and make the function idempotent.

* Update references to `[$]_m*` to the common pattern provided in `Locale::definePageScope`.

* Add version landing pages to _test/ so that they are crawled in the link checker.

Fixes: #764
Fixes: KEYMAN-COM-3H1
Test-bot: skip