### PR TITLE
chore: Add Portuguese locale

### DIFF
--- a/_includes/locale/locales.json
+++ b/_includes/locale/locales.json
@@ -3,5 +3,6 @@
   "de": "Deutsch",
   "es": "Español",
   "fr": "Français",
-  "km": "ខ្មែរ (Khmer)"
+  "km": "ខ្មែរ (Khmer)",
+  "pt": "Português"
 }

--- a/_includes/locale/strings/downloads/pt.php
+++ b/_includes/locale/strings/downloads/pt.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for downloads/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Downloads Page Title
+  "downloads_page_title" => "Downloads do Keyman",
+
+  # Downloads_page_description
+  "downloads_page_description" => "Downloads Estáveis do Keyman",
+
+  # Get the latest
+  "get_the_latest" => 
+    "Obtenha a última versão do Keyman aqui. Estes são downloads independentes e não contêm layouts de teclado
+    para sua língua. Veja também a %1\$s e a %2\$s.",
+
+  # Downloads pre-release page
+  "downloads_pre_release_page" => "Página da versão preliminar",
+
+  # Downloads old versions page
+  "downloads_old_versions_page" => "Página de download de versões anteriores",
+
+  # Keyman version history
+  "keyman_version_history_1" => "Histórico de versões do Keyman",
+
+  # Keyman version history (description)
+  "keyman_version_history_2" => "(todos os produtos)",
+
+  # Browse all versions
+  "browse_all_versions" => "Ver todas as versões (14.0 em diante)",
+
+  ### Product Downloads
+
+  # Keyman for Windows
+  "product_windows" => "Keyman para Windows",
+
+  # Keyman for macOS
+  "product_macos" => "Keyman para macOS",
+
+  # Keyman for Android
+  "product_android" => "Keyman para Android",
+
+  "available_on_play_store" => "Keyman para Android também está disponível na Play Store",
+
+  # Keyman for iPhone and iPad
+  "product_ios" => "Keyman para iPhone e iPad",
+
+  "available_on_app_store" => "Keyman para iPhone e iPad também está disponível na App Store.",
+
+  # Keyman for Linux
+  "product_linux" => "Keyman para Linux",
+
+  "install_via_launchpad" => "Ubuntu, Wasta-Linux: Keyman para Linux também pode ser instalado pelo launchpad:",
+
+  # Products for Software Developers
+  "products_for_software_developers" => "Produtos para Desenvolvedores de Software",
+
+  # KeymanWeb
+  "product_keymanweb" => "KeymanWeb",
+
+  # Keyman Developer
+  "product_developer" => "Desenvolvedor do Keyman",
+
+  # Keyman Engine for Android
+  "product_engine_android" => "Keyman Engine para Android",
+
+  # Keyman Engine for iOS
+  "product_engine_ios" => "Keyman Engine para iOS",
+
+  ## Tiers
+  "alpha" => "alpha",
+
+  "beta" => "beta",
+
+  "stable" => "estável",
+
+  # (released {date}, {file size})
+  "released_date_size" => "(publicado em %1\$s, %2\$s)",
+
+  # All {product} {tier} releases
+  "all_product_releases" => "Todas as versões %1\$s %2\$s",
+
+  # No downloads found for {product}
+  "no_downloads_found" => "Não foram encontrados downloads para %1\$s"
+]
+;
+

