### PR TITLE
feat: collapse UI language selector on phone devices

### DIFF
--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -91,21 +91,31 @@ END;
      * ui-language1 - Desktop globe hover
      * phone - Mobile list
      */
-    private static function render_globe_dropdown($divID = "ui-language"): void {
+    private static function render_phone_globe_dropdown() {
       // Phone layout
-      $globeClass = '';
-      if ($divID === "phone") {
-?>
-<div class="phone-menu-item">
-            <h3><span><img src="<?php echo Util::cdn("img/globe.png"); ?>" alt="UI globe dropdown" /></span> Display in:</h3>
-            <?= Menu::render_ui_list(); ?>
-        </div>
-      <?php
-        return;
-      } else if ($divID === "ui-language") {
+      $lang = Locale::currentLocaleName();
+      $img = Util::cdn("img/globe.png");
+      echo <<<END
+        <div class="phone-menu-item"><h3 id='locale-phone-menu-title'><span><img src="$img" alt="Select UI language" /></span> Display in: <a href='#'>$lang</a></h3>
+        <div id='locale-phone-menu'>
+      END;
+      Menu::render_ui_list();
+      echo "</div></div>";
+    }
+
+    /**
+     * Render the globe dropdown for changing the UI language
+     * @param divID - <div> ID to handle 2 cases:
+     * ui-language (default) Desktop globe hover
+     * ui-language1 - Desktop globe hover
+     */
+    private static function render_globe_dropdown($divID = "ui-language"): void {
+      if ($divID === "ui-language") {
         $globeClass = 'menu-item';
       } else if ($divID === "ui-language1") {
         $globeClass = 'help1-globe menu-item';
+      } else {
+        return;
       }
 
       // Desktop layout
@@ -114,7 +124,7 @@ echo <<<END
             <div id='$divID' class='$globeClass'>
 END;
 ?>
-              <h3><img src="<?php echo Util::cdn("img/globe.png"); ?>" alt="UI globe dropdown" /></h3>
+              <h3><img src="<?php echo Util::cdn("img/globe.png"); ?>" alt="Select UI language" /></h3>
               <div class="menu-item-dropdown">
                 <div class="menu-dropdown-inner">
                   <?= Menu::render_ui_list(); ?>
@@ -137,7 +147,7 @@ END;
                 <input id="search-submit2" type="image" src="<?php echo Util::cdn("img/search-button.png"); ?>" alt="search button" value="Search" onclick="if(document.getElementById('language-search2').value==''){return false;}">
             </form>
         </div>
-        <?= Menu::render_globe_dropdown("phone"); ?>
+        <?= Menu::render_phone_globe_dropdown(); ?>
   <div class="phone-menu-item">
             <h3>Products</h3>
             <ul>

--- a/_includes/locale/Locale.php
+++ b/_includes/locale/Locale.php
@@ -53,6 +53,13 @@
       return self::$currentLocales;
     }
 
+    public static function currentLocaleName() {
+      if(count(self::$currentLocales) == 0) {
+        Locale::setLocaleFromURL();
+      }
+      return DISPLAY_NAMES[self::$currentLocales[0]];
+    }
+
     /**
      * Returns an array of available locales, e.g. ["en","de",...]
      */

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -3115,3 +3115,15 @@ div.locale-visible#locale-not-localized,
 div.locale-visible#locale-not-internationalized {
 	display: block;
 }
+
+#locale-phone-menu {
+	display: none;
+}
+
+.phone-menu-item h3#locale-phone-menu-title {
+	border-bottom: none;
+}
+
+.locale-menu-visible#locale-phone-menu {
+	display: block;
+}

--- a/cdn/dev/js/kmlive.js
+++ b/cdn/dev/js/kmlive.js
@@ -81,6 +81,10 @@ function loaded(){
     $("#phone-menu").toggleClass('menu-visible');
   });
 
+  $('#locale-phone-menu-title').click(function(event) {
+    $("#locale-phone-menu").toggleClass('locale-menu-visible');
+  });
+
   // Downloads
   $('.download-cta-button').click(function(e){
     var platform = $(this).closest('.download-cta-big').attr('id');


### PR DESCRIPTION

Before:

<img width="481" height="312" alt="image" src="https://github.com/user-attachments/assets/86ee50b9-4ba9-4aa3-bd5f-a71878b41f43" />

After (on opening menu):

<img width="636" height="443" alt="image" src="https://github.com/user-attachments/assets/a0bfba69-a515-4324-bd3f-fc7167f94596" />

Expanded (after touching anywhere on globe heading):

<img width="653" height="527" alt="image" src="https://github.com/user-attachments/assets/65bcb099-cf18-4c31-830e-6ba644c056e8" />


Fixes: #779
Test-bot: skip