### PR TITLE
fix: make i18n redirects for /keyboards more resilient

### DIFF
--- a/_content/keyboards/session.php
+++ b/_content/keyboards/session.php
@@ -54,6 +54,7 @@
     ]);
     $session_query_q = "?$session_query";
   } else {
+    setcookie('embed_keyboards_no_locale_redirect', '', ["secure" => true, "samesite" => 'None', 'path' => '/']);
     $session_query = '';
     $session_query_q = '';
   }

--- a/go/site/redirect_locale.php
+++ b/go/site/redirect_locale.php
@@ -37,6 +37,10 @@
     $lang = Locale::DEFAULT_LOCALE;
   }
 
+  if(empty($lang)) {
+    $lang = Locale::DEFAULT_LOCALE;
+  }
+
   // The url that was originally requested is passed in through the server
   // variable REQUEST_URI by mod_rewrite, including the initial slash (/).
   $url = $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
Ensure that other embed-related properties are reset if `embed=none`

Fixes: #820
Test-bot: skip