--- a/_includes/locale/strings/keyboards/details/pt.php
+++ b/_includes/locale/strings/keyboards/details/pt.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for keyboards/keyboard-details.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Page Title
+  "details_page_title" => "%1\$s teclado",
+
+  # Placeholder for new keyboard search
+  "new_keyboard_search" => "Nova busca de teclado",
+
+  # Search Button Value
+  "search" => "Busca",
+
+  # Keyman Developer clone keyboard box
+
+  # Fill in New Project Details box below and click OK to clone {filename}
+  "new_project_details" =>
+    "Preencha os dados do Projeto Novo na caixa de diálogo abaixo e clique em OK para clonar %1\$s.",
+
+  # "Install keyboard" button text
+  "install_keyboard" => "Instalar teclado",
+
+  # "Install keyboard" button description
+  "install_keyboard_button_description" =>
+    "Instala %1\$s para %2\$s nesse dispositivo",
+
+  # keyboard download is not supported on this device
+  "keyboard_not_supported" =>
+    "Este teclado não é suportado nesse dispositivo, Você pode encontrar outras opções abaixo.",
+
+  # Try this keyboard heading
+  "try_this_keyboard" => "Experimente esse teclado",
+
+  # "Use keyboard online" button text
+  "use_keyboard_online" => "Use o teclado online",
+
+  # "Full online editor" button text
+  "full_online_editor" => "Editor online completo",
+
+  # "Use keyboard online" button description
+  "use_keyboard_button_description" =>
+    "Use o %1\$s no seu navegador. Não é necessário instalar nada.",
+
+  # Scan this QR code
+  "scan_qr_code" =>
+    "Escaneie este código para carregar este teclado em outro dispositivo",
+
+  # Headers in Keyboard Details section
+
+  "keyboard_details" => "Detalhes do teclado",
+
+  "keyboard_ID" => "ID do teclado",
+
+  "supported_platforms" => "Plataformas Suportadas",
+
+  "author" => "Autor",
+
+  "license" => "Licença",
+
+  "documentation" => "Documentação",
+
+  "keyboard_help" => "Ajuda do teclado",
+
+  "help_not_available" => "Ajuda não disponível.",
+
+  "source" => "Fonte",
+
+  "source_not_available" => "Fonte não disponível.",
+
+  "keyboard_version" => "Versão do teclado",
+
+  "last_updated" => "Ultima atualização",
+
+  "package_download" => "Download de pacote",
+
+  "monthly_downloads" => "Downloads Mensais",
+
+  "total_downloads" => "Total de Downloads",
+
+  # Total Downloads title - Downloads since {date}
+  "downloads_since" => "Downloads desde %1\$s",
+
+  # Date to start counting downloads
+  "date_counting" => "Outubro de 2019",
+
+  "encoding" => "Codificação",
+
+  # Encoding list
+  "encoding_list" => "Unicode, Legacy (ANSI)",
+
+  # Unicode encoding
+  "unicode" => "Unicode",
+
+  # Legacy (ANSI) encoding
+  "legacy_ansi" => "Legacy (ANSI)",
+
+  # Minimum Keyman Version
+  "minimum_version" => "Versão %1\$s mínima",
+
+  "related_keyboards" => "Teclados Relacionados",
+
+  # This keyboard is not available on keyman.com
+  "keyboard_not_available" => "Este teclado não está disponível em %1\$s",
+
+  "deprecated" => "(descontinuado)",
+
+  "new_version" => "(nova versão)",
+
+  "supported_languages" => "Línguas Suportadas",
+
+  # Expand {count} more >>
+  "expand_more" => "Expandir %1\$s mais >>",
+
+  # << Collapse
+  "collapse" => "<< Retrair",
+
+  "permanent_link_to_this_keyboard" => "Link permanente para este teclado:",
+
+  ## Obsolete keyboard notes
+
+  "important_note" => "Nota importante:",
+
+  "obsolete_version" =>
+    "Esta é uma versão obsoleta deste teclado. A menos que você tenha uma boa razão, clique aqui para instalar a nova versão, chamada",
+
+  "instead" => ", em vez disso.",
+
+  "view_obsolete_details" => "Visualizar os detalhes da versão obsoleta",
+
+  "new_search" => "Nova busca",
+
+  ## Errors
+
+  # Failed to load keyboard package [ID]
+  "failed_to_load_keyboard_package" => "Falha ao carregar o pacote de teclado %1\$s",
+
+  # Error returned from api.keyman.com: {error string}
+  "error_returned_from_api" => "Erro retornado de %1\$s: %2\$s",
+
+  # Keyboard package [ID] not found)'Failed to load keyboard package ' .
+  "package_not_found" => "Pacote de teclado %1\$s não encontrado.",
+
+  # Sorry, this keyboard requires Keyman {minimum version} or higher.
+  "requires_keyman_minimum_version" =>
+    "Desculpe, mas este teclado requer Keyman %1\$s ou subsequente.",
+
+  # Package status field
+  "package_status" => "Status",
+  "status_unknown" => "Desconhecido",
+  "status_unknown_explanation" => "O status do teclado não pode ser determinado.",
+  "status_experimental" => "Experimental",
+  "status_experimental_explanation" => "Use por sua conta e risco. Este teclado pode ser considerado como experimental por seu mantenedor. O método de digitação está sujeito a alterações sem aviso prévio. Fontes embarcadas com este teclado também podem mudar, o que torna o trabalho digitado anteriormente incompatível com atualizações.",
+  "status_legacy" => "Legacy",
+  "status_legacy_explanation" => "Funciona mas sem suporte. Este teclado não conta mais com o suporte do mantenedor. É improvável que os efeitos sejam corrigidos.",
+  "status_stable" => "Estável",
+  "status_stable_explanation" => "Seguro para usar. Este teclado é ativamente mantido e está em concordância com os padrões internacionais, tais como o Unicode.",
+
+];

