### PR TITLE
chore: verify bootstrap version format before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,6 @@ jobs:
         # shape of the tags, which is `v#.#.#`. Any other shape we will assume is a test
         # branch.
         cat resources/.bootstrap-required-version | grep -qP '^v\d+\.\d+\.\d+$' || (
-          echo "This branch cannot be merged, because resources/.bootstrap-required-version "
-          echo "references '$(cat resources/.bootstrap-required-version)', which does not"
-          echo "appear to be a published tag -- is it a test branch?"
+          echo "::error file=resources/.bootstrap-required-version,line=1,col=1::This branch cannot be merged, because resources/.bootstrap-required-version references \`$(cat resources/.bootstrap-required-version)\`, which does not appear to be a published tag -- is it a test branch?"
           exit 1
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,18 @@ jobs:
         source ./_common/tests.inc.sh
         set -e
         do_test_print_container_error_logs "$CONTAINER_DESC"
+
+    - name: Verify .bootstrap-required-version
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        # We want to avoid merging a bootstrap version that is not based on a published tag
+        # in the shared-sites repo. We will do this with a heuristic based on the normal
+        # shape of the tags, which is `v#.#.#`. Any other shape we will assume is a test
+        # branch.
+        cat resources/.bootstrap-required-version | grep -qP '^v\d+\.\d+\.\d+$' || (
+          echo "This branch cannot be merged, because resources/.bootstrap-required-version "
+          echo "references '$(cat resources/.bootstrap-required-version)', which does not"
+          echo "appear to be a published tag -- is it a test branch?"
+          exit 1
+        )

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,8 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=feat/linkinator-and-central-test-script
+BOOTSTRAP_VERSION="$(cat "$(dirname "THIS_SCRIPT")/resources/.bootstrap-required-version")" || exit 1
+readonly BOOTSTRAP_VERSION
 if ! [ -f "$BOOTSTRAP" ] || ! source "$BOOTSTRAP"; then
   curl -H "Cache-Control: no-cache" --fail --silent --show-error -w "curl: Finished attempt to download %{url}" "https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh" -o "$BOOTSTRAP.tmp" || exit 1
   source "$BOOTSTRAP.tmp"

--- a/resources/.bootstrap-required-version
+++ b/resources/.bootstrap-required-version
@@ -1,0 +1,1 @@
+feat/linkinator-and-central-test-script

--- a/resources/.bootstrap-required-version
+++ b/resources/.bootstrap-required-version
@@ -1,1 +1,1 @@
-feat/linkinator-and-central-test-script
+v1.0.14


### PR DESCRIPTION
It is important that the bootstrap version is pointing to a published tag, so that merged changes do not end up pointing to an ephemeral ref on the shared-sites repository. This change splits the bootstrap version into a separate file resources/.bootstrap-required-version, so that this version string can be easily checked in ci.yml, preventing merge of pull requests that point to branch names instead of tag names. For simplicity, the test verifies the shape of the version string as 'v#.#.#', but does not verify that it actually points to a tag, so in theory it could be fooled, but in practice we never use that pattern for branch names.

Test-bot: skip