### PR TITLE
fix: start session in redirect handler

### DIFF
--- a/go/site/redirect_locale.php
+++ b/go/site/redirect_locale.php
@@ -12,6 +12,8 @@
   use Keyman\Site\com\keyman\Locale;
   use Keyman\Site\com\keyman\Session;
 
+  Session::Start();
+
   if(isset($_SESSION['lang'])) {
     // We'll use the user's previously selected language if they've already been
     // browsing the site in the current session


### PR DESCRIPTION
The session was not automatically started when the redirect page was loaded, because it needed Locale to be touched first (due to the way autoload is resolved in PHP).

Fixes: #784
Test-bot: skip