### PR TITLE
feat: highlight selected ui language

### DIFF
--- a/_includes/2020/templates/Menu.php
+++ b/_includes/2020/templates/Menu.php
@@ -73,12 +73,12 @@ END;
       echo "<ul>\n                <!-- Just use autonyms -->\n";
       $linkArray = array();
       foreach(DISPLAY_NAMES as $id => $name) {
-        $linkArray[$id] = array(Menu::change_ui_language($id), $name);
+        $linkArray[$id] = array(Menu::change_ui_language($id), $name, $id == Locale::pageLocale() ? 'locale-selected' : '');
       }
 
       foreach($linkArray as $id) {
 echo <<<END
-                <li><a href="{$id[0]}">{$id[1]}</a></li>\n
+                <li class="${id[2]}"><a href="{$id[0]}">{$id[1]}</a></li>\n
 END;
       }
       echo "</ul>";

--- a/cdn/dev/css/template.css
+++ b/cdn/dev/css/template.css
@@ -927,6 +927,10 @@ input[type="search"] {
 	width: 180px;
 }
 
+#ui-language .menu-item-dropdown a {
+	font-weight: normal
+}
+
 /* end of hover */
 
 #buy,
@@ -3126,4 +3130,9 @@ div.locale-visible#locale-not-internationalized {
 
 .locale-menu-visible#locale-phone-menu {
 	display: block;
+}
+
+#ui-language .menu-item-dropdown .locale-selected a {
+	font-weight: 900;
+	color: black !important;
 }


### PR DESCRIPTION

For example:

<img width="329" height="383" alt="image" src="https://github.com/user-attachments/assets/57a80bf2-c167-4632-b359-dbf40fbe631d" />

Mouse hover is grey background and underline:

<img width="333" height="395" alt="image" src="https://github.com/user-attachments/assets/9822311f-2186-4ed5-8aab-61f32c6304a4" />


Fixes: #783
Test-bot: skip