### PR TITLE
chore: Update crowdin strings for Spanish

### DIFF
--- a/_includes/locale/strings/downloads/es.php
+++ b/_includes/locale/strings/downloads/es.php
@@ -50,7 +50,7 @@ return [
   "available_on_play_store" => "Keyman para Android también está disponible en Play Store.",
 
   # Keyman for iPhone and iPad
-  "product_ios" => "Teclado para iPhone e iPad",
+  "product_ios" => "Keyman para iPhone e iPad",
 
   "available_on_app_store" => "Keyman para iPhone e iPad se puede encontrar en la App Store.",
 

--- a/_includes/locale/strings/keyboards/details/es.php
+++ b/_includes/locale/strings/keyboards/details/es.php
@@ -3,7 +3,8 @@
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  *
- * Spanish strings for keyboards/keyboard-details.php
+ * Default English strings for keyboards/keyboard-details.php
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);
@@ -14,76 +15,76 @@ return [
 
   # Placeholder for new keyboard search
   "new_keyboard_search" => "Nueva búsqueda de teclado",
-  
+
   # Search Button Value
   "search" => "Buscar",
-  
+
   # Keyman Developer clone keyboard box
-  
+
   # Fill in New Project Details box below and click OK to clone {filename}
   "new_project_details" =>
     "Complete el cuadro Detalles del nuevo proyecto a continuación y haga clic en Aceptar para clonar %1\$s.",
-  
+
   # "Install keyboard" button text
   "install_keyboard" => "Instalar teclado",
-  
+
   # "Install keyboard" button description
   "install_keyboard_button_description" =>
     "Instalaciones %1\$s para %2\$s en este dispositivo",
-  
+
   # keyboard download is not supported on this device
-  "keyboard_not_supported" => 
+  "keyboard_not_supported" =>
     "Este teclado no es compatible con este dispositivo. Puede encontrar otras opciones a continuación.",
-  
+
   # Try this keyboard heading
   "try_this_keyboard" => "Prueba este teclado",
-  
+
   # "Use keyboard online" button text
   "use_keyboard_online" => "Utilizar el teclado en línea",
-  
+
   # "Full online editor" button text
   "full_online_editor" => "Editor en línea completo",
-  
+
   # "Use keyboard online" button description
-  "use_keyboard_button_description" => 
+  "use_keyboard_button_description" =>
     "Usar %1\$s en tu navegador web. No es necesario instalar nada.",
-  
+
   # Scan this QR code
-  "scan_qr_code" => 
+  "scan_qr_code" =>
     "Escanee este código para cargar este teclado en otro dispositivo",
-  
+
   # Headers in Keyboard Details section
-  
+
   "keyboard_details" => "Detalles del teclado",
-  
+
   "keyboard_ID" => "Identificación del teclado",
-  
+
   "supported_platforms" => "Plataformas compatibles",
-  
+
   "author" => "Autor",
-  
+
   "license" => "Licencia",
-  
+
   "documentation" => "Documentación",
-  
+
   "keyboard_help" => "Ayuda con el teclado",
-  
+
   "help_not_available" => "Ayuda no disponible.",
-  
+
   "source" => "Fuente",
-  
+
   "source_not_available" => "Fuente no disponible.",
-  
+
   "keyboard_version" => "Versión de teclado",
-  
+
   "last_updated" => "Última actualización",
-  
+
   "package_download" => "Descarga del paquete",
-  
+
   "monthly_downloads" => "Descargas mensuales",
-  
+
   "total_downloads" => "Descargas totales",
-  
+
   # Total Downloads title - Downloads since {date}
   "downloads_since" => "Descargas desde %1\$s",
 
@@ -91,67 +92,75 @@ return [
   "date_counting" => "Octubre de 2019",
 
   "encoding" => "Codificación",
-  
+
   # Encoding list
   "encoding_list" => "Unicode, Legado (ANSI)",
-  
+
   # Unicode encoding
   "unicode" => "Unicode",
-  
+
   # Legacy (ANSI) encoding
   "legacy_ansi" => "Legado (ANSI)",
-  
+
   # Minimum Keyman Version
   "minimum_version" => "Versión mínima de %1\$s",
-  
+
   "related_keyboards" => "Teclados relacionados",
-  
+
   # This keyboard is not available on keyman.com
   "keyboard_not_available" => "Este teclado no está disponible en %1\$s",
-  
+
   "deprecated" => "(obsoleta)",
-  
+
   "new_version" => "(nueva versión)",
-  
+
   "supported_languages" => "Idiomas compatibles",
-  
+
   # Expand {count} more >>
   "expand_more" => "Expandir %1\$s más >>",
-  
+
   # << Collapse
   "collapse" => "<< Colapsar",
-  
+
   "permanent_link_to_this_keyboard" => "Enlace permanente a este teclado:",
-  
+
   ## Obsolete keyboard notes
-  
+
   "important_note" => "Nota importante:",
-  
-  "obsolete_version" => 
+
+  "obsolete_version" =>
     "Esta es una versión obsoleta de este teclado. A menos que tenga una buena razón, haga clic aquí para instalar la nueva versión, llamada",
-  
+
   "instead" => ", en cambio.",
-  
+
   "view_obsolete_details" => "Ver detalles de la versión obsoleta en su lugar",
-  
+
   "new_search" => "Nueva búsqueda",
-  
-  ## TODO: Previous/Next pagination handled in search.js
-  
-  
+
   ## Errors
-  
+
   # Failed to load keyboard package [ID]
   "failed_to_load_keyboard_package" => "No se pudo cargar el paquete de teclado %1\$s",
-  
+
   # Error returned from api.keyman.com: {error string}
   "error_returned_from_api" => "Error devuelto desde %1\$s: %2\$s",
-  
-  # Keyboard package [ID] not found)'Failed to load keyboard package ' . 
+
+  # Keyboard package [ID] not found)'Failed to load keyboard package ' .
   "package_not_found" => "No se encontró el paquete de teclado %1\$s.",
-  
+
   # Sorry, this keyboard requires Keyman {minimum version} or higher.
-  "requires_keyman_minimum_version" => 
-    "Lo sentimos, este teclado requiere Keyman %1\$s o superior."
+  "requires_keyman_minimum_version" =>
+    "Lo sentimos, este teclado requiere Keyman %1\$s o superior.",
+
+  # Package status field
+  "package_status" => "Estado",
+  "status_unknown" => "Desconocido",
+  "status_unknown_explanation" => "No se pudo determinar el estado del teclado.",
+  "status_experimental" => "Experimental",
+  "status_experimental_explanation" => "Utilice bajo su propio riesgo. Este teclado puede ser considerado un experimento por su mantenedor. El método de escritura está sujeto a cambios sin previo aviso. Las fuentes empaquetadas con el teclado también pueden cambiar, haciendo que el trabajo previamente escrito sea incompatible con las actualizaciones.",
+  "status_legacy" => "Legado",
+  "status_legacy_explanation" => "Funcionando pero no soportado. Este teclado ya no es soportado por su mantenedor. Es poco probable que los defectos sean reparados.",
+  "status_stable" => "Estable",
+  "status_stable_explanation" => "Seguro de usar. Este teclado se mantiene activamente y cumple con las normas internacionales como Unicode.",
 
 ];

--- a/_includes/locale/strings/keyboards/es.php
+++ b/_includes/locale/strings/keyboards/es.php
@@ -1,8 +1,10 @@
 <?php
+
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  *
- * Spanish strings for keyboards/index.php
+ * Default English strings for keyboards/index.php
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);
@@ -13,7 +15,7 @@ return [
 
   # Page Description
   "page_description" => "Keyman Búsqueda por Teclado",
-  
+
   # Keyboard search bar
   "keyboard_search" => "Búsqueda por teclado:",
   
@@ -49,6 +51,6 @@ return [
   
   # Search box hint (line 3):
   "searchbox_hint_3" => 
-    "Utilice el prefijo %1\$s para buscar una etiqueta de idioma BCP 47, por ejemplo, %2\$s busca Tigrigna (Etiopía)."
+    "Utilice el prefijo %1\$s para buscar una etiqueta de idioma BCP 47, por ejemplo, %2\$s busca Tigrigna (Etiopía).",
 
 ];

--- a/_includes/locale/strings/keyboards/install/es.php
+++ b/_includes/locale/strings/keyboards/install/es.php
@@ -3,7 +3,8 @@
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  *
- * Spanish strings for keyboards/keyboard-install.php
+ * Default English strings for keyboards/keyboard-install.php
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);
@@ -41,10 +42,10 @@ return [
   # Keyman for {platform} not installed
   "platform_not_installed" =>
     "Si aún no ha instalado %1\$s, instálelo primero antes de instalar el teclado.",
-
+  
   # Download and install Keyman title
   "download_keyman_title" => "Descarga e instala Keyman",
-    
+
   # Install Keyman for {platform}
   "install_keyman" => "Instalar %1\$s",
 

--- a/_includes/locale/strings/keyboards/share/es.php
+++ b/_includes/locale/strings/keyboards/share/es.php
@@ -3,8 +3,8 @@
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  *
- * Spanish strings for keyboards/keyboard-share.php
- * Use placeholders like %1\$s
+ * Default English strings for keyboards/keyboard-share.php
+ * When exporting strings from crowdin, convert \\$s to \$s
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
This updates Spanish strings per @philleckrone

Screenshot of keyboard status (experimental)

<img width="1412" height="346" alt="image" src="https://github.com/user-attachments/assets/988145f6-fe4e-4afc-8a40-f7d469b974e1" />

---
 
btw, the preambles were originally hand-written. Using the crowdin automation to retrieve the files just copies the preamble from the original en.php files

```php
/*
 * Keyman is copyright (C) SIL Global. MIT License.
 *
 * Default English strings for .... .php
 * When exporting strings from crowdin, convert \\$s to \$s
 */
```

Test-bot: skip
