### PR TITLE
chore: use keymancom instead of keyman for localization site

### DIFF
--- a/_includes/2020/templates/Body.php
+++ b/_includes/2020/templates/Body.php
@@ -9,9 +9,5 @@
     static function render($fields = []) {
       echo '<div class="main">';
       echo '<div id="section2"><div class="wrapper">';
-      echo <<<END
-    <div id="locale-not-internationalized">This page has not yet been updated for languages other than English. <a href='/about/get-involved'>Help us do this</a></div>
-    <div id="locale-not-localized">This page is not yet available in your selected language. <a href='https://translate.keyman.com'>Help us translate this page</a></div>
-END;
     }
   }

--- a/_includes/2020/templates/Foot.php
+++ b/_includes/2020/templates/Foot.php
@@ -1,8 +1,8 @@
 <?php
   declare(strict_types=1);
-
   namespace Keyman\Site\com\keyman\templates;
 
+  require_once(__DIR__ . "/../../autoload.php");
   use Keyman\Site\Common\ImageRandomizer;
   use Keyman\Site\Common\KeymanVersion;
   use Keyman\Site\Common\KeymanHosts;
@@ -17,7 +17,7 @@
 ?>
 
         <div id="locale-not-internationalized">This page has not yet been updated for languages other than English. <a href='/about/get-involved'>Can you help make this happen?</a></div>
-        <div id="locale-not-localized">This page is not yet available in your selected language. <a href='https://translate.keyman.com'>Help us translate this page</a></div>
+        <div id="locale-not-localized">This page is not yet available in your selected language. <a href='https://translate.keyman.com/project/keymancom'>Help us translate this page</a></div>
 
       </div>
     </div>


### PR DESCRIPTION
Content on websites is in the keymancom project on Crowdin.

Test-bot: skip