### PR TITLE
feat: show keyboard status in Details

### DIFF
--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -276,20 +276,24 @@ END;
 
         // Package Status
 
-        $status = 'unknown';
-        if(self::$keyboard->sourcePath) {
-          $sourcePath = self::$keyboard->sourcePath;
-          if(preg_match('/^experimental/', $sourcePath)) {
-            $status = 'experimental';
-          } else if(preg_match('/^legacy/', $sourcePath)) {
-            $status = 'legacy';
-          } else if(preg_match('/^release/', $sourcePath)) {
-            $status = 'stable';
-          }
-        }
+        $status = self::GetStatusFromSourcePath(self::$keyboard->sourcePath ?? '');
         self::$packageStatus = htmlentities($_m_Keyboards_Details("status_$status"));
         self::$packageStatusExplanation = htmlentities($_m_Keyboards_Details("status_{$status}_explanation"));
       }
+    }
+
+    private static function GetStatusFromSourcePath($sourcePath) {
+      $status = 'unknown';
+      if(!empty($sourcePath)) {
+        if(preg_match('/^experimental/', $sourcePath)) {
+          $status = 'experimental';
+        } else if(preg_match('/^legacy/', $sourcePath)) {
+          $status = 'legacy';
+        } else if(preg_match('/^release/', $sourcePath)) {
+          $status = 'stable';
+        }
+      }
+      return $status;
     }
 
     private static function array_find($xs, $f) {

--- a/_includes/includes/ui/keyboard-details.php
+++ b/_includes/includes/ui/keyboard-details.php
@@ -56,6 +56,8 @@
     static private $kmpDownloadUrl;
     static private $downloadCount;
     static private $totalDownloadCount;
+    static private $packageStatus;
+    static private $packageStatusExplanation;
 
     static private $deprecatedBy;
 
@@ -271,6 +273,22 @@ END;
             }
           }
         }
+
+        // Package Status
+
+        $status = 'unknown';
+        if(self::$keyboard->sourcePath) {
+          $sourcePath = self::$keyboard->sourcePath;
+          if(preg_match('/^experimental/', $sourcePath)) {
+            $status = 'experimental';
+          } else if(preg_match('/^legacy/', $sourcePath)) {
+            $status = 'legacy';
+          } else if(preg_match('/^release/', $sourcePath)) {
+            $status = 'stable';
+          }
+        }
+        self::$packageStatus = htmlentities($_m_Keyboards_Details("status_$status"));
+        self::$packageStatusExplanation = htmlentities($_m_Keyboards_Details("status_{$status}_explanation"));
       }
     }
 
@@ -593,6 +611,10 @@ END;
 
           <table id='keyboard-details'>
             <tbody>
