### PR TITLE
feat: select best language when redirecting to an i18nized page

### DIFF
--- a/.htaccess.in
+++ b/.htaccess.in
@@ -338,7 +338,8 @@ RedirectMatch "/connectwithart(/|$)" "https://sites.google.com/sil.org/connectwi
 
 RedirectMatch "^/lt4all(/?)$"          "/ldml/lt4all"
 
-# per-language landing pages
+# per-language permalinks -- no need for i18nized versions
+
 RedirectMatch "^/albanian(/?)$"         "/keyboards/basic_kbdal"
 RedirectMatch "^/ancient-egyptian(/?)$" "/keyboards/hieroglyphic"
 RedirectMatch "^/ancient-hebrew(/?)$"   "/keyboards/galaxie_greek_hebrew_mnemonic"
@@ -378,19 +379,29 @@ RedirectMatch 301 "^/(amharic|burmese|cameroon|ethiopic|eurolatin|greek|ipa|sinh
 
 # ------------------------------------------------------------------
 # i18n redirect --> /file to <lang>/file
+#
+# Uses redirect_locale.php to find appropriate lang to redirect to:
+# * existing session language, if already set,
+# * HTTP Accept-Language header to find a reasonable default
 # ------------------------------------------------------------------
 
 #
-# if $1 is a folder or file in /_content, then redirect to currentlang (en?)
-# e.g. would redirect windows/download --> en/windows/download/
+# if $1 is a folder or file that exists in /_content, then redirect
+# e.g. would redirect windows/download --> <lang>/windows/download/
+#
 RewriteCond "%{DOCUMENT_ROOT}/_content/$1.php" -f [OR]
 RewriteCond "%{DOCUMENT_ROOT}/_content/$1.md" -f [OR]
 RewriteCond "%{DOCUMENT_ROOT}/_content/$1" -d
-RewriteRule "^(.*)$" "en/$1" [R,L]
+RewriteCond "%{REQUEST_METHOD}" GET [OR]
+RewriteCond "%{REQUEST_METHOD}" HEAD
+RewriteRule "^(.*)$" "/go/site/redirect_locale.php" [L]
 
 #
 # Paths involving queries (don't match on file/directory)
-RewriteRule "^(downloads/releases|keyboards)/(.+)$" "en/$1/$2" [R,L]
+# - downloads/releases
+# - keyboards
+#
+RewriteRule "^(downloads/releases|keyboards)/(.+)$" "/go/site/redirect_locale.php" [L]
 
 # ##################################################################
 # Rewriting

--- a/_content/keyboards/session.php
+++ b/_content/keyboards/session.php
@@ -1,12 +1,8 @@
 <?php
   use \Keyman\Site\com\keyman\Locale;
+  use \Keyman\Site\com\keyman\Session;
 
