### PR TITLE
fix: lang query parameter overrides session lang variable

### DIFF
--- a/_content/keyboards/session.php
+++ b/_content/keyboards/session.php
@@ -41,8 +41,10 @@
     // and otherwise cookies are blocked
     setcookie('embed_keyboards_no_locale_redirect', '1', ["secure" => true, "samesite" => 'None', 'path' => '/']);
 
-    if(!isset($_SESSION['lang'])) {
-      $_SESSION['lang'] = isset($_REQUEST['lang']) ? $_REQUEST['lang'] : 'en';
+    if(isset($_REQUEST['lang'])) {
+      $_SESSION['lang'] = $_REQUEST['lang'];
+    } else if(!isset($_SESSION['lang'])) {
+      $_SESSION['lang'] = 'en';
     }
     Locale::setOverrideLocale($_SESSION['lang']);
 


### PR DESCRIPTION
When in embedded keyboard search, if a lang parameter is passed in the query string, it should override the session value, otherwise, the first language set for a given session of Keyman Configuration will stick until the end of the session.

Test-bot: skip