--- a/_includes/locale/strings/keyboards/install/pt.php
+++ b/_includes/locale/strings/keyboards/install/pt.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for keyboards/keyboard-install.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Page Title
+  "install_page_title" => "%1\$s teclado",
+
+  # {Keyboard} download should start shortly
+  "download_start_shortly" => 
+    "Download do %1\$s teclado vai iniciar logo. Caso não inicie, clique no botão abaixo para começar o download.",
+
+  # Help on installing keyboard
+  "help_on_installing_keyboard" => "Ajuda na instalação do teclado",
+
+  # Help on installing Keyman
+  "help_on_installing_keyman" => "Ajuda na instalação do Keyman",
+
+  # Download keyboard
+  "download_keyboard" => "Download do teclado",
+
+  # Download just this keyboard...
+  "download_just_keyboard" => "Download somente deste teclado",
+
+  # ... and then install in the app
+  "and_then_install_in_the_app" => "em seguida, instale no app.",
+
+  # Install keyboard button 
+  "install_keyboard" => "Instalar teclado",
+
+  # {keyboard} home
+  "keyboard_home" => "%1\$s teclado inícial",
+
+  # Keyman for {platform} not installed
+  "platform_not_installed" =>
+    "Se você ainda não instalou %1\$s, por favor, instale primeiro antes de instalar o teclado.",
+  
+  # Download and install Keyman title
+  "download_keyman_title" => "Baixar e instalar o Keyman",
+
+  # Install Keyman for {platform}
+  "install_keyman" => "Instalar %1\$s",
+
+  # Keyman for Android
+  "with_play_store" => 
+    "Instalar o Keyman junto com %1\$s teclado através do Google Play Store:",
+
+  # Install from Play Store
+  "install_from_play_store" => 
+    "Instalar da Play Store",
+
+  # Installs Keyman and {keyboard} for {platform}
+  "keyman_and_keyboard_for_platform" =>
+    "Instala o Keyman e %1\$s o teclado para %2\$s",
+
+  # Keyman already installed?
+  "already_installed" => "Keyman já está instalado?",
+
+  # Downloads {keyboard} for {platform}
+  "downloads_keyboard_for_platform" =>
+    "Downloads %1\$s para %2\$s",
+
+  # {Keyboard} not found
+  "keyboard_not_found" => "O teclado %1\$s não foi encontrado."
+
+];

--- a/_includes/locale/strings/keyboards/pt.json
+++ b/_includes/locale/strings/keyboards/pt.json
@@ -1,0 +1,15 @@
+{
+  "resultOne": "resultado",
+  "resultMore": "resultados",
+  "pageNumberOfTotalPages": "página {pageNumber} de {totalPages}.",
+  "keyboardSearchTitle": "Busca de teclado",
+  "obsoleteKeyboards": "Teclados obsoletos",
+  "monthlyDownloadZero": "Sem downloads recentes",
+  "monthlyDownloadOne": "download mensal",
+  "monthlyDownloadMore": "downloads mensais",
+  "notUnicode": "Nota: Não é um teclado Unicode",
+  "designedForPlatform": "Projetado para {platform}",
+  "noMatchesFoundForKeyboard": "Não foi encontrado nenhum resultado para '{keyboard}'",
+  "previousPager": "< Anterior",
+  "nextPager": "> Próximo"
+}

--- a/_includes/locale/strings/keyboards/pt.php
+++ b/_includes/locale/strings/keyboards/pt.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for keyboards/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Page Title
+  "page_title" => "Busca de Teclado",
+
+  # Page Description
+  "page_description" => "Busca de teclado Keyman",
+
+  # Keyboard search bar
+  "keyboard_search" => "Busca de teclado:",
+  
+  # Search bar placeholder
+  "enter_language" => "Digite a língua ou teclado",
+  
+  # Search Button Value
+  "search" => "Busca",
+  
+  # Link to start a new keyboard search
+  "new_search" => "Nova busca",
+  
+  # Search box instruction (Popular keyboards | All keyboards)
+  "enter_name" => "Digite o nome de um teclado ou língua a ser pesquisado",
+  
+  # Search box link for popular keyboards
+  "popular_keyboards" => "Teclados populares",
+  
+  # Search box link for all Keyman keyboards
+  "all_keyboards" => "Todos os teclados",
+  
+  # Search box hint: List header
+  "hints" => "Dicas",
+  
+  # Search box hint: Description
+  "searchbox_description" => 
+    "A busca sempre lista os teclados. Pesquisa por nomes e detalhes do teclado, nomes das línguas, nomes dos países e nomes dos scripts.",
+
+  # Search box hint (line 2):
+  "searchbox_hint_2" => 
+    "Você pode aplicar os prefixos %1\$s (teclados) %2\$s (línguas) %3\$s (scripts, sistemas de escrita) ou   %4\$s (países) para filtrar os resultados. Por exemplo,  %5\$s buscas por teclados de línguas usadas na Tailândia.",
+  
+  # Search box hint (line 3):
+  "searchbox_hint_3" => 
+    "Use o prefixo %1\$s para fazer a busca por uma etiqueta da língua BCP 47, por exemplo %2\$s procura por Tigrigna (Etiópia)",
+
+];