-  if(!isset($_SESSION)) {
-    session_set_cookie_params(["SameSite" => "None"]);   // Allow use in iframe, needed for Download Keyboards dialog
-    session_set_cookie_params(["Secure" => "true"]);     // None requires Secure to be set
-    session_start();
-    $session_started = true;
-  }
+  Session::Start();
 
   if(isset($_REQUEST['embed'])) {
     $embed = $_REQUEST['embed'];

--- a/_includes/2020/Session.php
+++ b/_includes/2020/Session.php
@@ -1,0 +1,18 @@
+<?php
+  /*
+   * Keyman is copyright (C) SIL Global. MIT License.
+   */
+  declare(strict_types=1);
+
+  namespace Keyman\Site\com\keyman;
+
+  class Session {
+    public static function Start() {
+      if(!isset($_SESSION)) {
+        session_set_cookie_params(["SameSite" => "None"]);   // Allow use in iframe, needed for Download Keyboards dialog
+        session_set_cookie_params(["Secure" => "true"]);     // None requires Secure to be set
+        session_start();
+        $session_started = true;
+      }
+    }
+  }

--- a/_includes/2020/templates/Head.php
+++ b/_includes/2020/templates/Head.php
@@ -35,15 +35,6 @@ class Head {
       }
 
       $fields->pageLocale = Locale::pageLocale();
-
-      // Redirect to /en/... if not a supported locale; this needs to be emitted
-      // as a HTTP header before first content byte.
-      if(Locale::invalidLocale()) {
-        if(preg_match('/^\\/[^\/]+\\/(.+)$/', $_SERVER['REQUEST_URI'], $matches)) {
-          header("Location: /" . Locale::DEFAULT_LOCALE . "/" . $matches[1]);
-          return;
-        }
-      }
 ?><!DOCTYPE html>
 <html lang='<?=$fields->pageLocale?>'>
 <head>

--- a/_includes/errors/404.php
+++ b/_includes/errors/404.php
@@ -1,5 +1,39 @@
 <?php
+  /*
+   * Keyman is copyright (C) SIL Global. MIT License.
+   */
+  declare(strict_types=1);
+
   require_once _KEYMANCOM_INCLUDES . '/includes/template.php';
+  require_once _KEYMANCOM_INCLUDES . '/autoload.php';
+
+  // Avoid showing a HTML response for requests where the Accept: header is
+  // missing or does not correspond to a text/html-type, so that the client
+  // doesn't get HTML where it doesn't expect it
+
+  $negotiator = new \Negotiation\Negotiator();
+
+  if(empty($_SERVER['HTTP_ACCEPT'])) {
+    $acceptHeader = 'unknown';
+  } else {
+    $acceptHeader = $_SERVER['HTTP_ACCEPT'];
+  }
+
+  $mediaType = $negotiator->getBest($acceptHeader, ['text/html']);
+  if(!$mediaType) {
+    header('HTTP/1.0 404 Page not found');
+    return;
+  }
+
+  // We need to avoid saving any locale that is calculated on this page because
+  // 404.php requests can arise unexpectedly, and the URL may be anything, so
+  // calculating locale from page url could result in it being reset to
+  // `DEFAULT_LOCALE`. For example, missing images or background requests like
+  // Chrome requesting /.well-known/appspecific/com.chrome.devtools.json when
+  // DevTools is open.
+
+  use Keyman\Site\com\keyman\Locale;
+  Locale::$saveLocale = false;
 
   head([
     'title' => "Page not found",
@@ -16,7 +50,7 @@
       $s = @htmlspecialchars($v, ENT_QUOTES, 'ISO-8859-1');
     return $s;
   }
-  
+
 ?>
 <h1>Page not found</h1>
 

--- a/_includes/includes/template.php
+++ b/_includes/includes/template.php
@@ -1,8 +1,13 @@
 <?php
+  /*
+   * Keyman is copyright (C) SIL Global. MIT License.
+   */
+
   require_once _KEYMANCOM_INCLUDES . '/includes/servervars.php';
 
   // *Don't* use autoloader here because of potential side-effects in older pages
   require_once _KEYMANCOM_INCLUDES . '/2020/Util.php';
+  require_once _KEYMANCOM_INCLUDES . '/2020/Session.php'; // must be before Locale.php
   require_once _KEYMANCOM_INCLUDES . '/locale/Locale.php';
   require_once _KEYMANCOM_COMMON . '/KeymanVersion.php';
   require_once _KEYMANCOM_INCLUDES . '/2020/templates/Head.php';

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -1,14 +1,15 @@
 <?php
-
-/*
- * Keyman is copyright (C) SIL Global. MIT License.
- */
-
+  /*
+  * Keyman is copyright (C) SIL Global. MIT License.
+  */
   declare(strict_types=1);
 
   namespace Keyman\Site\com\keyman;
 
   use \Keyman\Site\Common\KeymanHosts;
+  use \Keyman\Site\com\keyman\Session;
+
+  Session::Start();
 
   function define_display_locales() {
     $_defined_locales = json_decode(file_get_contents(__DIR__ . '/locales.json'), true);
@@ -32,6 +33,14 @@
     private static $invalidLocale = false;
 
     /**
+     * For pages which don't belong in the _content hierarchy, such as 404.php,
+     * we do not want to save the selected locale to the session, because it may
+     * not be correct, and we also want to skip redirection when an invalid
+     * locale is found.
+     */
+    public static $saveLocale = true;
+
+    /**
      * Return the current locales. Fallback to 'en'
      * @return $currentLocales
      */
@@ -40,6 +49,13 @@
         Locale::setLocaleFromURL();
       }
       return self::$currentLocales;
+    }
+
+    /**
+     * Returns an array of available locales, e.g. ["en","de",...]
+     */
+    public static function availableLocales() {
+      return array_keys(DISPLAY_NAMES);
     }
 
     /**
@@ -79,7 +95,9 @@
       // First component of the URL is always the locale
       if(preg_match('/^\\/(([a-z]{2,3})(-([A-Za-z]{4}))?(-([a-z]{2}|[0-9]{3}))?)\\//', $_SERVER['REQUEST_URI'], $matches)) {
         if(!isset(DISPLAY_NAMES[$matches[1]])) {
-          // Note: this is an unsupported locale, so we'll end up redirecting in head.php to /en/...
+          // Note: this is an unsupported locale; this should not be possible
+          // with the current .htaccess design for any pages in _content,
+          // because we only accept valid locales for rewriting to those files
           $pageLocale = Locale::DEFAULT_LOCALE;
           self::$invalidLocale = true;
         } else {
@@ -99,15 +117,29 @@
      *                    locales (other than 'en', which is always added)
      */
     private static function setLocale($locale, $fallback) {
+      self::$currentLocales = [];
+
       if ($fallback) {
-        self::$currentLocales = self::calculateFallbackLocales($locale);
+        $locales = self::calculateFallbackLocales($locale);
+        // Only add recognized locales
+        foreach($locales as $l) {
+          if(isset(DISPLAY_NAMES[$l])) {
+            array_push(self::$currentLocales, $l);
+          }
+        }
       } else {
-        self::$currentLocales =[$locale];
+        if(isset(DISPLAY_NAMES[$locale])) {
+          self::$currentLocales = [$locale];
+        }
       }
 
       if(!in_array(Locale::DEFAULT_LOCALE, self::$currentLocales)) {
         // Push default fallback locale to the end
         array_push(self::$currentLocales, Locale::DEFAULT_LOCALE);
+      }
+
+      if(self::$saveLocale) {
+        $_SESSION['lang'] = self::$currentLocales[0];
       }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
         "sentry/sdk": "^2.1.0",
         "php-http/curl-client": "^2.1",
         "erusev/parsedown": "^1.7",
-        "erusev/parsedown-extra": "^0.8.1"
+        "erusev/parsedown-extra": "^0.8.1",
+        "willdurand/negotiation": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a7e1cc495f11886e6069228ea157caa",
+    "content-hash": "714c3b645ff33a6d090e83f78f24009d",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2008,6 +2008,62 @@
                 }
             ],
             "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "willdurand/negotiation",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/Negotiation.git",