+            <tr>
+              <th><?= $_m_Keyboards_Details("package_status") ?></th>
+              <td class='dotted-underline' title="<?= self::$packageStatusExplanation ?>"><?= self::$packageStatus ?></td>
+            </tr>
 <?php
               if(isset(self::$keyboard->packageFilename)) {
 ?>

--- a/_includes/locale/strings/keyboards/details/en.php
+++ b/_includes/locale/strings/keyboards/details/en.php
@@ -15,141 +15,152 @@ return [
 
   # Placeholder for new keyboard search
   "new_keyboard_search" => "New keyboard search",
-  
+
   # Search Button Value
   "search" => "Search",
-  
+
   # Keyman Developer clone keyboard box
-  
+
   # Fill in New Project Details box below and click OK to clone {filename}
   "new_project_details" =>
     "Fill in New Project Details box below and click OK to clone %1\$s.",
-  
+
   # "Install keyboard" button text
   "install_keyboard" => "Install keyboard",
-  
+
   # "Install keyboard" button description
   "install_keyboard_button_description" =>
     "Installs %1\$s for %2\$s on this device",
-  
+
   # keyboard download is not supported on this device
-  "keyboard_not_supported" => 
+  "keyboard_not_supported" =>
     "This keyboard is not supported on this device. You may find other options below.",
-  
+
   # Try this keyboard heading
   "try_this_keyboard" => "Try this keyboard",
-  
+
   # "Use keyboard online" button text
   "use_keyboard_online" => "Use keyboard online",
-  
+
   # "Full online editor" button text
   "full_online_editor" => "Full online editor",
-  
+
   # "Use keyboard online" button description
-  "use_keyboard_button_description" => 
+  "use_keyboard_button_description" =>
     "Use %1\$s in your web browser. No need to install anything.",
-  
+
   # Scan this QR code
-  "scan_qr_code" => 
+  "scan_qr_code" =>
     "Scan this code to load this keyboard on another device",
-  
+
   # Headers in Keyboard Details section
-  
+
   "keyboard_details" => "Keyboard Details",
-  
+
   "keyboard_ID" => "Keyboard ID",
-  
+
   "supported_platforms" => "Supported Platforms",
-  
+
   "author" => "Author",
-  
+
   "license" => "License",
-  
+
   "documentation" => "Documentation",
-  
+
   "keyboard_help" => "Keyboard help",
-  
+
   "help_not_available" => "Help not available.",
-  
+
   "source" => "Source",
-  
+
   "source_not_available" => "Source not available.",
-  
+
   "keyboard_version" => "Keyboard Version",
-  
+
   "last_updated" => "Last Updated",
-  
+
   "package_download" => "Package Download",
-  
+
   "monthly_downloads" => "Monthly Downloads",
-  
+
   "total_downloads" => "Total Downloads",
-  
+
   # Total Downloads title - Downloads since {date}
   "downloads_since" => "Downloads since %1\$s",
-  
+
   # Date to start counting downloads
   "date_counting" => "October 2019",
 
   "encoding" => "Encoding",
-  
+
   # Encoding list
   "encoding_list" => "Unicode, Legacy (ANSI)",
-  
+
   # Unicode encoding
   "unicode" => "Unicode",
-  
+
   # Legacy (ANSI) encoding
   "legacy_ansi" => "Legacy (ANSI)",
-  
+
   # Minimum Keyman Version
   "minimum_version" => "Minimum %1\$s Version",
-  
+
   "related_keyboards" => "Related Keyboards",
-  
+
   # This keyboard is not available on keyman.com
   "keyboard_not_available" => "This keyboard is not available on %1\$s",
-  
+
   "deprecated" => "(deprecated)",
-  
+
   "new_version" => "(new version)",
-  
+
   "supported_languages" => "Supported Languages",
-  
+
   # Expand {count} more >>
   "expand_more" => "Expand %1\$s more >>",
-  
+
   # << Collapse
   "collapse" => "<< Collapse",
-  
+
   "permanent_link_to_this_keyboard" => "Permanent link to this keyboard:",
-  
+
   ## Obsolete keyboard notes
-  
+
   "important_note" => "Important note:",
-  
-  "obsolete_version" => 
+
+  "obsolete_version" =>
     "This is an obsolete version of this keyboard. Unless you have a good reason, click here to install the new version, called",
-  
+
   "instead" => ", instead.",
-  
+
   "view_obsolete_details" => "View details for obsolete version instead",
-  
+
   "new_search" => "New search",
-  
+
   ## Errors
-  
+
   # Failed to load keyboard package [ID]
   "failed_to_load_keyboard_package" => "Failed to load keyboard package %1\$s",
-  
+
   # Error returned from api.keyman.com: {error string}
   "error_returned_from_api" => "Error returned from %1\$s: %2\$s",
-  
-  # Keyboard package [ID] not found)'Failed to load keyboard package ' . 
+
+  # Keyboard package [ID] not found)'Failed to load keyboard package ' .
   "package_not_found" => "Keyboard package %1\$s not found.",
-  
+
   # Sorry, this keyboard requires Keyman {minimum version} or higher.
-  "requires_keyman_minimum_version" => 
-    "Sorry, this keyboard requires Keyman %1\$s or higher."
+  "requires_keyman_minimum_version" =>
+    "Sorry, this keyboard requires Keyman %1\$s or higher.",
+
+  # Package status field
+  "package_status" => "Status",
+  "status_unknown" => "Unknown",
+  "status_unknown_explanation" => "The status of the keyboard could not be determined.",
+  "status_experimental" => "Experimental",
+  "status_experimental_explanation" => "Use at your own risk. This keyboard may be considered an experiment by its maintainer. The typing method is subject to change without notice. Fonts packaged with the keyboard may also change, making previously typed work incompatible with updates.",
+  "status_legacy" => "Legacy",
+  "status_legacy_explanation" => "Working but unsupported. This keyboard is no longer supported by its maintainer. Defects are unlikely to be fixed.",
+  "status_stable" => "Stable",
+  "status_stable_explanation" => "Safe to use. This keyboard is actively maintained and complies with international standards such as Unicode.",
 
 ];

--- a/cdn/dev/keyboard-search/search.css
+++ b/cdn/dev/keyboard-search/search.css
@@ -285,6 +285,11 @@ h2 a {
   display: inline;
 }
 
+#keyboard-details .dotted-underline {
+  text-decoration: underline dotted;
+  cursor: help;
+}
+
 .clear-left {
   clear: left;
 }


### PR DESCRIPTION
Add a keyboard status field to the details, and an explanation. Extend the UI with a tooltip explanation of the field, exposed with dotted underline. Note that the tooltip will not be accessible on touch devices at this time (both this and other tooltips on the page are areas for future enhancement).

Fixes: #566
Test-bot: skip