--- a/_includes/locale/strings/keyboards/share/pt.php
+++ b/_includes/locale/strings/keyboards/share/pt.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Default English strings for keyboards/keyboard-share.php
+ * When exporting strings from crowdin, convert \\$s to \$s
+ */
+
+declare(strict_types=1);
+
+return [
+  # Head options title
+  "head_title" => "Compartilhar o teclado %1\$s",
+
+  # Page title - Sharing {keyboard}
+  "h1_sharing_keyboard" => "Compartilhando teclado %1\$s",
+
+  "line1" => "Você provavelmente chegou aqui escaneando um QRCode ou abrindo um link
+    para compartilhar um teclado a partir do aplicativo Keyman.",
+
+  "line2" => "Desculpe-nos, mas infelizmente, o teclado no qual você está interessado, chamado ",
+
+  "line3" => "atualmente não está disponível no repositório de teclados Keyman.",
+
+  "h2_how_to_get" => "Como você pode obter este teclado",
+
+  "how_to_get_1" => "Este teclado foi distribuido de pessoa para pessoa, e não através do repositório de teclados do Keyman, assim a melhor maneira de acessar o teclado é perguntar para a pessoa que compartilhou com você este link ou QRCode.",
+
+  "how_to_get_2" => "Caso você não consiga contatar a pessoa que compartilhou  com você, não hesite em perguntar  no ",
+
+  # link to the Keyman forum
+  "keyman_forum" => "Fórum da Comunidade Keyman",
+
+  "how_to_get_3" => "para assistência na localização do teclado ou uma alternativa adequada."
+
+
+];

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -38,6 +38,7 @@ files:
         de: de
         fr: fr
         km: km
+        pt-PT: pt
 
   # PHP files
 
@@ -51,6 +52,7 @@ files:
         de: de
         fr: fr
         km: km
+        pt-PT: pt
 
   - source: /_includes/locale/strings/keyboards/details/en.php
     dest: /keyboards/keyboards-details/en.php
@@ -62,6 +64,7 @@ files:
         de: de
         fr: fr
         km: km
+        pt-PT: pt
 
   - source: /_includes/locale/strings/keyboards/install/en.php
     dest: /keyboards/keyboards-install/en.php
@@ -73,6 +76,7 @@ files:
         de: de
         fr: fr
         km: km
+        pt-PT: pt
 
   - source: /_includes/locale/strings/keyboards/share/en.php
     dest: /keyboards/keyboards-share/en.php
@@ -84,6 +88,7 @@ files:
         de: de
         fr: fr
         km: km
+        pt-PT: pt
 
   # Product Download files
   - source: /_includes/locale/strings/downloads/en.php
@@ -96,6 +101,7 @@ files:
         de: de
         fr: fr
         km: km
+        pt-PT: pt
 
 
   # crowdin parameters descriptions:


### PR DESCRIPTION
A user contacted our support email with the following:
> I’ve learned from the Language Technology group that there is a need for translation for Keyman’s website. Please let me know If I can help with Portuguese translation.

and he quickly contributed to the Crowdin project:
https://crowdin.com/project/keymancom/pt-PT

## Screenshots of the new Portuguese locale:

### Locale picker
<img width="284" height="375" alt="pt" src="https://github.com/user-attachments/assets/f58cb028-747e-4a62-b67c-106261694c80" />

---

### New keyboard search
<img width="1261" height="424" alt="Screenshot 2026-08-19 083938" src="https://github.com/user-attachments/assets/0f6aaf25-36c8-4e78-8d78-763346f3ec72" />

---

### Keyboard search result
<img width="1298" height="620" alt="pt results" src="https://github.com/user-attachments/assets/ac14b2e7-ea5a-4a2d-aa62-edae90bd696e" />

---

Test-bot: skip