+                "reference": "68e9ea0553ef6e2ee8db5c1d98829f111e623ec2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/Negotiation/zipball/68e9ea0553ef6e2ee8db5c1d98829f111e623ec2",
+                "reference": "68e9ea0553ef6e2ee8db5c1d98829f111e623ec2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Negotiation\\": "src/Negotiation"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "will+git@drnd.me"
+                }
+            ],
+            "description": "Content Negotiation tools for PHP provided as a standalone library.",
+            "homepage": "http://williamdurand.fr/Negotiation/",
+            "keywords": [
+                "accept",
+                "content",
+                "format",
+                "header",
+                "negotiation"
+            ],
+            "support": {
+                "issues": "https://github.com/willdurand/Negotiation/issues",
+                "source": "https://github.com/willdurand/Negotiation/tree/3.1.0"
+            },
+            "time": "2022-01-30T20:08:53+00:00"
         }
     ],
     "packages-dev": [

--- a/go/site/redirect_locale.php
+++ b/go/site/redirect_locale.php
@@ -1,0 +1,43 @@
+<?php
+  /*
+   * Keyman is copyright (C) SIL Global. MIT License.
+   *
+   * Redirect a top-level page to the best locale available for the user; called
+   * by the mod_rewrite i18n rules in .htaccess.
+   */
+  declare(strict_types=1);
+
+  require_once _KEYMANCOM_INCLUDES . '/autoload.php';
+
+  use Keyman\Site\com\keyman\Locale;
+  use Keyman\Site\com\keyman\Session;
+
+  if(isset($_SESSION['lang'])) {
+    // We'll use the user's previously selected language if they've already been
+    // browsing the site in the current session
+    $lang = $_SESSION['lang'];
+  } else if(isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+    // Use HTTP Accept-Language: header to determine default language
+    $negotiator = new \Negotiation\LanguageNegotiator();
+
+    $acceptLanguageHeader = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+    $availableLocales     = Locale::availableLocales();
+    $bestLanguage = $negotiator->getBest($acceptLanguageHeader, $availableLocales);
+    $lang = $bestLanguage->getType();
+
+    // We'll use Locale to validate and do fallback on the $lang variable;
+    // normally this will have been done by LanguageNegotiator already, so
+    // this may not be necessary
+    Locale::setOverrideLocale($lang, true);
+    $lang = Locale::pageLocale();
+  } else {
+    // No language provided, fallback to the default locale
+    $lang = Locale::DEFAULT_LOCALE;
+  }
+
+  // The url that was originally requested is passed in through the server
+  // variable REQUEST_URI by mod_rewrite, including the initial slash (/).
+  $url = $_SERVER['REQUEST_URI'];
+  $localizedUrl = "/$lang$url";
+
+  header("Location: $localizedUrl");


### PR DESCRIPTION
Select the most appropriate language when a top-level page is encountered, either from the user's most recently chosen language, or else from the request Accept-Language header.

Install Negotiator to parse Accept-Language.

Fix a bug with the 404 page where the locale would be reset secretly by unexpected requests.

Remove the invalid locale redirect from Head.php because it cannot be encountered with the current htaccess patterns.

Establish the use of sessions throughout the site, to allow us to track the current language server-side. This could alternately be done with a cookie.

Fixes: #762
Fixes: #772
Test-bot: skip